### PR TITLE
feat(agent-output): act on a fenced block's language — nested markdown and diff colouring

### DIFF
--- a/docs/superpowers/plans/2026-09-03-fence-language-semantics.md
+++ b/docs/superpowers/plans/2026-09-03-fence-language-semantics.md
@@ -1,0 +1,1233 @@
+# Fenced-Block Language Semantics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Agent Output panel act on a fenced block's info string — render ` ```markdown ` as a nested document behind one panel switch, color ` ```diff ` by line marker, and leave every other language exactly as it renders today.
+
+**Architecture:** `BuildCodeBlock` gains a resolver lookup keyed on the fence's first info token. A resolver hit returns an `IFenceBody` that produces the block *body only*; the border, header, language label and Copy button stay in `BuildCodeBlock`, so Copy keeps yielding raw source for every block. The markdown handler recurses back into the renderer's existing `AppendBlocks` through a delegate, capped at depth 1. A mutable render-pass object carries the panel's switch state down and a "did we transform anything" tally back up.
+
+**Tech Stack:** C# / .NET 10, Avalonia, Markdig 1.3.2 (already referenced), xUnit. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-09-03-fence-language-semantics-design.md`
+
+## Global Constraints
+
+- **Build and test only via the wrappers.** `scripts/build.sh <args>` (Git Bash) or `scripts/build.ps1 <args>`. A raw `dotnet build` hangs when stdout is captured. See `CLAUDE.md`.
+- **No new package references.** Markdig is already present; nothing else may be added.
+- **Unrecognized info strings must be byte-identical to today.** Any change to an existing expectation in `MarkdownRendererTests` is a bug in this work, not a test to update. The one permitted mechanical edit is adding `.Root` at the 14 sites that call `MarkdownRenderer.Build`.
+- **Copy always yields raw source**, in every switch position and for every handler.
+- **Agent output is untrusted text.** No new HTML path, no unbounded recursion, no unbounded per-line work.
+- **Nesting depth cap is 1.** `MaxFenceDepth = 1`.
+- **Theme brushes resolve per build** via `Find(anchor, "Nt*", fallback)`, degrading to a fixed fallback when the resource is absent.
+- **This branch is stacked on #378.** Do not rebase onto `main` until #378 merges.
+- Close any running NovaTerminal launched from this worktree before building; it locks `NovaTerminal.exe` and the build fails with MSB3027.
+
+---
+
+### Task 1: Extract `MarkdownTheme` into its own file
+
+Behaviour-neutral refactor. It exists because Tasks 3 and 4 put handlers in separate files, and those handlers need the theme type — which is currently a `private sealed class` nested inside `MarkdownRenderer`.
+
+**Files:**
+- Create: `src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs`
+- Modify: `src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs` (delete the nested `Theme` class at lines 643-674; retarget every `Theme` reference)
+- Test: no new test. Verification is the existing suite staying green — that is the correct check for an extraction that must change no behavior.
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `internal sealed class MarkdownTheme` with `IBrush Foreground, Secondary, CodeBackground, PanelBackground, Hairline, Accent` (all `required ... { get; init; }`) and `internal static MarkdownTheme Resolve(StyledElement anchor)`.
+
+- [ ] **Step 1: Create the new file**
+
+```csharp
+using Avalonia;
+using Avalonia.Media;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>Resolved brush set for one render pass.</summary>
+/// <remarks>
+/// Extracted from <see cref="MarkdownRenderer"/> so fence-body handlers in sibling files can
+/// take it. Resolution is unchanged: prefer the app's <c>Nt*</c> theme brushes, fall back to the
+/// fixed palette the pane's other hand-styled surfaces hard-code.
+/// </remarks>
+internal sealed class MarkdownTheme
+{
+    private static readonly IBrush FallbackForeground = new SolidColorBrush(Color.FromRgb(0xF3, 0xF6, 0xFA));
+    private static readonly IBrush FallbackSecondary = new SolidColorBrush(Color.FromRgb(0x96, 0xA0, 0xAE));
+    private static readonly IBrush FallbackCodeBackground = new SolidColorBrush(Color.FromRgb(0x16, 0x18, 0x1C));
+    private static readonly IBrush FallbackPanel = new SolidColorBrush(Color.FromRgb(0x1B, 0x1D, 0x21));
+    private static readonly IBrush FallbackHairline = new SolidColorBrush(Color.FromRgb(0x2A, 0x2F, 0x35));
+    private static readonly IBrush FallbackAccent = new SolidColorBrush(Color.FromRgb(0x4C, 0x8B, 0xD8));
+
+    internal required IBrush Foreground { get; init; }
+
+    internal required IBrush Secondary { get; init; }
+
+    internal required IBrush CodeBackground { get; init; }
+
+    internal required IBrush PanelBackground { get; init; }
+
+    internal required IBrush Hairline { get; init; }
+
+    internal required IBrush Accent { get; init; }
+
+    internal static MarkdownTheme Resolve(StyledElement anchor)
+    {
+        return new MarkdownTheme
+        {
+            Foreground = Find(anchor, "NtFg", FallbackForeground),
+            Secondary = Find(anchor, "NtFg3", FallbackSecondary),
+            CodeBackground = Find(anchor, "NtPanelAlt", FallbackCodeBackground),
+            PanelBackground = Find(anchor, "NtPanel", FallbackPanel),
+            Hairline = Find(anchor, "NtHairline", FallbackHairline),
+            Accent = Find(anchor, "NtBlue", FallbackAccent),
+        };
+    }
+
+    private static IBrush Find(StyledElement anchor, string key, IBrush fallback)
+    {
+        // Control themes put brushes in as object values; anything that is not a brush
+        // (an unexpected override) degrades to the fixed fallback rather than crashing.
+        return anchor.TryFindResource(key, out object? value) && value is IBrush brush
+            ? brush
+            : fallback;
+    }
+}
+```
+
+- [ ] **Step 2: Delete the nested class and its now-duplicated fallback fields**
+
+In `MarkdownRenderer.cs`, delete the `private sealed class Theme { ... }` block (lines 643-674) and the six `Fallback*` fields (lines 58-63) — they moved into `MarkdownTheme`.
+
+- [ ] **Step 3: Retarget every `Theme` reference**
+
+Replace the type name `Theme` with `MarkdownTheme` throughout `MarkdownRenderer.cs`. There are references in `Build` (the `var theme = Theme.Resolve(...)` local) and in the parameter lists of `AppendBlocks`, `BuildHeading`, `BuildParagraph`, `BuildCodeBlock`, `BuildList`, `BuildQuote`, `BuildTable` and the inline builders.
+
+```bash
+grep -n "Theme" src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+```
+
+Expected after the edit: every hit reads `MarkdownTheme`, and none of them is a declaration.
+
+- [ ] **Step 4: Build and run the full AgentOutput suite**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~AgentOutput"`
+Expected: PASS, 86 tests, 0 failed. A refactor that changes a count or an expectation has changed behavior and must be corrected, not accepted.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+git commit -m "refactor(agent-output): extract MarkdownTheme from the renderer
+
+Fence-body handlers land in sibling files and need the theme type, which
+was a private nested class. Pure move: same Resolve, same Find, same
+fallbacks, no behavior change."
+```
+
+---
+
+### Task 2: `MarkdownRenderResult` and the render pass
+
+Threads two things through the walk that later tasks need: the panel's switch state going down, and a "did any handler transform a block" tally coming back up. No handler exists yet, so `HasTransformBlock` is always false at the end of this task — that is the expected state and the test asserts it.
+
+**Files:**
+- Create: `src/NovaTerminal.App/AgentOutput/MarkdownRenderPass.cs`
+- Modify: `src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs` (`Build` signature and return, `AppendBlocks`, `BuildCodeBlock`, `BuildList`, `BuildQuote`, `BuildTable`)
+- Modify: `src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs:105`
+- Test: `tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs`
+
+**Interfaces:**
+- Consumes: `MarkdownTheme` (Task 1).
+- Produces:
+  - `public sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock)`
+  - `internal sealed class MarkdownRenderPass` with `internal required bool RenderFencedMarkdown { get; init; }` and `internal bool HasTransformBlock { get; set; }`
+  - `public static MarkdownRenderResult Build(string markdown, StyledElement resourceAnchor, Action<string>? onCopyText = null, Action<string>? onOpenLink = null, bool renderFencedMarkdown = true)`
+  - `AppendBlocks(IList<Control> target, IEnumerable<Block> blocks, MarkdownTheme theme, Action<string>? onCopyText, Action<string>? onOpenLink, MarkdownRenderPass pass, int depth)` — and the same two trailing parameters `(MarkdownRenderPass pass, int depth)` appended to `BuildCodeBlock`, `BuildList`, `BuildQuote`, `BuildTable`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `MarkdownRendererTests.cs`:
+
+```csharp
+[Fact]
+public void Build_ReportsNoTransformBlock_ForOrdinaryMarkdown()
+{
+    MarkdownRenderResult result = MarkdownRenderer.Build("# Title\n\nbody\n", Anchor);
+
+    Assert.IsType<StackPanel>(result.Root);
+    Assert.False(result.HasTransformBlock);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~Build_ReportsNoTransformBlock"`
+Expected: FAIL to compile — `MarkdownRenderResult` does not exist and `Build` returns `Control`.
+
+- [ ] **Step 3: Create the render pass**
+
+```csharp
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>Mutable state for one render pass of <see cref="MarkdownRenderer.Build"/>.</summary>
+/// <remarks>
+/// Two jobs, both of which have to cross the recursive block walk. <see cref="RenderFencedMarkdown"/>
+/// travels down: it is the panel's switch, and a fence handler that transforms content has to
+/// honour it. <see cref="HasTransformBlock"/> travels up: the panel shows its switch only when
+/// the render actually produced something the switch governs, so a response with no such block
+/// carries no pointless control.
+/// </remarks>
+internal sealed class MarkdownRenderPass
+{
+    internal required bool RenderFencedMarkdown { get; init; }
+
+    /// <summary>Set by any handler whose <c>IsTransform</c> is true, at any depth.</summary>
+    internal bool HasTransformBlock { get; set; }
+}
+```
+
+- [ ] **Step 4: Change `Build` to return a result and open the pass**
+
+Replace the body of `Build` (`MarkdownRenderer.cs:71-83`):
+
+```csharp
+public static MarkdownRenderResult Build(
+    string markdown,
+    StyledElement resourceAnchor,
+    Action<string>? onCopyText = null,
+    Action<string>? onOpenLink = null,
+    bool renderFencedMarkdown = true)
+{
+    MarkdownDocument document = Markdown.Parse(markdown ?? string.Empty, Pipeline);
+    var theme = MarkdownTheme.Resolve(resourceAnchor);
+    var pass = new MarkdownRenderPass { RenderFencedMarkdown = renderFencedMarkdown };
+
+    var root = new StackPanel { Spacing = 2 };
+    AppendBlocks(root.Children, document, theme, onCopyText, onOpenLink, pass, depth: 0);
+    return new MarkdownRenderResult(root, pass.HasTransformBlock);
+}
+```
+
+And declare the result record at the top of the file, immediately above `public static class MarkdownRenderer`:
+
+```csharp
+/// <summary>One render's output: the tree, and whether it contains a switch-governed block.</summary>
+public sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock);
+```
+
+- [ ] **Step 5: Append `(pass, depth)` to the five recursive methods**
+
+Add `MarkdownRenderPass pass, int depth` as the last two parameters of `AppendBlocks`, `BuildCodeBlock`, `BuildList`, `BuildQuote` and `BuildTable`, and pass them through at every call site. The three inner `AppendBlocks` calls recurse at the *same* depth — only a fence handler increments it:
+
+- `MarkdownRenderer.cs:282` (in `BuildList`) → `AppendBlocks(itemContent.Children, listItem, theme, onCopyText, onOpenLink, pass, depth);`
+- `MarkdownRenderer.cs:299` (in `BuildQuote`) → `AppendBlocks(content.Children, quote, theme, onCopyText, onOpenLink, pass, depth);`
+- `MarkdownRenderer.cs:358` (in `BuildTable`) → `AppendBlocks(cellContent.Children, cell, theme, onCopyText, onOpenLink, pass, depth);`
+
+In `AppendBlocks`, the two code-block arms become:
+
+```csharp
+case FencedCodeBlock fenced:
+    target.Add(BuildCodeBlock(GetLinesText(fenced), fenced.Info.ToString(), theme, onCopyText, pass, depth));
+    break;
+
+case CodeBlock code:
+    target.Add(BuildCodeBlock(GetLinesText(code), null, theme, onCopyText, pass, depth));
+    break;
+```
+
+`BuildHeading` and `BuildParagraph` are untouched: they contain inlines, not blocks, and build no code block.
+
+- [ ] **Step 6: Update the one production call site**
+
+`AgentOutputPanel.axaml.cs:105` currently assigns `Control rendered = MarkdownRenderer.Build(...)`. Change to:
+
+```csharp
+MarkdownRenderResult rendered = MarkdownRenderer.Build(
+    markdown,
+    this,
+    onCopyText: text => _ = CopyToClipboardAsync(text),
+    onOpenLink: url => _ = OpenLinkAsync(url));
+MarkdownHost.Children.Add(rendered.Root);
+```
+
+- [ ] **Step 7: Add `.Root` at the 14 existing test call sites**
+
+Every `(StackPanel)MarkdownRenderer.Build(...)` in `MarkdownRendererTests.cs` becomes `(StackPanel)MarkdownRenderer.Build(...).Root`. This is the only permitted edit to those tests; no expectation changes.
+
+```bash
+grep -c "MarkdownRenderer.Build" tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+```
+
+Expected: 15 (the 14 pre-existing plus the new test from Step 1).
+
+- [ ] **Step 8: Run the suite**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~AgentOutput"`
+Expected: PASS, 87 tests, 0 failed.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/NovaTerminal.App/AgentOutput/ tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+git commit -m "refactor(agent-output): thread a render pass through the markdown walk
+
+Build returns MarkdownRenderResult instead of a bare Control, and a
+MarkdownRenderPass carries the panel's fence switch down the recursive
+walk and a has-transform tally back up. No handler consumes either yet,
+so HasTransformBlock is still always false."
+```
+
+---
+
+### Task 3: The fence seam and the `diff` handler
+
+The diff handler goes first because it is the simpler of the two — no recursion, no switch participation — so it proves the seam before the markdown handler leans on it.
+
+**Files:**
+- Create: `src/NovaTerminal.App/AgentOutput/Fences/IFenceBody.cs`
+- Create: `src/NovaTerminal.App/AgentOutput/Fences/FenceBodyResolver.cs`
+- Create: `src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs`
+- Modify: `src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs` (three brushes)
+- Modify: `src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs` (`BuildCodeBlock` consults the resolver)
+- Test: `tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs`
+
+**Interfaces:**
+- Consumes: `MarkdownTheme` (Task 1), `MarkdownRenderPass` (Task 2).
+- Produces:
+  - `internal delegate Control NestedMarkdownRenderer(string markdown, int depth);`
+  - `internal sealed record FenceContext(int Depth, bool RenderFencedMarkdown, NestedMarkdownRenderer RenderNested, Action<string>? OnCopyText);`
+  - `internal interface IFenceBody { bool IsTransform { get; } Control Build(string code, MarkdownTheme theme, FenceContext context); }`
+  - `internal static class FenceBodyResolver` with `internal static IFenceBody? Resolve(string? info)` and `internal static string NormalizeInfo(string? info)`
+  - `MarkdownTheme` gains `IBrush Added, Removed, Hunk`
+  - `internal const int MarkdownRenderer.MaxFenceDepth = 1`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs`:
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+using NovaTerminal.AgentOutput;
+using NovaTerminal.AgentOutput.Fences;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// The fence-body seam: which info strings resolve, and what each handler makes of a body.
+/// </summary>
+public sealed class FenceBodyTests
+{
+    private static readonly Border Anchor = new();
+
+    [Theory]
+    [InlineData("markdown")]
+    [InlineData("md")]
+    [InlineData("MARKDOWN")]
+    [InlineData("Md")]
+    [InlineData("markdown title=\"README\"")]
+    [InlineData("  markdown  ")]
+    public void MarkdownAliases_Resolve(string info)
+        => Assert.NotNull(FenceBodyResolver.Resolve(info));
+
+    [Theory]
+    [InlineData("diff")]
+    [InlineData("patch")]
+    [InlineData("DIFF")]
+    public void DiffAliases_Resolve(string info)
+        => Assert.NotNull(FenceBodyResolver.Resolve(info));
+
+    [Theory]
+    [InlineData("csharp")]
+    [InlineData("bash")]
+    [InlineData("json")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void UnrecognizedInfo_DoesNotResolve(string? info)
+        => Assert.Null(FenceBodyResolver.Resolve(info));
+
+    [Fact]
+    public void DiffHandler_IsNotATransform()
+    {
+        IFenceBody body = Assert.IsType<DiffFenceBody>(FenceBodyResolver.Resolve("diff"));
+        Assert.False(body.IsTransform);
+    }
+
+    [Theory]
+    [InlineData("+added line", "NtGreen")]
+    [InlineData("-removed line", "NtRed")]
+    [InlineData("@@ -1,2 +1,3 @@", "NtYellow")]
+    [InlineData("+++ b/file.cs", "Secondary")]
+    [InlineData("--- a/file.cs", "Secondary")]
+    [InlineData("diff --git a/x b/x", "Secondary")]
+    [InlineData("index 1234567..89abcde 100644", "Secondary")]
+    [InlineData(" context line", "Foreground")]
+    public void DiffHandler_ColorsLinesByMarker(string line, string expectedRole)
+    {
+        var theme = MarkdownThemeProbe.WithDistinctBrushes();
+        IFenceBody body = FenceBodyResolver.Resolve("diff")!;
+
+        Control control = body.Build(line, theme, Context(theme));
+
+        var text = Assert.IsType<SelectableTextBlock>(control);
+        Run run = text.Inlines!.OfType<Run>().Single();
+        Assert.Same(MarkdownThemeProbe.BrushFor(theme, expectedRole), run.Foreground);
+    }
+
+    [Fact]
+    public void DiffHandler_EmitsOneRunPerLine()
+    {
+        var theme = MarkdownThemeProbe.WithDistinctBrushes();
+        IFenceBody body = FenceBodyResolver.Resolve("diff")!;
+
+        Control control = body.Build("+one\n-two\n three", theme, Context(theme));
+
+        var text = Assert.IsType<SelectableTextBlock>(control);
+        Assert.Equal(3, text.Inlines!.OfType<Run>().Count());
+    }
+
+    private static FenceContext Context(MarkdownTheme theme)
+        => new(Depth: 0, RenderFencedMarkdown: true, RenderNested: (_, _) => new Border(), OnCopyText: null);
+}
+```
+
+The `MarkdownThemeProbe` helper keeps brush identity assertions readable. Create it in the same file, below the test class:
+
+```csharp
+/// <summary>
+/// Builds a theme whose brushes are all distinct instances, so a test can assert which role a
+/// run was painted with by reference rather than by colour value.
+/// </summary>
+internal static class MarkdownThemeProbe
+{
+    private static readonly Dictionary<string, IBrush> Roles = new()
+    {
+        ["Foreground"] = new SolidColorBrush(Color.FromRgb(1, 1, 1)),
+        ["Secondary"] = new SolidColorBrush(Color.FromRgb(2, 2, 2)),
+        ["NtGreen"] = new SolidColorBrush(Color.FromRgb(3, 3, 3)),
+        ["NtRed"] = new SolidColorBrush(Color.FromRgb(4, 4, 4)),
+        ["NtYellow"] = new SolidColorBrush(Color.FromRgb(5, 5, 5)),
+    };
+
+    internal static IBrush BrushFor(MarkdownTheme theme, string role) => role switch
+    {
+        "Foreground" => theme.Foreground,
+        "Secondary" => theme.Secondary,
+        "NtGreen" => theme.Added,
+        "NtRed" => theme.Removed,
+        "NtYellow" => theme.Hunk,
+        _ => throw new ArgumentOutOfRangeException(nameof(role), role, "unknown role"),
+    };
+
+    internal static MarkdownTheme WithDistinctBrushes() => new()
+    {
+        Foreground = Roles["Foreground"],
+        Secondary = Roles["Secondary"],
+        CodeBackground = new SolidColorBrush(Color.FromRgb(6, 6, 6)),
+        PanelBackground = new SolidColorBrush(Color.FromRgb(7, 7, 7)),
+        Hairline = new SolidColorBrush(Color.FromRgb(8, 8, 8)),
+        Accent = new SolidColorBrush(Color.FromRgb(9, 9, 9)),
+        Added = Roles["NtGreen"],
+        Removed = Roles["NtRed"],
+        Hunk = Roles["NtYellow"],
+    };
+}
+```
+
+`MarkdownTheme` and `MarkdownRenderPass` are `internal`, and `NovaTerminal.App.csproj:510` already grants `InternalsVisibleTo` to `NovaTerminal.App.Tests`, so no visibility change is needed.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~FenceBodyTests"`
+Expected: FAIL to compile — `NovaTerminal.AgentOutput.Fences` does not exist.
+
+- [ ] **Step 3: Add the three theme brushes**
+
+In `MarkdownTheme.cs`, add the fallbacks and properties, and resolve them:
+
+```csharp
+    private static readonly IBrush FallbackAdded = new SolidColorBrush(Color.FromRgb(0x6F, 0xBF, 0x73));
+    private static readonly IBrush FallbackRemoved = new SolidColorBrush(Color.FromRgb(0xD9, 0x6C, 0x6C));
+    private static readonly IBrush FallbackHunk = new SolidColorBrush(Color.FromRgb(0xD6, 0xB0, 0x5C));
+```
+
+```csharp
+    /// <summary>Diff addition lines.</summary>
+    internal required IBrush Added { get; init; }
+
+    /// <summary>Diff removal lines.</summary>
+    internal required IBrush Removed { get; init; }
+
+    /// <summary>Diff hunk headers.</summary>
+    internal required IBrush Hunk { get; init; }
+```
+
+```csharp
+            Added = Find(anchor, "NtGreen", FallbackAdded),
+            Removed = Find(anchor, "NtRed", FallbackRemoved),
+            Hunk = Find(anchor, "NtYellow", FallbackHunk),
+```
+
+- [ ] **Step 4: Create the interface and context**
+
+`src/NovaTerminal.App/AgentOutput/Fences/IFenceBody.cs`:
+
+```csharp
+using System;
+using Avalonia.Controls;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Renders a nested markdown document at the given depth.</summary>
+internal delegate Control NestedMarkdownRenderer(string markdown, int depth);
+
+/// <summary>What a handler is allowed to know about the render it sits inside.</summary>
+internal sealed record FenceContext(
+    int Depth,
+    bool RenderFencedMarkdown,
+    NestedMarkdownRenderer RenderNested,
+    Action<string>? OnCopyText);
+
+/// <summary>
+/// Produces the body of one fenced code block, chosen by the fence's info string.
+/// </summary>
+/// <remarks>
+/// A handler owns the <b>body only</b>. The border, header row, language label and Copy button
+/// stay with the renderer, which keeps two properties that would otherwise erode one handler at
+/// a time: every code block looks like every other one, and Copy always yields the raw source
+/// no matter what is on screen.
+/// </remarks>
+internal interface IFenceBody
+{
+    /// <summary>
+    /// True when this handler replaces the source with something else, and so participates in
+    /// the panel's rendered/source switch. A restyle hides nothing and is not a transform.
+    /// </summary>
+    bool IsTransform { get; }
+
+    Control Build(string code, MarkdownTheme theme, FenceContext context);
+}
+```
+
+- [ ] **Step 5: Create the resolver**
+
+`src/NovaTerminal.App/AgentOutput/Fences/FenceBodyResolver.cs`:
+
+```csharp
+using System;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Maps a fence info string to a body handler, or to null for "leave it alone".</summary>
+/// <remarks>
+/// A closed switch on purpose. Nothing outside this assembly registers a handler, so a
+/// registration mechanism would be machinery with no consumer.
+/// </remarks>
+internal static class FenceBodyResolver
+{
+    private static readonly MarkdownFenceBody Markdown = new();
+    private static readonly DiffFenceBody Diff = new();
+
+    internal static IFenceBody? Resolve(string? info) => NormalizeInfo(info) switch
+    {
+        "markdown" or "md" => Markdown,
+        "diff" or "patch" => Diff,
+        _ => null,
+    };
+
+    /// <summary>
+    /// The first whitespace-delimited token, lowercased invariantly.
+    /// </summary>
+    /// <remarks>
+    /// The first token rather than the whole string, so <c>markdown title="README"</c> still
+    /// resolves. Splitting here rather than trusting Markdig's own Info/Arguments division keeps
+    /// the match independent of how the parser chooses to divide them.
+    /// </remarks>
+    internal static string NormalizeInfo(string? info)
+    {
+        if (string.IsNullOrWhiteSpace(info))
+        {
+            return string.Empty;
+        }
+
+        ReadOnlySpan<char> span = info.AsSpan().Trim();
+        int end = span.IndexOfAny(' ', '\t');
+        if (end >= 0)
+        {
+            span = span[..end];
+        }
+
+        return span.ToString().ToLowerInvariant();
+    }
+}
+```
+
+- [ ] **Step 6: Create the diff handler**
+
+`src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs`:
+
+```csharp
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Colors a unified diff by each line's leading marker.</summary>
+/// <remarks>
+/// A restyle, not a transform: the text is unchanged and nothing is hidden, so there is nothing
+/// for the panel's switch to recover and <see cref="IsTransform"/> is false.
+/// </remarks>
+internal sealed class DiffFenceBody : IFenceBody
+{
+    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
+
+    public bool IsTransform => false;
+
+    public Control Build(string code, MarkdownTheme theme, FenceContext context)
+    {
+        var text = new SelectableTextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12,
+            FontFamily = new FontFamily(MonospaceFontFamily),
+            Foreground = theme.Foreground,
+        };
+
+        string[] lines = code.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string line = lines[i];
+            text.Inlines?.Add(new Run
+            {
+                Text = i == lines.Length - 1 ? line : line + "\n",
+                Foreground = BrushFor(line, theme),
+            });
+        }
+
+        return text;
+    }
+
+    /// <summary>
+    /// Order is load-bearing: the three-character file headers are tested before the
+    /// one-character markers, or <c>+++ b/file</c> reads as an addition.
+    /// </summary>
+    private static IBrush BrushFor(string line, MarkdownTheme theme)
+    {
+        if (line.StartsWith("+++", StringComparison.Ordinal) ||
+            line.StartsWith("---", StringComparison.Ordinal) ||
+            line.StartsWith("diff --git", StringComparison.Ordinal) ||
+            line.StartsWith("index ", StringComparison.Ordinal))
+        {
+            return theme.Secondary;
+        }
+
+        if (line.StartsWith("@@", StringComparison.Ordinal))
+        {
+            return theme.Hunk;
+        }
+
+        if (line.StartsWith("+", StringComparison.Ordinal))
+        {
+            return theme.Added;
+        }
+
+        if (line.StartsWith("-", StringComparison.Ordinal))
+        {
+            return theme.Removed;
+        }
+
+        return theme.Foreground;
+    }
+}
+```
+
+- [ ] **Step 7: Create a placeholder markdown handler so the resolver compiles**
+
+Task 4 fills this in. For now it must resolve and behave exactly like the unhandled path, so no observable change ships in this task:
+
+```csharp
+using Avalonia.Controls;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Renders a markdown fence as a nested document. Filled in by Task 4.</summary>
+internal sealed class MarkdownFenceBody : IFenceBody
+{
+    public bool IsTransform => true;
+
+    public Control Build(string code, MarkdownTheme theme, FenceContext context)
+        => context.RenderNested(code, context.Depth + 1);
+}
+```
+
+- [ ] **Step 8: Consult the resolver from `BuildCodeBlock`**
+
+In `MarkdownRenderer.cs`, add the depth constant beside `MonospaceFontFamily`:
+
+```csharp
+    /// <summary>
+    /// Deepest nesting a fence handler may render into. Agent output is untrusted and this tree
+    /// is rebuilt on the streaming debounce, so a fence inside a rendered fence stays source.
+    /// </summary>
+    internal const int MaxFenceDepth = 1;
+```
+
+Then, inside `BuildCodeBlock`, replace the single-`Run` body construction with a resolver lookup. The chrome below it is untouched:
+
+```csharp
+    IFenceBody? handler = depth < MaxFenceDepth ? FenceBodyResolver.Resolve(language) : null;
+    Control body;
+    if (handler is null)
+    {
+        var codeText = new SelectableTextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12,
+            FontFamily = new FontFamily(MonospaceFontFamily),
+            Foreground = theme.Foreground,
+        };
+        codeText.Inlines?.Add(new Run { Text = code });
+        body = codeText;
+    }
+    else
+    {
+        if (handler.IsTransform)
+        {
+            pass.HasTransformBlock = true;
+        }
+
+        body = handler.Build(
+            code,
+            theme,
+            new FenceContext(
+                depth,
+                pass.RenderFencedMarkdown,
+                (nested, nestedDepth) => BuildNested(nested, theme, onCopyText, pass, nestedDepth),
+                onCopyText));
+    }
+```
+
+Use `body` where the old `codeText` was used, in the inner content `Border`.
+
+Add the nested-render helper next to `AppendBlocks`:
+
+```csharp
+    /// <summary>Renders a fence's body as markdown, one level deeper in the same pass.</summary>
+    private static Control BuildNested(
+        string markdown,
+        MarkdownTheme theme,
+        Action<string>? onCopyText,
+        MarkdownRenderPass pass,
+        int depth)
+    {
+        MarkdownDocument document = Markdown.Parse(markdown ?? string.Empty, Pipeline);
+        var panel = new StackPanel { Spacing = 2 };
+        AppendBlocks(panel.Children, document, theme, onCopyText, onOpenLink: null, pass, depth);
+        return panel;
+    }
+```
+
+Add `using NovaTerminal.AgentOutput.Fences;` to the file's usings.
+
+- [ ] **Step 9: Run the fence tests**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~FenceBodyTests"`
+Expected: PASS, 21 tests, 0 failed.
+
+- [ ] **Step 10: Run the whole AgentOutput suite for regressions**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~AgentOutput"`
+Expected: PASS. `FencedCodeBlock_RendersItsText_WithACopyButton` uses ` ```csharp `, which must still resolve to null and render identically.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add src/NovaTerminal.App/AgentOutput/ tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs
+git commit -m "feat(agent-output): add the fence-body seam and a diff handler
+
+BuildCodeBlock now asks FenceBodyResolver what a fence's info string
+means; a null answer keeps today's flat Run exactly as it was. The diff
+handler colors lines by leading marker, testing the three-character file
+headers before the one-character ones so '+++ b/file' is not an addition.
+
+Block chrome stays with the renderer, so Copy still yields raw source
+for every block regardless of handler."
+```
+
+---
+
+### Task 4: The `markdown` handler and the depth cap
+
+**Files:**
+- Modify: `src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs`
+- Test: `tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs`
+
+**Interfaces:**
+- Consumes: `IFenceBody`, `FenceContext`, `NestedMarkdownRenderer` (Task 3); `MarkdownRenderer.MaxFenceDepth` (Task 3); `MarkdownRenderResult` (Task 2).
+- Produces: no new public surface.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `MarkdownRendererTests.cs`:
+
+```csharp
+[Fact]
+public void MarkdownFence_RendersNestedBlocks_NotSource()
+{
+    MarkdownRenderResult result = MarkdownRenderer.Build("```markdown\n# Nested Title\n```\n", Anchor);
+
+    // A rendered heading is a TextBlock with the heading's own size, not a monospace code run.
+    TextBlock? heading = TextBlocks((StackPanel)result.Root)
+        .FirstOrDefault(b => TextOf(b).Contains("Nested Title", StringComparison.Ordinal));
+    Assert.NotNull(heading);
+    Assert.True(heading!.FontSize > 12, "a rendered heading is larger than code text");
+    Assert.True(result.HasTransformBlock);
+}
+
+[Fact]
+public void MarkdownFence_WithSwitchOff_RendersSource_ButStillReportsTransform()
+{
+    MarkdownRenderResult result = MarkdownRenderer.Build(
+        "```markdown\n# Nested Title\n```\n",
+        Anchor,
+        renderFencedMarkdown: false);
+
+    TextBlock? source = TextBlocks((StackPanel)result.Root)
+        .FirstOrDefault(b => TextOf(b).Contains("# Nested Title", StringComparison.Ordinal));
+    Assert.NotNull(source);
+
+    // The switch must stay visible, or the choice is not reversible.
+    Assert.True(result.HasTransformBlock);
+}
+
+[Fact]
+public void MarkdownFence_NestedInsideAnother_RendersTheInnerOneAsSource()
+{
+    const string md = "````markdown\n# Outer\n\n```markdown\n# Inner\n```\n````\n";
+
+    MarkdownRenderResult result = MarkdownRenderer.Build(md, Anchor);
+
+    // Outer renders: its heading is a real heading.
+    TextBlock? outer = TextBlocks((StackPanel)result.Root)
+        .FirstOrDefault(b => TextOf(b).Contains("Outer", StringComparison.Ordinal));
+    Assert.NotNull(outer);
+    Assert.True(outer!.FontSize > 12);
+
+    // Inner does not: its hash survives as literal text at the depth cap.
+    TextBlock? inner = TextBlocks((StackPanel)result.Root)
+        .FirstOrDefault(b => TextOf(b).Contains("# Inner", StringComparison.Ordinal));
+    Assert.NotNull(inner);
+}
+
+[Fact]
+public void MarkdownFence_KeepsCopyYieldingRawSource()
+{
+    string? copied = null;
+    MarkdownRenderResult result = MarkdownRenderer.Build(
+        "```markdown\n# Nested Title\n```\n",
+        Anchor,
+        onCopyText: text => copied = text);
+
+    Button copy = Descendants((StackPanel)result.Root).OfType<Button>().First(b => b.Content as string == "Copy");
+    copy.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+    Assert.Equal("# Nested Title\n", copied);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~MarkdownFence"`
+Expected: FAIL. The switch-off test fails because the Task 3 placeholder ignores `RenderFencedMarkdown` and always renders nested.
+
+- [ ] **Step 3: Implement the handler**
+
+Replace `MarkdownFenceBody.cs` in full:
+
+```csharp
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>
+/// Renders a <c>markdown</c> / <c>md</c> fence as a nested document rather than as source.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recursion goes back through the renderer's own block walk rather than reimplementing it, so
+/// every block type the panel already supports - headings, tables, task lists, links with their
+/// scheme allowlist - works inside a fence with no duplicated rendering logic.
+/// </para>
+/// <para>
+/// The switch is honoured here rather than at the resolver, because a handler that renders
+/// source must still report itself as a transform: that is what keeps the panel's switch on
+/// screen, and a switch that hid itself when flipped would be a one-way door.
+/// </para>
+/// </remarks>
+internal sealed class MarkdownFenceBody : IFenceBody
+{
+    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
+
+    public bool IsTransform => true;
+
+    public Control Build(string code, MarkdownTheme theme, FenceContext context)
+    {
+        if (!context.RenderFencedMarkdown)
+        {
+            return BuildSource(code, theme);
+        }
+
+        return context.RenderNested(code, context.Depth + 1);
+    }
+
+    /// <summary>The unhandled path's body, reproduced for the switch's source position.</summary>
+    private static Control BuildSource(string code, MarkdownTheme theme)
+    {
+        var text = new SelectableTextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12,
+            FontFamily = new FontFamily(MonospaceFontFamily),
+            Foreground = theme.Foreground,
+        };
+        text.Inlines?.Add(new Run { Text = code });
+        return text;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~MarkdownFence"`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Run the whole AgentOutput suite**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~AgentOutput"`
+Expected: PASS, 0 failed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+git commit -m "feat(agent-output): render markdown fences as nested documents
+
+A markdown/md fence recurses back through the renderer's own block walk,
+so every block type the panel supports works inside a fence for free.
+Capped at depth 1: a fence inside a rendered fence stays source.
+
+With the switch off the handler renders source but still reports itself
+as a transform, which is what keeps the switch on screen - a switch that
+vanished when flipped would be a one-way door."
+```
+
+---
+
+### Task 5: The panel switch
+
+**Files:**
+- Modify: `src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs`
+- Modify: `src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml` (header row)
+- Modify: `src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs` (pass the flag, gate visibility, handle the click)
+- Test: `tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs`, `tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs`
+
+**Interfaces:**
+- Consumes: `MarkdownRenderResult.HasTransformBlock` (Task 2), `renderFencedMarkdown` parameter on `Build` (Task 2).
+- Produces: `AgentOutputViewModel.RenderFencedMarkdown` (`bool`, default `true`, raises `PropertyChanged`).
+
+- [ ] **Step 1: Write the failing view-model test**
+
+Add to `AgentOutputViewModelTests.cs`:
+
+```csharp
+[Fact]
+public void RenderFencedMarkdown_DefaultsToTrue()
+{
+    var vm = new AgentOutputViewModel();
+
+    Assert.True(vm.RenderFencedMarkdown);
+}
+
+[Fact]
+public void RenderFencedMarkdown_RaisesPropertyChanged_OnlyWhenItChanges()
+{
+    var vm = new AgentOutputViewModel();
+
+    var names = Changed(vm, () => vm.RenderFencedMarkdown = false);
+    Assert.Contains(nameof(AgentOutputViewModel.RenderFencedMarkdown), names);
+
+    var again = Changed(vm, () => vm.RenderFencedMarkdown = false);
+    Assert.DoesNotContain(nameof(AgentOutputViewModel.RenderFencedMarkdown), again);
+}
+```
+
+`Changed` is the existing helper in that file.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~RenderFencedMarkdown"`
+Expected: FAIL to compile — the property does not exist.
+
+- [ ] **Step 3: Add the property**
+
+In `AgentOutputViewModel.cs`, add the backing field beside the others and the property following the file's established shape:
+
+```csharp
+    private bool _renderFencedMarkdown = true;
+```
+
+```csharp
+    /// <summary>
+    /// Render <c>```markdown</c> fences as documents rather than as source.
+    /// </summary>
+    /// <remarks>
+    /// Panel-level rather than per-block, and deliberately so: the panel rebuilds its whole
+    /// control tree on every <see cref="MarkdownText"/> change, which while streaming is every
+    /// few hundred milliseconds. State living in a block's own control would reset on every
+    /// tick, and keying it by block ordinal would reattach a choice to the wrong block when a
+    /// new block arrives earlier in the stream. One field survives all of that. Per-pane
+    /// runtime state; not persisted.
+    /// </remarks>
+    public bool RenderFencedMarkdown
+    {
+        get => _renderFencedMarkdown;
+        set
+        {
+            if (_renderFencedMarkdown == value)
+            {
+                return;
+            }
+
+            _renderFencedMarkdown = value;
+            OnPropertyChanged(nameof(RenderFencedMarkdown));
+        }
+    }
+```
+
+- [ ] **Step 4: Run the view-model test to verify it passes**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~RenderFencedMarkdown"`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Write the failing panel test**
+
+Add to `AgentOutputPanelTests.cs`. Three details of that file's pattern are load-bearing: `[AvaloniaFact]` rather than `[Fact]` (the panel is a XAML `UserControl` and `InitializeComponent` needs the headless application up — a plain `[Fact]` throws), the `CreatePanel(out var viewModel)` helper, and `FindControl<T>("Name")` rather than walking the visual tree. Add `using Avalonia.Controls.Primitives;` for `ToggleButton`.
+
+```csharp
+[AvaloniaFact]
+public void FenceSwitch_IsHidden_WhenTheResponseHasNoMarkdownFence()
+{
+    var panel = CreatePanel(out var viewModel);
+
+    viewModel.SetUpdate("# Just a heading\n\nno fences here\n", isStreaming: false);
+
+    Assert.False(panel.FindControl<ToggleButton>("BtnRenderFences").IsVisible);
+}
+
+[AvaloniaFact]
+public void FenceSwitch_IsVisible_WhenTheResponseHasAMarkdownFence()
+{
+    var panel = CreatePanel(out var viewModel);
+
+    viewModel.SetUpdate("```markdown\n# Nested\n```\n", isStreaming: false);
+
+    Assert.True(panel.FindControl<ToggleButton>("BtnRenderFences").IsVisible);
+}
+
+[AvaloniaFact]
+public void FenceSwitch_UncheckedThenNewContent_KeepsRenderingSource()
+{
+    var panel = CreatePanel(out var viewModel);
+    viewModel.SetUpdate("```markdown\n# First\n```\n", isStreaming: false);
+
+    ToggleButton toggle = panel.FindControl<ToggleButton>("BtnRenderFences");
+    toggle.IsChecked = false;
+    toggle.RaiseEvent(new RoutedEventArgs(ToggleButton.ClickEvent));
+
+    // The choice lives on the view model, so the next content update must not undo it - that is
+    // the whole reason the switch is panel-level rather than per-block.
+    viewModel.SetUpdate("```markdown\n# Second\n```\n", isStreaming: false);
+
+    Assert.False(viewModel.RenderFencedMarkdown);
+    Assert.Contains(
+        "# Second",
+        panel.FindControl<StackPanel>("MarkdownHost").Children
+            .OfType<Control>()
+            .SelectMany(TextOf),
+        StringComparer.Ordinal);
+}
+```
+
+The third test needs `using Avalonia.Interactivity;` and a small text-collecting helper; if `AgentOutputPanelTests.cs` has no equivalent, add one mirroring `MarkdownRendererTests.TextOf`:
+
+```csharp
+private static IEnumerable<string> TextOf(Control control)
+{
+    if (control is TextBlock block && block.Text is { Length: > 0 } text)
+    {
+        yield return text;
+    }
+
+    if (control is Panel panel)
+    {
+        foreach (Control child in panel.Children)
+        {
+            foreach (string nested in TextOf(child))
+            {
+                yield return nested;
+            }
+        }
+    }
+
+    if (control is Border { Child: Control inner })
+    {
+        foreach (string nested in TextOf(inner))
+        {
+            yield return nested;
+        }
+    }
+
+    if (control is ContentControl { Content: Control content })
+    {
+        foreach (string nested in TextOf(content))
+        {
+            yield return nested;
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~FenceSwitch"`
+Expected: FAIL — no control named `BtnRenderFences`.
+
+- [ ] **Step 7: Add the switch to the header**
+
+In `AgentOutputPanel.axaml`, widen the header grid's columns from `*,Auto,Auto` to `*,Auto,Auto,Auto`, insert the toggle at column 1, and move Copy and Close to columns 2 and 3:
+
+```xml
+            <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="6" Margin="10,8,10,6">
+```
+
+```xml
+                <ToggleButton x:Name="BtnRenderFences"
+                              Grid.Column="1"
+                              Content="md"
+                              FontSize="11"
+                              Padding="7,2"
+                              IsChecked="True"
+                              IsVisible="False"
+                              VerticalAlignment="Top"
+                              ToolTip.Tip="Render ```markdown blocks as formatted documents"
+                              Click="OnRenderFencesClick"/>
+```
+
+Change `BtnCopyAll` to `Grid.Column="2"` and `BtnClose` to `Grid.Column="3"`.
+
+- [ ] **Step 8: Wire the switch in the code-behind**
+
+In `AgentOutputPanel.axaml.cs`, pass the flag and gate the toggle's visibility on the render result:
+
+```csharp
+        MarkdownRenderResult rendered = MarkdownRenderer.Build(
+            markdown,
+            this,
+            onCopyText: text => _ = CopyToClipboardAsync(text),
+            onOpenLink: url => _ = OpenLinkAsync(url),
+            renderFencedMarkdown: _viewModel?.RenderFencedMarkdown ?? true);
+        MarkdownHost.Children.Add(rendered.Root);
+
+        // A switch that governs nothing is clutter, so it appears only for a response that
+        // actually contains a block it governs.
+        BtnRenderFences.IsVisible = rendered.HasTransformBlock;
+```
+
+Add the click handler beside `OnCopyAllClick`:
+
+```csharp
+    private void OnRenderFencesClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        _viewModel.RenderFencedMarkdown = BtnRenderFences.IsChecked ?? true;
+        Render();
+    }
+```
+
+Extend the property filter at `AgentOutputPanel.axaml.cs:74` so a programmatic change also re-renders:
+
+```csharp
+        if (e.PropertyName is nameof(AgentOutputViewModel.MarkdownText)
+            or nameof(AgentOutputViewModel.HasContent)
+            or nameof(AgentOutputViewModel.RenderFencedMarkdown))
+```
+
+- [ ] **Step 9: Run the panel tests to verify they pass**
+
+Run: `scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~FenceSwitch"`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 10: Run every affected suite**
+
+Run each and expect 0 failed:
+
+```bash
+scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~AgentOutput"
+scripts/build.sh test tests/NovaTerminal.App.Tests --filter "FullyQualifiedName~Controls|FullyQualifiedName~TerminalPane" --blame-hang-timeout 5m
+scripts/build.sh test tests/NovaTerminal.VT.Tests
+scripts/build.sh test tests/NovaTerminal.Architecture.Tests
+```
+
+- [ ] **Step 11: Verify in the running app**
+
+Build and launch from this worktree, then in a pane run a command whose output contains a ` ```markdown ` fence and one containing a ` ```diff ` fence. Confirm: the fence renders as a document, the `md` toggle appears in the panel header, unchecking it shows source, Copy yields raw source in both positions, and a response with no fence shows no toggle.
+
+```bash
+scripts/build.sh build src/NovaTerminal.App
+```
+
+Launch with an absolute path via `Start-Process`; a `cd`-prefixed background launch has been observed to exit 127 without starting. Close the app before the next build — it locks `NovaTerminal.exe`.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add src/NovaTerminal.App/AgentOutput/ tests/NovaTerminal.App.Tests/AgentOutput/
+git commit -m "feat(agent-output): add the panel-level fence rendering switch
+
+One bool on the view model, surfaced as an 'md' toggle in the panel
+header and shown only when the current response actually contains a
+block it governs.
+
+Panel-level rather than per-block because the panel rebuilds its whole
+control tree on every text change: per-block state would reset every
+streaming tick, and keying it by block ordinal would reattach a choice
+to the wrong block when a block arrives earlier in the stream."
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** §1 the seam → Task 3 Steps 4-5, 8. §2 info-string matching → Task 3 Step 5, tested Step 1. §3 markdown handler and depth cap → Task 4, cap constant in Task 3 Step 8. §4 diff handler → Task 3 Steps 3, 6, with the header-before-marker ordering tested. §5 panel switch → Task 5. §6 render result and switch visibility → Task 2 (type), Task 5 Step 8 (gating). §7 targeted refactor → Task 1 (theme extraction), Task 3 (`Fences/` directory). Edge cases: empty body → the unhandled path via `NormalizeInfo` returning empty; casing and aliases → Task 3 Step 1 theory data; malformed diff → the `Foreground` default, tested by the context-line case. Testing section → covered across Tasks 2-5. No spec requirement is without a task.
+
+**Three gaps found and closed while reviewing.** The spec's testing list includes "Copy yields raw source in both switch positions" with no task — added as Task 4 Step 1's fourth test. The spec also asks that the choice "survives a subsequent `MarkdownText` update" and nothing verified it — added as Task 5 Step 5's third panel test, which is the one that actually justifies the switch being panel-level. And the first draft of those panel tests used `[Fact]`; `AgentOutputPanelTests` is `[AvaloniaFact]` throughout because the panel is a XAML `UserControl` whose `InitializeComponent` needs the headless application, so a plain `[Fact]` would have thrown rather than failed usefully.
+
+**Type consistency.** `MarkdownTheme` (Task 1) is the parameter type in `IFenceBody.Build` (Task 3) and both handlers. `MarkdownRenderPass.HasTransformBlock` (Task 2) is what Task 3 Step 8 sets and what `MarkdownRenderResult.HasTransformBlock` (Task 2) carries out to Task 5 Step 8. `renderFencedMarkdown` is the `Build` parameter (Task 2), `MarkdownRenderPass.RenderFencedMarkdown` (Task 2), `FenceContext.RenderFencedMarkdown` (Task 3) and `AgentOutputViewModel.RenderFencedMarkdown` (Task 5) — one concept, one name at every layer. `MaxFenceDepth` is declared once (Task 3 Step 8) and read once (same step).
+
+**One risk the executor should know.** Task 3 Step 8 rewrites the body-construction half of `BuildCodeBlock` while leaving its chrome alone. If #378 takes further review changes to that method, this is where the conflict lands.

--- a/docs/superpowers/plans/2026-09-03-fence-language-semantics.md
+++ b/docs/superpowers/plans/2026-09-03-fence-language-semantics.md
@@ -682,6 +682,8 @@ In `MarkdownRenderer.cs`, add the depth constant beside `MonospaceFontFamily`:
     internal const int MaxFenceDepth = 1;
 ```
 
+First, `BuildCodeBlock` gains an `Action<string>? onOpenLink` parameter — place it immediately after `onCopyText`, and pass `onOpenLink` at both `BuildCodeBlock` call sites in `AppendBlocks`. Without it a link inside a rendered markdown fence is inert, and spec §3 requires links to work there.
+
 Then, inside `BuildCodeBlock`, replace the single-`Run` body construction with a resolver lookup. The chrome below it is untouched:
 
 ```csharp
@@ -712,7 +714,7 @@ Then, inside `BuildCodeBlock`, replace the single-`Run` body construction with a
             new FenceContext(
                 depth,
                 pass.RenderFencedMarkdown,
-                (nested, nestedDepth) => BuildNested(nested, theme, onCopyText, pass, nestedDepth),
+                (nested, nestedDepth) => BuildNested(nested, theme, onCopyText, onOpenLink, pass, nestedDepth),
                 onCopyText));
     }
 ```
@@ -727,12 +729,13 @@ Add the nested-render helper next to `AppendBlocks`:
         string markdown,
         MarkdownTheme theme,
         Action<string>? onCopyText,
+        Action<string>? onOpenLink,
         MarkdownRenderPass pass,
         int depth)
     {
         MarkdownDocument document = Markdown.Parse(markdown ?? string.Empty, Pipeline);
         var panel = new StackPanel { Spacing = 2 };
-        AppendBlocks(panel.Children, document, theme, onCopyText, onOpenLink: null, pass, depth);
+        AppendBlocks(panel.Children, document, theme, onCopyText, onOpenLink, pass, depth);
         return panel;
     }
 ```
@@ -841,7 +844,10 @@ public void MarkdownFence_KeepsCopyYieldingRawSource()
     Button copy = Descendants((StackPanel)result.Root).OfType<Button>().First(b => b.Content as string == "Copy");
     copy.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
 
-    Assert.Equal("# Nested Title\n", copied);
+    // Contains, not Equal: whether GetLinesText keeps a trailing newline is not this test's
+    // subject. The surviving hash is what proves Copy yielded source rather than rendered text.
+    Assert.NotNull(copied);
+    Assert.Contains("# Nested Title", copied!, StringComparison.Ordinal);
 }
 ```
 
@@ -1153,6 +1159,17 @@ In `AgentOutputPanel.axaml.cs`, pass the flag and gate the toggle's visibility o
         // A switch that governs nothing is clutter, so it appears only for a response that
         // actually contains a block it governs.
         BtnRenderFences.IsVisible = rendered.HasTransformBlock;
+```
+
+`Render()` has a no-content early return (`if (!hasContent) { MarkdownHost.Children.Clear(); return; }`). Reset the switch there too, or it keeps the previous response's visibility while the panel shows its empty state:
+
+```csharp
+        if (!hasContent)
+        {
+            MarkdownHost.Children.Clear();
+            BtnRenderFences.IsVisible = false;
+            return;
+        }
 ```
 
 Add the click handler beside `OnCopyAllClick`:

--- a/docs/superpowers/specs/2026-09-03-fence-language-semantics-design.md
+++ b/docs/superpowers/specs/2026-09-03-fence-language-semantics-design.md
@@ -162,7 +162,10 @@ A switch that is usually a no-op is clutter, so it appears only when the current
 produced a transform block. `Build` therefore returns a small result instead of a bare
 `Control`:
 
-    internal sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock);
+    public sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock);
+
+Public, not `internal`: `MarkdownRenderer.Build` is itself public, and C# forbids a public
+method returning a less-accessible type (CS0050).
 
 `AgentOutputPanel` binds the switch's visibility to `HasTransformBlock`. There is exactly one
 caller of `Build`, so this is a contained change.
@@ -246,6 +249,14 @@ guard that an unrecognized language is untouched.
 - `IsTransform` exists so the switch can be gated, which means a future handler that transforms
   content inherits the switch whether or not that is the right affordance for it. Revisit when a
   third transform handler appears, not before.
+- The depth cap gates *every* handler, not only the recursing one, so a ` ```diff ` fence nested
+  inside a rendered ` ```markdown ` fence loses its colouring and renders as source. Guarding at
+  the lookup is the safer construction, so this is accepted rather than worked around.
+- `IsFileHeader` requires a trailing space, which fixes `+++counter;` but still mis-colours a
+  removed line whose own text begins with `-- ` (deleting a SQL or Lua comment `-- note` yields
+  the diff line `--- note`, coloured as a file header). Distinguishing these needs positional
+  context — headers only after `diff --git`/`index `, or as a `---`/`+++` pair — which is out of
+  scope here.
 
 ## Sequencing
 

--- a/docs/superpowers/specs/2026-09-03-fence-language-semantics-design.md
+++ b/docs/superpowers/specs/2026-09-03-fence-language-semantics-design.md
@@ -1,0 +1,258 @@
+# Fenced-Block Language Semantics in the Agent Output Panel
+
+Date: 2026-09-03
+Status: designed (not implemented)
+Depends on: PR #378 (`agent-output-markdown-panel`) — this branch is stacked on it, because
+`main` has no `AgentOutput` subsystem yet. Rebase onto `main` once #378 merges.
+
+## Summary
+
+Give the Agent Output panel an opinion about **what a fenced block contains**, keyed on its
+info string:
+
+- ` ```markdown ` / ` ```md ` renders as a nested document instead of as source, governed by a
+  single panel-level switch;
+- ` ```diff ` keeps its monospace body but colors each line by its leading marker;
+- **every other info string, and every block without one, renders exactly as it does today.**
+
+The language is already captured — `MarkdownRenderer.cs:105` passes `fenced.Info.ToString()`
+into `BuildCodeBlock` — and used for exactly one thing: a label `TextBlock`. This makes it
+mean something.
+
+## Why
+
+Reported from real use: `claude -p "generate some markdown example"` answers with its entire
+response wrapped in a ` ```markdown ` fence, so the panel showed a page of unrendered markdown
+source with a language label on top. That rendering is *correct* — a fence means source — but
+it revealed that the panel has no way to distinguish "here is code" from "here is a document I
+wrote for you", which is a distinction agents make constantly.
+
+The insight this came from: the markdown case is not a markdown special case. It is the first
+instance of the renderer needing an opinion about a fence's *content type*, and the same seam
+serves diffs, JSON, and anything later.
+
+## Non-goals
+
+- **Syntax highlighting.** Coloring `csharp`/`python`/`bash` bodies per token is the other axis
+  entirely — it needs a tokenizer per language (a new dependency or N hand-rolled ones), token
+  colors as theme resources across light and dark, and a perf budget that survives re-rendering
+  on the 300ms streaming debounce. Explicitly deferred.
+- **Actionability.** No Run button on ` ```bash `, no Apply on ` ```diff `. Executing
+  agent-authored commands needs a confirmation-and-trust design of its own.
+- **An open/plugin registry.** Handlers are resolved by a closed `switch` over info strings.
+  Nothing outside the assembly registers handlers, so a registration mechanism would be
+  machinery without a consumer.
+- **Persisting the switch.** It is per-pane runtime state, not a `TerminalSettings` field. A
+  settings field would also have to be threaded through `TerminalPane.ApplySettings`'s
+  effective-settings whitelist and registered in the MCP `SettingsTools` drift guard; that cost
+  is not worth a view preference.
+- **A JSON handler.** A third handler shape, cheap but out of the first cut.
+
+## Design
+
+### 1. The seam
+
+`BuildCodeBlock` hardcodes the body as a single flat `Run` (`MarkdownRenderer.cs:192`). It
+instead asks a resolver:
+
+    internal static IFenceBody? Resolve(string? info)   // null => today's behavior, unchanged
+
+A handler produces the block **body only**:
+
+    internal interface IFenceBody
+    {
+        /// True when this handler replaces the source with something else, and so
+        /// participates in the panel's rendered/source switch. A restyle (diff) is not
+        /// a transform.
+        bool IsTransform { get; }
+
+        Control Build(string code, MarkdownTheme theme, FenceContext context);
+    }
+
+    internal sealed record FenceContext(
+        int Depth,
+        bool RenderFencedMarkdown,
+        NestedMarkdownRenderer RenderNested,
+        Action<string>? OnCopyText);
+
+    internal delegate Control NestedMarkdownRenderer(string markdown, int depth);
+
+**Block chrome is not a handler's business.** The border, header row, language label and Copy
+button stay in `BuildCodeBlock`. This keeps two guarantees that would otherwise erode
+per-handler: every code block looks like every other one, and **Copy always yields the raw
+source** regardless of what is displayed — automatic, since the Copy handler already closes
+over `code`.
+
+Two rejected alternatives, on the record:
+
+- **Pre-transforming the source text** (unwrapping fences before Markdig parses) is the
+  cheapest option and is wrong twice over: it destroys the source irrecoverably, so the switch
+  cannot exist, and it cannot express diff coloring at all, which is styling rather than text.
+- **Post-processing the built control tree** (walking it and swapping code-block `Border`s) has
+  no parse information left at that point and couples to the tree's exact shape.
+
+### 2. Info-string matching
+
+Match on the **first whitespace-delimited token** of the info string, trimmed and lowercased
+with `ToLowerInvariant`. Deliberately not on the whole string: ` ```markdown title="README" `
+must still resolve to the markdown handler. Taking the first token ourselves makes the match
+independent of how Markdig chooses to split `Info` from `Arguments`.
+
+Recognized: `markdown`, `md` → markdown handler. `diff`, `patch` → diff handler. Anything else,
+including the empty string and indented (`CodeBlock`) blocks that have no info at all, resolves
+to `null` and takes the existing path untouched.
+
+### 3. Handler: markdown
+
+Parses the body and calls back into the renderer's existing `AppendBlocks`, so every block type
+the panel already supports — headings, tables, task lists, nested code blocks, links with their
+scheme allowlist — works inside a fence for free, with no duplicated rendering logic.
+
+**Depth cap: `MaxFenceDepth = 1`.** A markdown fence encountered at depth 0 renders nested; one
+encountered at depth 1 or deeper renders as source. Agent output is untrusted content and this
+tree is rebuilt on the streaming debounce, so unbounded recursion is a cost multiplier against
+a case that does not occur in practice.
+
+`IsTransform => true`.
+
+When `FenceContext.RenderFencedMarkdown` is false the handler returns the plain source body —
+identical to the unhandled path, but still reporting itself as a transform so the switch stays
+visible and the choice is reversible.
+
+### 4. Handler: diff
+
+Keeps the body monospace and emits one `Run` per line, colored by leading marker. Order of tests
+matters — the three-character file headers must be checked before the one-character markers, or
+`+++ b/file` reads as an addition:
+
+| Line starts with | Brush | Rationale |
+|---|---|---|
+| `+++ ` or `--- ` | `Secondary` | File headers, not content changes |
+| `diff --git`, `index ` | `Secondary` | Git envelope |
+| `@@` | `NtYellow` | Hunk header |
+| `+` | `NtGreen` | Addition |
+| `-` | `NtRed` | Removal |
+| anything else | `Foreground` | Context line |
+
+`NtGreen`, `NtRed` and `NtYellow` already exist as theme resource keys, so this adds three
+properties to the theme record using the established `Find(anchor, "NtGreen", fallback)` pattern
+and no new theme plumbing.
+
+`IsTransform => false` — nothing is hidden by a restyle, so there is nothing to recover and the
+switch does not apply.
+
+### 5. The panel switch
+
+One `bool RenderFencedMarkdown` on `AgentOutputViewModel`, default **true**, surfaced as a
+switch in the **panel** header beside Copy — not in each block's header.
+
+The reason is the re-render: `AgentOutputPanel.axaml.cs:74` rebuilds the entire control tree
+whenever `MarkdownText` changes, which during streaming is every ~300ms. Per-block state living
+in a block's own control would be reset on every tick, and keying it by block ordinal would
+silently reattach a choice to the wrong block when a new block arrives earlier in the stream.
+One view-model bool survives every re-render for free and has no identity problem at all. The
+cost is granularity — it flips every markdown fence in the response together — which is a case
+that does not arise in practice.
+
+Per-pane, resets with the pane. Not persisted (see non-goals).
+
+### 6. Render result and switch visibility
+
+A switch that is usually a no-op is clutter, so it appears only when the current render actually
+produced a transform block. `Build` therefore returns a small result instead of a bare
+`Control`:
+
+    internal sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock);
+
+`AgentOutputPanel` binds the switch's visibility to `HasTransformBlock`. There is exactly one
+caller of `Build`, so this is a contained change.
+
+### 7. Targeted refactor
+
+`MarkdownRenderer.cs` is ~700 lines and its private nested `Theme` class is needed by handlers in
+other files. Extract it to `AgentOutput/MarkdownTheme.cs` as `internal sealed class MarkdownTheme`
+(same `Resolve`/`Find` behavior, three brushes added), and put the handlers in
+`AgentOutput/Fences/`. This keeps the renderer focused on block dispatch and makes each handler
+independently testable, which is the stated benefit of having an interface at all.
+
+No layering change: everything stays inside `NovaTerminal.App`, so the architecture guards are
+unaffected.
+
+## Edge cases
+
+- **Empty or whitespace-only fence body** — renders as today. A handler that would produce
+  nothing must not produce an empty bordered box.
+- **Unterminated fence while streaming** — Markdig treats it as a fenced block whose content is
+  everything to the end. The markdown handler renders a partial document, which grows on the
+  next tick; no special handling.
+- **Markdown fence whose content is not markdown** — renders as one paragraph. Acceptable; the
+  switch recovers the source.
+- **Malformed diff** (no markers) — every line takes `Foreground`, i.e. looks like today.
+- **Info string casing and aliases** — `MARKDOWN`, `Md`, `Patch` all match, per §2.
+
+## Testing
+
+Unit, against the renderer and handlers directly:
+
+- a markdown fence renders nested blocks (a heading inside a fence produces a heading control,
+  not a code block);
+- the same fence with `RenderFencedMarkdown: false` renders source, and still reports
+  `HasTransformBlock`;
+- depth cap: a markdown fence inside a markdown fence renders the inner one as source;
+- diff marker mapping, including that `+++ b/file` is `Secondary` and not `NtGreen`;
+- unknown info strings (`csharp`, `bash`, `""`) and indented code blocks are byte-identical to
+  current output;
+- info-string normalization: `MARKDOWN`, `md`, and `markdown title="x"` all resolve;
+- Copy yields raw source in both switch positions.
+
+Panel and view-model:
+
+- the switch is hidden when a response has no transform block and visible when it has one;
+- toggling it re-renders, and the choice survives a subsequent `MarkdownText` update.
+
+Regression: the existing `MarkdownRendererTests` (block subset, raw-HTML inertness, link
+allowlist) must keep asserting exactly what they assert today — any change to an *expectation*
+there means the unhandled path moved and is a bug in this work. Their call sites do need one
+mechanical edit each, because `Build` returns `MarkdownRenderResult` rather than `Control` (§6):
+14 sites currently written `(StackPanel)MarkdownRenderer.Build(...)` become
+`(StackPanel)MarkdownRenderer.Build(...).Root`. That is the only permitted diff in that file's
+existing tests.
+
+`MarkdownRendererTests.cs:120` already renders a ` ```csharp ` block, so it doubles as the
+guard that an unrecognized language is untouched.
+
+## Files touched
+
+- `src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs` — resolver call in `BuildCodeBlock`,
+  depth parameter through `AppendBlocks`, `MarkdownRenderResult`
+- `src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs` — **new** (extracted, +3 brushes)
+- `src/NovaTerminal.App/AgentOutput/Fences/IFenceBody.cs` — **new**
+- `src/NovaTerminal.App/AgentOutput/Fences/FenceBodyResolver.cs` — **new**
+- `src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs` — **new**
+- `src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs` — **new**
+- `src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs` — `RenderFencedMarkdown`
+- `src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml` and `.axaml.cs` — header switch,
+  pass the flag
+- `tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs` — extended
+- `tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs` — **new**
+- `tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs` — switch visibility
+- `tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs` — the new property
+
+## Accepted limitations
+
+- The switch is **all-or-nothing per response**, by design (§5).
+- The switch does **not persist** across panes or restarts (non-goals).
+- A markdown fence nested inside another renders as source, by design (§3).
+- `IsTransform` exists so the switch can be gated, which means a future handler that transforms
+  content inherits the switch whether or not that is the right affordance for it. Revisit when a
+  third transform handler appears, not before.
+
+## Sequencing
+
+1. #378 merges.
+2. Rebase `feat/fence-language-semantics` onto `main`.
+3. Implement per the plan that follows this spec.
+
+Implementing before step 1 is possible — the branch is stacked and builds — but the PR cannot
+merge until #378 does, and any further review churn on #378's `MarkdownRenderer.cs` lands here
+as a conflict.

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
@@ -10,7 +10,7 @@
          column in TerminalPane stays Auto-sized. -->
     <Border Background="#1B1D21" BorderBrush="#31353A" BorderThickness="1,0,0,0">
         <Grid RowDefinitions="Auto,*">
-            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="6" Margin="10,8,10,6">
+            <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="6" Margin="10,8,10,6">
                 <StackPanel Spacing="1">
                     <TextBlock Text="Agent Output"
                                Foreground="#F3F6FA"
@@ -22,8 +22,18 @@
                                IsVisible="False"/>
                 </StackPanel>
 
+                <ToggleButton x:Name="BtnRenderFences"
+                              Grid.Column="1"
+                              Content="md"
+                              FontSize="11"
+                              Padding="7,2"
+                              IsChecked="True"
+                              IsVisible="False"
+                              VerticalAlignment="Top"
+                              ToolTip.Tip="Render ```markdown blocks as formatted documents"
+                              Click="OnRenderFencesClick"/>
                 <Button x:Name="BtnCopyAll"
-                        Grid.Column="1"
+                        Grid.Column="2"
                         Content="Copy"
                         FontSize="11"
                         Padding="7,2"
@@ -31,7 +41,7 @@
                         ToolTip.Tip="Copy the raw markdown source"
                         Click="OnCopyAllClick"/>
                 <Button x:Name="BtnClose"
-                        Grid.Column="2"
+                        Grid.Column="3"
                         Content="✕"
                         FontSize="11"
                         Padding="6,2"

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml
@@ -24,7 +24,7 @@
 
                 <ToggleButton x:Name="BtnRenderFences"
                               Grid.Column="1"
-                              Content="md"
+                              Content="Render"
                               FontSize="11"
                               Padding="7,2"
                               IsChecked="True"

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
@@ -102,12 +102,12 @@ public partial class AgentOutputPanel : UserControl
         bool isStreaming = _viewModel?.IsStreaming ?? false;
 
         MarkdownHost.Children.Clear();
-        Control rendered = MarkdownRenderer.Build(
+        MarkdownRenderResult rendered = MarkdownRenderer.Build(
             markdown,
             this,
             onCopyText: text => _ = CopyToClipboardAsync(text),
             onOpenLink: url => _ = OpenLinkAsync(url));
-        MarkdownHost.Children.Add(rendered);
+        MarkdownHost.Children.Add(rendered.Root);
 
         if (wasPinned && isStreaming)
         {

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input.Platform;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
@@ -71,7 +72,9 @@ public partial class AgentOutputPanel : UserControl
     private void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
         // Always on the UI thread: the tracker posts its updates through the pane's dispatcher.
-        if (e.PropertyName is nameof(AgentOutputViewModel.MarkdownText) or nameof(AgentOutputViewModel.HasContent))
+        if (e.PropertyName is nameof(AgentOutputViewModel.MarkdownText)
+            or nameof(AgentOutputViewModel.HasContent)
+            or nameof(AgentOutputViewModel.RenderFencedMarkdown))
         {
             Render();
         }
@@ -93,6 +96,7 @@ public partial class AgentOutputPanel : UserControl
         if (!hasContent)
         {
             MarkdownHost.Children.Clear();
+            BtnRenderFences.IsVisible = false;
             return;
         }
 
@@ -106,8 +110,13 @@ public partial class AgentOutputPanel : UserControl
             markdown,
             this,
             onCopyText: text => _ = CopyToClipboardAsync(text),
-            onOpenLink: url => _ = OpenLinkAsync(url));
+            onOpenLink: url => _ = OpenLinkAsync(url),
+            renderFencedMarkdown: _viewModel?.RenderFencedMarkdown ?? true);
         MarkdownHost.Children.Add(rendered.Root);
+
+        // A switch that governs nothing is clutter, so it appears only for a response that
+        // actually contains a block it governs.
+        BtnRenderFences.IsVisible = rendered.HasTransformBlock;
 
         if (wasPinned && isStreaming)
         {
@@ -141,6 +150,17 @@ public partial class AgentOutputPanel : UserControl
 
     private void OnCloseClick(object? sender, RoutedEventArgs e)
         => CloseRequested?.Invoke();
+
+    private void OnRenderFencesClick(object? sender, RoutedEventArgs e)
+    {
+        if (_viewModel is null)
+        {
+            return;
+        }
+
+        _viewModel.RenderFencedMarkdown = BtnRenderFences.IsChecked ?? true;
+        Render();
+    }
 
     // Task-returning rather than async void (SonarCloud S3168): both are fire-and-forget UI
     // side effects, so the discard at each call site is the containment — an exception surfaces

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputPanel.axaml.cs
@@ -66,6 +66,7 @@ public partial class AgentOutputPanel : UserControl
 
         _viewModel = viewModel;
         _viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        BtnRenderFences.IsChecked = viewModel.RenderFencedMarkdown;
         Render();
     }
 
@@ -159,7 +160,6 @@ public partial class AgentOutputPanel : UserControl
         }
 
         _viewModel.RenderFencedMarkdown = BtnRenderFences.IsChecked ?? true;
-        Render();
     }
 
     // Task-returning rather than async void (SonarCloud S3168): both are fire-and-forget UI

--- a/src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputViewModel.cs
@@ -20,6 +20,7 @@ public sealed class AgentOutputViewModel : INotifyPropertyChanged
     private bool _isStreaming;
     private string _markdownText = string.Empty;
     private string _statusText = string.Empty;
+    private bool _renderFencedMarkdown = true;
 
     /// <summary>Raised when any bound property changes.</summary>
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -123,6 +124,32 @@ public sealed class AgentOutputViewModel : INotifyPropertyChanged
 
             _statusText = value;
             OnPropertyChanged(nameof(StatusText));
+        }
+    }
+
+    /// <summary>
+    /// Render <c>```markdown</c> fences as documents rather than as source.
+    /// </summary>
+    /// <remarks>
+    /// Panel-level rather than per-block, and deliberately so: the panel rebuilds its whole
+    /// control tree on every <see cref="MarkdownText"/> change, which while streaming is every
+    /// few hundred milliseconds. State living in a block's own control would reset on every
+    /// tick, and keying it by block ordinal would reattach a choice to the wrong block when a
+    /// new block arrives earlier in the stream. One field survives all of that. Per-pane
+    /// runtime state; not persisted.
+    /// </remarks>
+    public bool RenderFencedMarkdown
+    {
+        get => _renderFencedMarkdown;
+        set
+        {
+            if (_renderFencedMarkdown == value)
+            {
+                return;
+            }
+
+            _renderFencedMarkdown = value;
+            OnPropertyChanged(nameof(RenderFencedMarkdown));
         }
     }
 

--- a/src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs
@@ -1,0 +1,74 @@
+using System;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Colors a unified diff by each line's leading marker.</summary>
+/// <remarks>
+/// A restyle, not a transform: the text is unchanged and nothing is hidden, so there is nothing
+/// for the panel's switch to recover and <see cref="IsTransform"/> is false.
+/// </remarks>
+internal sealed class DiffFenceBody : IFenceBody
+{
+    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
+
+    public bool IsTransform => false;
+
+    public Control Build(string code, MarkdownTheme theme, FenceContext context)
+    {
+        var text = new SelectableTextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12,
+            FontFamily = new FontFamily(MonospaceFontFamily),
+            Foreground = theme.Foreground,
+        };
+
+        string[] lines = code.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n');
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string line = lines[i];
+            text.Inlines?.Add(new Run
+            {
+                Text = i == lines.Length - 1 ? line : line + "\n",
+                Foreground = BrushFor(line, theme),
+            });
+        }
+
+        return text;
+    }
+
+    /// <summary>
+    /// Order is load-bearing: the three-character file headers are tested before the
+    /// one-character markers, or <c>+++ b/file</c> reads as an addition.
+    /// </summary>
+    private static IBrush BrushFor(string line, MarkdownTheme theme)
+    {
+        if (line.StartsWith("+++", StringComparison.Ordinal) ||
+            line.StartsWith("---", StringComparison.Ordinal) ||
+            line.StartsWith("diff --git", StringComparison.Ordinal) ||
+            line.StartsWith("index ", StringComparison.Ordinal))
+        {
+            return theme.Secondary;
+        }
+
+        if (line.StartsWith("@@", StringComparison.Ordinal))
+        {
+            return theme.Hunk;
+        }
+
+        if (line.StartsWith("+", StringComparison.Ordinal))
+        {
+            return theme.Added;
+        }
+
+        if (line.StartsWith("-", StringComparison.Ordinal))
+        {
+            return theme.Removed;
+        }
+
+        return theme.Foreground;
+    }
+}

--- a/src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs
@@ -12,8 +12,6 @@ namespace NovaTerminal.AgentOutput.Fences;
 /// </remarks>
 internal sealed class DiffFenceBody : IFenceBody
 {
-    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
-
     public bool IsTransform => false;
 
     public Control Build(string code, MarkdownTheme theme, FenceContext context)
@@ -22,7 +20,7 @@ internal sealed class DiffFenceBody : IFenceBody
         {
             TextWrapping = TextWrapping.Wrap,
             FontSize = 12,
-            FontFamily = new FontFamily(MonospaceFontFamily),
+            FontFamily = new FontFamily(MarkdownRenderer.MonospaceFontFamily),
             Foreground = theme.Foreground,
         };
 

--- a/src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/DiffFenceBody.cs
@@ -46,8 +46,8 @@ internal sealed class DiffFenceBody : IFenceBody
     /// </summary>
     private static IBrush BrushFor(string line, MarkdownTheme theme)
     {
-        if (line.StartsWith("+++", StringComparison.Ordinal) ||
-            line.StartsWith("---", StringComparison.Ordinal) ||
+        if (IsFileHeader(line, "+++") ||
+            IsFileHeader(line, "---") ||
             line.StartsWith("diff --git", StringComparison.Ordinal) ||
             line.StartsWith("index ", StringComparison.Ordinal))
         {
@@ -71,4 +71,13 @@ internal sealed class DiffFenceBody : IFenceBody
 
         return theme.Foreground;
     }
+
+    /// <summary>
+    /// A unified-diff file header: the three-character marker followed by a space, or the bare
+    /// marker alone. Requiring the space matters because an added line whose own text starts
+    /// with "++" produces "+++content" and is an addition, not a header.
+    /// </summary>
+    private static bool IsFileHeader(string line, string marker)
+        => line.StartsWith(marker + " ", StringComparison.Ordinal) ||
+           string.Equals(line, marker, StringComparison.Ordinal);
 }

--- a/src/NovaTerminal.App/AgentOutput/Fences/FenceBodyResolver.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/FenceBodyResolver.cs
@@ -1,0 +1,46 @@
+using System;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Maps a fence info string to a body handler, or to null for "leave it alone".</summary>
+/// <remarks>
+/// A closed switch on purpose. Nothing outside this assembly registers a handler, so a
+/// registration mechanism would be machinery with no consumer.
+/// </remarks>
+internal static class FenceBodyResolver
+{
+    private static readonly MarkdownFenceBody Markdown = new();
+    private static readonly DiffFenceBody Diff = new();
+
+    internal static IFenceBody? Resolve(string? info) => NormalizeInfo(info) switch
+    {
+        "markdown" or "md" => Markdown,
+        "diff" or "patch" => Diff,
+        _ => null,
+    };
+
+    /// <summary>
+    /// The first whitespace-delimited token, lowercased invariantly.
+    /// </summary>
+    /// <remarks>
+    /// The first token rather than the whole string, so <c>markdown title="README"</c> still
+    /// resolves. Splitting here rather than trusting Markdig's own Info/Arguments division keeps
+    /// the match independent of how the parser chooses to divide them.
+    /// </remarks>
+    internal static string NormalizeInfo(string? info)
+    {
+        if (string.IsNullOrWhiteSpace(info))
+        {
+            return string.Empty;
+        }
+
+        ReadOnlySpan<char> span = info.AsSpan().Trim();
+        int end = span.IndexOfAny(' ', '\t');
+        if (end >= 0)
+        {
+            span = span[..end];
+        }
+
+        return span.ToString().ToLowerInvariant();
+    }
+}

--- a/src/NovaTerminal.App/AgentOutput/Fences/IFenceBody.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/IFenceBody.cs
@@ -1,0 +1,34 @@
+using System;
+using Avalonia.Controls;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Renders a nested markdown document at the given depth.</summary>
+internal delegate Control NestedMarkdownRenderer(string markdown, int depth);
+
+/// <summary>What a handler is allowed to know about the render it sits inside.</summary>
+internal sealed record FenceContext(
+    int Depth,
+    bool RenderFencedMarkdown,
+    NestedMarkdownRenderer RenderNested,
+    Action<string>? OnCopyText);
+
+/// <summary>
+/// Produces the body of one fenced code block, chosen by the fence's info string.
+/// </summary>
+/// <remarks>
+/// A handler owns the <b>body only</b>. The border, header row, language label and Copy button
+/// stay with the renderer, which keeps two properties that would otherwise erode one handler at
+/// a time: every code block looks like every other one, and Copy always yields the raw source
+/// no matter what is on screen.
+/// </remarks>
+internal interface IFenceBody
+{
+    /// <summary>
+    /// True when this handler replaces the source with something else, and so participates in
+    /// the panel's rendered/source switch. A restyle hides nothing and is not a transform.
+    /// </summary>
+    bool IsTransform { get; }
+
+    Control Build(string code, MarkdownTheme theme, FenceContext context);
+}

--- a/src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs
@@ -21,8 +21,6 @@ namespace NovaTerminal.AgentOutput.Fences;
 /// </remarks>
 internal sealed class MarkdownFenceBody : IFenceBody
 {
-    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
-
     public bool IsTransform => true;
 
     public Control Build(string code, MarkdownTheme theme, FenceContext context)
@@ -42,7 +40,7 @@ internal sealed class MarkdownFenceBody : IFenceBody
         {
             TextWrapping = TextWrapping.Wrap,
             FontSize = 12,
-            FontFamily = new FontFamily(MonospaceFontFamily),
+            FontFamily = new FontFamily(MarkdownRenderer.MonospaceFontFamily),
             Foreground = theme.Foreground,
         };
         text.Inlines?.Add(new Run { Text = code });

--- a/src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs
@@ -1,12 +1,51 @@
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
 
 namespace NovaTerminal.AgentOutput.Fences;
 
-/// <summary>Renders a markdown fence as a nested document. Filled in by Task 4.</summary>
+/// <summary>
+/// Renders a <c>markdown</c> / <c>md</c> fence as a nested document rather than as source.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recursion goes back through the renderer's own block walk rather than reimplementing it, so
+/// every block type the panel already supports - headings, tables, task lists, links with their
+/// scheme allowlist - works inside a fence with no duplicated rendering logic.
+/// </para>
+/// <para>
+/// The switch is honoured here rather than at the resolver, because a handler that renders
+/// source must still report itself as a transform: that is what keeps the panel's switch on
+/// screen, and a switch that hid itself when flipped would be a one-way door.
+/// </para>
+/// </remarks>
 internal sealed class MarkdownFenceBody : IFenceBody
 {
+    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
+
     public bool IsTransform => true;
 
     public Control Build(string code, MarkdownTheme theme, FenceContext context)
-        => context.RenderNested(code, context.Depth + 1);
+    {
+        if (!context.RenderFencedMarkdown)
+        {
+            return BuildSource(code, theme);
+        }
+
+        return context.RenderNested(code, context.Depth + 1);
+    }
+
+    /// <summary>The unhandled path's body, reproduced for the switch's source position.</summary>
+    private static Control BuildSource(string code, MarkdownTheme theme)
+    {
+        var text = new SelectableTextBlock
+        {
+            TextWrapping = TextWrapping.Wrap,
+            FontSize = 12,
+            FontFamily = new FontFamily(MonospaceFontFamily),
+            Foreground = theme.Foreground,
+        };
+        text.Inlines?.Add(new Run { Text = code });
+        return text;
+    }
 }

--- a/src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs
+++ b/src/NovaTerminal.App/AgentOutput/Fences/MarkdownFenceBody.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+
+namespace NovaTerminal.AgentOutput.Fences;
+
+/// <summary>Renders a markdown fence as a nested document. Filled in by Task 4.</summary>
+internal sealed class MarkdownFenceBody : IFenceBody
+{
+    public bool IsTransform => true;
+
+    public Control Build(string code, MarkdownTheme theme, FenceContext context)
+        => context.RenderNested(code, context.Depth + 1);
+}

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderPass.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderPass.cs
@@ -1,0 +1,17 @@
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>Mutable state for one render pass of <see cref="MarkdownRenderer.Build"/>.</summary>
+/// <remarks>
+/// Two jobs, both of which have to cross the recursive block walk. <see cref="RenderFencedMarkdown"/>
+/// travels down: it is the panel's switch, and a fence handler that transforms content has to
+/// honour it. <see cref="HasTransformBlock"/> travels up: the panel shows its switch only when
+/// the render actually produced something the switch governs, so a response with no such block
+/// carries no pointless control.
+/// </remarks>
+internal sealed class MarkdownRenderPass
+{
+    internal required bool RenderFencedMarkdown { get; init; }
+
+    /// <summary>Set by any handler whose <c>IsTransform</c> is true, at any depth.</summary>
+    internal bool HasTransformBlock { get; set; }
+}

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
@@ -51,7 +51,13 @@ public sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock);
 /// </remarks>
 public static class MarkdownRenderer
 {
-    private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
+    /// <summary>
+    /// The monospace stack every code-shaped body uses: the unhandled fence path here, and both
+    /// fence handlers in <c>AgentOutput/Fences/</c>. One constant so the switch-off source body
+    /// and the unhandled body stay visually identical by construction, not by two literals
+    /// happening to agree.
+    /// </summary>
+    internal const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
 
     /// <summary>
     /// Deepest nesting a fence handler may render into. Agent output is untrusted and this tree
@@ -209,7 +215,14 @@ public static class MarkdownRenderer
         MarkdownRenderPass pass,
         int depth)
     {
-        IFenceBody? handler = depth < MaxFenceDepth ? FenceBodyResolver.Resolve(language) : null;
+        // A whitespace-only body has nothing for a handler to transform, and the spec requires it to
+        // render as it always has. Resolving no handler is what delivers that: the unhandled path
+        // below is byte-identical to today, and HasTransformBlock stays false, so the panel does not
+        // offer a switch over a block that displays nothing. Reachable on every streaming tick where
+        // a fence opener has arrived before its body.
+        IFenceBody? handler = depth < MaxFenceDepth && !string.IsNullOrWhiteSpace(code)
+            ? FenceBodyResolver.Resolve(language)
+            : null;
         Control body;
         if (handler is null)
         {
@@ -236,7 +249,11 @@ public static class MarkdownRenderer
                 new FenceContext(
                     depth,
                     pass.RenderFencedMarkdown,
-                    (nested, nestedDepth) => BuildNested(nested, theme, onCopyText, onOpenLink, pass, nestedDepth),
+                    // Clamped rather than forwarded verbatim: the depth cap must hold structurally,
+                    // not by convention. A handler that passed context.Depth instead of Depth + 1
+                    // would otherwise recurse without bound on attacker-influenceable text - this
+                    // seam enforces the bound so no handler can opt out of it.
+                    (nested, nestedDepth) => BuildNested(nested, theme, onCopyText, onOpenLink, pass, Math.Max(nestedDepth, depth + 1)),
                     onCopyText));
         }
 

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
@@ -18,6 +18,9 @@ using MInline = Markdig.Syntax.Inlines.Inline;
 
 namespace NovaTerminal.AgentOutput;
 
+/// <summary>One render's output: the tree, and whether it contains a switch-governed block.</summary>
+public sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock);
+
 /// <summary>
 /// Renders markdown text as an Avalonia control tree for the Agent Output panel.
 /// </summary>
@@ -60,18 +63,23 @@ public static class MarkdownRenderer
     /// </param>
     /// <param name="onCopyText">Invoked when the user copies a code block or inline run.</param>
     /// <param name="onOpenLink">Invoked when the user clicks a link.</param>
-    public static Control Build(
+    /// <param name="renderFencedMarkdown">
+    /// The panel's fence-rendering switch; travels down the walk via <see cref="MarkdownRenderPass"/>.
+    /// </param>
+    public static MarkdownRenderResult Build(
         string markdown,
         StyledElement resourceAnchor,
         Action<string>? onCopyText = null,
-        Action<string>? onOpenLink = null)
+        Action<string>? onOpenLink = null,
+        bool renderFencedMarkdown = true)
     {
         MarkdownDocument document = Markdown.Parse(markdown ?? string.Empty, Pipeline);
         var theme = MarkdownTheme.Resolve(resourceAnchor);
+        var pass = new MarkdownRenderPass { RenderFencedMarkdown = renderFencedMarkdown };
 
         var root = new StackPanel { Spacing = 2 };
-        AppendBlocks(root.Children, document, theme, onCopyText, onOpenLink);
-        return root;
+        AppendBlocks(root.Children, document, theme, onCopyText, onOpenLink, pass, depth: 0);
+        return new MarkdownRenderResult(root, pass.HasTransformBlock);
     }
 
     private static void AppendBlocks(
@@ -79,7 +87,9 @@ public static class MarkdownRenderer
         IEnumerable<Block> blocks,
         MarkdownTheme theme,
         Action<string>? onCopyText,
-        Action<string>? onOpenLink)
+        Action<string>? onOpenLink,
+        MarkdownRenderPass pass,
+        int depth)
     {
         foreach (Block block in blocks)
         {
@@ -94,19 +104,19 @@ public static class MarkdownRenderer
                     break;
 
                 case FencedCodeBlock fenced:
-                    target.Add(BuildCodeBlock(GetLinesText(fenced), fenced.Info.ToString(), theme, onCopyText));
+                    target.Add(BuildCodeBlock(GetLinesText(fenced), fenced.Info.ToString(), theme, onCopyText, pass, depth));
                     break;
 
                 case CodeBlock code:
-                    target.Add(BuildCodeBlock(GetLinesText(code), null, theme, onCopyText));
+                    target.Add(BuildCodeBlock(GetLinesText(code), null, theme, onCopyText, pass, depth));
                     break;
 
                 case ListBlock list:
-                    target.Add(BuildList(list, theme, onCopyText, onOpenLink));
+                    target.Add(BuildList(list, theme, onCopyText, onOpenLink, pass, depth));
                     break;
 
                 case QuoteBlock quote:
-                    target.Add(BuildQuote(quote, theme, onCopyText, onOpenLink));
+                    target.Add(BuildQuote(quote, theme, onCopyText, onOpenLink, pass, depth));
                     break;
 
                 case ThematicBreakBlock:
@@ -119,7 +129,7 @@ public static class MarkdownRenderer
                     break;
 
                 case Table table:
-                    target.Add(BuildTable(table, theme, onCopyText, onOpenLink));
+                    target.Add(BuildTable(table, theme, onCopyText, onOpenLink, pass, depth));
                     break;
 
 
@@ -172,7 +182,9 @@ public static class MarkdownRenderer
         string code,
         string? language,
         MarkdownTheme theme,
-        Action<string>? onCopyText)
+        Action<string>? onCopyText,
+        MarkdownRenderPass pass,
+        int depth)
     {
         var codeText = new SelectableTextBlock
         {
@@ -239,7 +251,9 @@ public static class MarkdownRenderer
         ListBlock list,
         MarkdownTheme theme,
         Action<string>? onCopyText,
-        Action<string>? onOpenLink)
+        Action<string>? onOpenLink,
+        MarkdownRenderPass pass,
+        int depth)
     {
         var panel = new StackPanel { Margin = new Thickness(0, 3, 0, 3) };
         int itemNumber = ParseOrderedStart(list);
@@ -271,7 +285,7 @@ public static class MarkdownRenderer
             row.Children.Add(markerText);
 
             var itemContent = new StackPanel { Spacing = 2 };
-            AppendBlocks(itemContent.Children, listItem, theme, onCopyText, onOpenLink);
+            AppendBlocks(itemContent.Children, listItem, theme, onCopyText, onOpenLink, pass, depth);
             Grid.SetColumn(itemContent, 1);
             row.Children.Add(itemContent);
 
@@ -285,10 +299,12 @@ public static class MarkdownRenderer
         QuoteBlock quote,
         MarkdownTheme theme,
         Action<string>? onCopyText,
-        Action<string>? onOpenLink)
+        Action<string>? onOpenLink,
+        MarkdownRenderPass pass,
+        int depth)
     {
         var content = new StackPanel { Spacing = 2 };
-        AppendBlocks(content.Children, quote, theme, onCopyText, onOpenLink);
+        AppendBlocks(content.Children, quote, theme, onCopyText, onOpenLink, pass, depth);
 
         return new Border
         {
@@ -319,7 +335,9 @@ public static class MarkdownRenderer
         Table table,
         MarkdownTheme theme,
         Action<string>? onCopyText,
-        Action<string>? onOpenLink)
+        Action<string>? onOpenLink,
+        MarkdownRenderPass pass,
+        int depth)
     {
         int columnCount = Math.Max(table.ColumnDefinitions.Count, 1);
         var grid = new Grid { Margin = new Thickness(0, 6, 0, 6) };
@@ -347,7 +365,7 @@ public static class MarkdownRenderer
                 }
 
                 var cellContent = new StackPanel { Spacing = 2 };
-                AppendBlocks(cellContent.Children, cell, theme, onCopyText, onOpenLink);
+                AppendBlocks(cellContent.Children, cell, theme, onCopyText, onOpenLink, pass, depth);
 
                 if (row.IsHeader)
                 {

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
@@ -54,14 +54,6 @@ public static class MarkdownRenderer
         .DisableHtml()
         .Build();
 
-    // Fixed fallback palette, matching the pane's other hand-styled surfaces.
-    private static readonly IBrush FallbackForeground = new SolidColorBrush(Color.FromRgb(0xF3, 0xF6, 0xFA));
-    private static readonly IBrush FallbackSecondary = new SolidColorBrush(Color.FromRgb(0x96, 0xA0, 0xAE));
-    private static readonly IBrush FallbackCodeBackground = new SolidColorBrush(Color.FromRgb(0x16, 0x18, 0x1C));
-    private static readonly IBrush FallbackPanel = new SolidColorBrush(Color.FromRgb(0x1B, 0x1D, 0x21));
-    private static readonly IBrush FallbackHairline = new SolidColorBrush(Color.FromRgb(0x2A, 0x2F, 0x35));
-    private static readonly IBrush FallbackAccent = new SolidColorBrush(Color.FromRgb(0x4C, 0x8B, 0xD8));
-
     /// <param name="markdown">The raw markdown source.</param>
     /// <param name="resourceAnchor">
     /// Element whose resource scope the <c>Nt*</c> brushes are resolved from (usually the panel).
@@ -75,7 +67,7 @@ public static class MarkdownRenderer
         Action<string>? onOpenLink = null)
     {
         MarkdownDocument document = Markdown.Parse(markdown ?? string.Empty, Pipeline);
-        var theme = Theme.Resolve(resourceAnchor);
+        var theme = MarkdownTheme.Resolve(resourceAnchor);
 
         var root = new StackPanel { Spacing = 2 };
         AppendBlocks(root.Children, document, theme, onCopyText, onOpenLink);
@@ -85,7 +77,7 @@ public static class MarkdownRenderer
     private static void AppendBlocks(
         IList<Control> target,
         IEnumerable<Block> blocks,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText,
         Action<string>? onOpenLink)
     {
@@ -136,7 +128,7 @@ public static class MarkdownRenderer
         }
     }
 
-    private static Control BuildHeading(HeadingBlock heading, Theme theme)
+    private static Control BuildHeading(HeadingBlock heading, MarkdownTheme theme)
     {
         double size = heading.Level switch
         {
@@ -161,7 +153,7 @@ public static class MarkdownRenderer
 
     private static Control BuildParagraph(
         ParagraphBlock paragraph,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText,
         Action<string>? onOpenLink)
     {
@@ -179,7 +171,7 @@ public static class MarkdownRenderer
     private static Control BuildCodeBlock(
         string code,
         string? language,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText)
     {
         var codeText = new SelectableTextBlock
@@ -245,7 +237,7 @@ public static class MarkdownRenderer
 
     private static Control BuildList(
         ListBlock list,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText,
         Action<string>? onOpenLink)
     {
@@ -291,7 +283,7 @@ public static class MarkdownRenderer
 
     private static Control BuildQuote(
         QuoteBlock quote,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText,
         Action<string>? onOpenLink)
     {
@@ -325,7 +317,7 @@ public static class MarkdownRenderer
 
     private static Control BuildTable(
         Table table,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText,
         Action<string>? onOpenLink)
     {
@@ -392,7 +384,7 @@ public static class MarkdownRenderer
     private static void AppendInlines(
         InlineCollection target,
         ContainerInline? container,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText,
         Action<string>? onOpenLink)
     {
@@ -475,7 +467,7 @@ public static class MarkdownRenderer
     private static void AppendEmphasis(
         InlineCollection target,
         EmphasisInline emphasis,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onCopyText,
         Action<string>? onOpenLink)
     {
@@ -504,7 +496,7 @@ public static class MarkdownRenderer
     private static void AppendLink(
         InlineCollection target,
         LinkInline link,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onOpenLink)
     {
         AppendLinkTarget(target, link.Url, GetLiteralText(link), theme, onOpenLink);
@@ -514,7 +506,7 @@ public static class MarkdownRenderer
         InlineCollection target,
         string url,
         string label,
-        Theme theme,
+        MarkdownTheme theme,
         Action<string>? onOpenLink)
     {
         var linkText = new TextBlock
@@ -640,36 +632,4 @@ public static class MarkdownRenderer
         }
     }
 
-    /// <summary>Resolved brush set for one render pass.</summary>
-    private sealed class Theme
-    {
-        internal required IBrush Foreground { get; init; }
-        internal required IBrush Secondary { get; init; }
-        internal required IBrush CodeBackground { get; init; }
-        internal required IBrush PanelBackground { get; init; }
-        internal required IBrush Hairline { get; init; }
-        internal required IBrush Accent { get; init; }
-
-        internal static Theme Resolve(StyledElement anchor)
-        {
-            return new Theme
-            {
-                Foreground = Find(anchor, "NtFg", FallbackForeground),
-                Secondary = Find(anchor, "NtFg3", FallbackSecondary),
-                CodeBackground = Find(anchor, "NtPanelAlt", FallbackCodeBackground),
-                PanelBackground = Find(anchor, "NtPanel", FallbackPanel),
-                Hairline = Find(anchor, "NtHairline", FallbackHairline),
-                Accent = Find(anchor, "NtBlue", FallbackAccent),
-            };
-        }
-
-        private static IBrush Find(StyledElement anchor, string key, IBrush fallback)
-        {
-            // Control themes put brushes in as object values; anything that is not a brush
-            // (an unexpected override) degrades to the fixed fallback rather than crashing.
-            return anchor.TryFindResource(key, out object? value) && value is IBrush brush
-                ? brush
-                : fallback;
-        }
-    }
 }

--- a/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownRenderer.cs
@@ -14,6 +14,7 @@ using Markdig.Extensions.TaskLists;
 using Markdig.Helpers;
 using Markdig.Syntax;
 using Markdig.Syntax.Inlines;
+using NovaTerminal.AgentOutput.Fences;
 using MInline = Markdig.Syntax.Inlines.Inline;
 
 namespace NovaTerminal.AgentOutput;
@@ -51,6 +52,12 @@ public sealed record MarkdownRenderResult(Control Root, bool HasTransformBlock);
 public static class MarkdownRenderer
 {
     private const string MonospaceFontFamily = "Cascadia Mono PL, Consolas, Menlo, monospace";
+
+    /// <summary>
+    /// Deepest nesting a fence handler may render into. Agent output is untrusted and this tree
+    /// is rebuilt on the streaming debounce, so a fence inside a rendered fence stays source.
+    /// </summary>
+    internal const int MaxFenceDepth = 1;
 
     private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
         .UseAdvancedExtensions()
@@ -104,11 +111,11 @@ public static class MarkdownRenderer
                     break;
 
                 case FencedCodeBlock fenced:
-                    target.Add(BuildCodeBlock(GetLinesText(fenced), fenced.Info.ToString(), theme, onCopyText, pass, depth));
+                    target.Add(BuildCodeBlock(GetLinesText(fenced), fenced.Info.ToString(), theme, onCopyText, onOpenLink, pass, depth));
                     break;
 
                 case CodeBlock code:
-                    target.Add(BuildCodeBlock(GetLinesText(code), null, theme, onCopyText, pass, depth));
+                    target.Add(BuildCodeBlock(GetLinesText(code), null, theme, onCopyText, onOpenLink, pass, depth));
                     break;
 
                 case ListBlock list:
@@ -136,6 +143,21 @@ public static class MarkdownRenderer
                     // YamlFrontMatter and anything else unrecognized: skip.
             }
         }
+    }
+
+    /// <summary>Renders a fence's body as markdown, one level deeper in the same pass.</summary>
+    private static Control BuildNested(
+        string markdown,
+        MarkdownTheme theme,
+        Action<string>? onCopyText,
+        Action<string>? onOpenLink,
+        MarkdownRenderPass pass,
+        int depth)
+    {
+        MarkdownDocument document = Markdown.Parse(markdown ?? string.Empty, Pipeline);
+        var panel = new StackPanel { Spacing = 2 };
+        AppendBlocks(panel.Children, document, theme, onCopyText, onOpenLink, pass, depth);
+        return panel;
     }
 
     private static Control BuildHeading(HeadingBlock heading, MarkdownTheme theme)
@@ -183,17 +205,40 @@ public static class MarkdownRenderer
         string? language,
         MarkdownTheme theme,
         Action<string>? onCopyText,
+        Action<string>? onOpenLink,
         MarkdownRenderPass pass,
         int depth)
     {
-        var codeText = new SelectableTextBlock
+        IFenceBody? handler = depth < MaxFenceDepth ? FenceBodyResolver.Resolve(language) : null;
+        Control body;
+        if (handler is null)
         {
-            TextWrapping = TextWrapping.Wrap,
-            FontSize = 12,
-            FontFamily = new FontFamily(MonospaceFontFamily),
-            Foreground = theme.Foreground,
-        };
-        codeText.Inlines?.Add(new Run { Text = code });
+            var codeText = new SelectableTextBlock
+            {
+                TextWrapping = TextWrapping.Wrap,
+                FontSize = 12,
+                FontFamily = new FontFamily(MonospaceFontFamily),
+                Foreground = theme.Foreground,
+            };
+            codeText.Inlines?.Add(new Run { Text = code });
+            body = codeText;
+        }
+        else
+        {
+            if (handler.IsTransform)
+            {
+                pass.HasTransformBlock = true;
+            }
+
+            body = handler.Build(
+                code,
+                theme,
+                new FenceContext(
+                    depth,
+                    pass.RenderFencedMarkdown,
+                    (nested, nestedDepth) => BuildNested(nested, theme, onCopyText, onOpenLink, pass, nestedDepth),
+                    onCopyText));
+        }
 
         var header = new Grid { ColumnDefinitions = ColumnDefinitions.Parse("*,Auto") };
         if (!string.IsNullOrWhiteSpace(language))
@@ -240,7 +285,7 @@ public static class MarkdownRenderer
                     new Border
                     {
                         Padding = new Thickness(8, 6, 8, 8),
-                        Child = codeText,
+                        Child = body,
                     },
                 },
             },

--- a/src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs
@@ -1,0 +1,55 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Media;
+
+namespace NovaTerminal.AgentOutput;
+
+/// <summary>Resolved brush set for one render pass.</summary>
+/// <remarks>
+/// Extracted from <see cref="MarkdownRenderer"/> so fence-body handlers in sibling files can
+/// take it. Resolution is unchanged: prefer the app's <c>Nt*</c> theme brushes, fall back to the
+/// fixed palette the pane's other hand-styled surfaces hard-code.
+/// </remarks>
+internal sealed class MarkdownTheme
+{
+    private static readonly IBrush FallbackForeground = new SolidColorBrush(Color.FromRgb(0xF3, 0xF6, 0xFA));
+    private static readonly IBrush FallbackSecondary = new SolidColorBrush(Color.FromRgb(0x96, 0xA0, 0xAE));
+    private static readonly IBrush FallbackCodeBackground = new SolidColorBrush(Color.FromRgb(0x16, 0x18, 0x1C));
+    private static readonly IBrush FallbackPanel = new SolidColorBrush(Color.FromRgb(0x1B, 0x1D, 0x21));
+    private static readonly IBrush FallbackHairline = new SolidColorBrush(Color.FromRgb(0x2A, 0x2F, 0x35));
+    private static readonly IBrush FallbackAccent = new SolidColorBrush(Color.FromRgb(0x4C, 0x8B, 0xD8));
+
+    internal required IBrush Foreground { get; init; }
+
+    internal required IBrush Secondary { get; init; }
+
+    internal required IBrush CodeBackground { get; init; }
+
+    internal required IBrush PanelBackground { get; init; }
+
+    internal required IBrush Hairline { get; init; }
+
+    internal required IBrush Accent { get; init; }
+
+    internal static MarkdownTheme Resolve(StyledElement anchor)
+    {
+        return new MarkdownTheme
+        {
+            Foreground = Find(anchor, "NtFg", FallbackForeground),
+            Secondary = Find(anchor, "NtFg3", FallbackSecondary),
+            CodeBackground = Find(anchor, "NtPanelAlt", FallbackCodeBackground),
+            PanelBackground = Find(anchor, "NtPanel", FallbackPanel),
+            Hairline = Find(anchor, "NtHairline", FallbackHairline),
+            Accent = Find(anchor, "NtBlue", FallbackAccent),
+        };
+    }
+
+    private static IBrush Find(StyledElement anchor, string key, IBrush fallback)
+    {
+        // Control themes put brushes in as object values; anything that is not a brush
+        // (an unexpected override) degrades to the fixed fallback rather than crashing.
+        return anchor.TryFindResource(key, out object? value) && value is IBrush brush
+            ? brush
+            : fallback;
+    }
+}

--- a/src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs
@@ -18,6 +18,9 @@ internal sealed class MarkdownTheme
     private static readonly IBrush FallbackPanel = new SolidColorBrush(Color.FromRgb(0x1B, 0x1D, 0x21));
     private static readonly IBrush FallbackHairline = new SolidColorBrush(Color.FromRgb(0x2A, 0x2F, 0x35));
     private static readonly IBrush FallbackAccent = new SolidColorBrush(Color.FromRgb(0x4C, 0x8B, 0xD8));
+    private static readonly IBrush FallbackAdded = new SolidColorBrush(Color.FromRgb(0x6F, 0xBF, 0x73));
+    private static readonly IBrush FallbackRemoved = new SolidColorBrush(Color.FromRgb(0xD9, 0x6C, 0x6C));
+    private static readonly IBrush FallbackHunk = new SolidColorBrush(Color.FromRgb(0xD6, 0xB0, 0x5C));
 
     internal required IBrush Foreground { get; init; }
 
@@ -31,6 +34,15 @@ internal sealed class MarkdownTheme
 
     internal required IBrush Accent { get; init; }
 
+    /// <summary>Diff addition lines.</summary>
+    internal required IBrush Added { get; init; }
+
+    /// <summary>Diff removal lines.</summary>
+    internal required IBrush Removed { get; init; }
+
+    /// <summary>Diff hunk headers.</summary>
+    internal required IBrush Hunk { get; init; }
+
     internal static MarkdownTheme Resolve(StyledElement anchor)
     {
         return new MarkdownTheme
@@ -41,6 +53,9 @@ internal sealed class MarkdownTheme
             PanelBackground = Find(anchor, "NtPanel", FallbackPanel),
             Hairline = Find(anchor, "NtHairline", FallbackHairline),
             Accent = Find(anchor, "NtBlue", FallbackAccent),
+            Added = Find(anchor, "NtGreen", FallbackAdded),
+            Removed = Find(anchor, "NtRed", FallbackRemoved),
+            Hunk = Find(anchor, "NtYellow", FallbackHunk),
         };
     }
 

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
@@ -1,5 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Controls.Primitives;
+using Avalonia.Interactivity;
 using NovaTerminal.AgentOutput;
 using Avalonia.Headless.XUnit;
 using Xunit;
@@ -111,5 +116,107 @@ public sealed class AgentOutputPanelTests
         // Agent output is untrusted: a crafted [label](target) must never name something the
         // shell handler would launch or hand to a protocol handler.
         Assert.False(AgentOutputPanel.IsSafeExternalUrl(url));
+    }
+
+    // ---------------------------------------------------------------- fence rendering switch
+
+    [AvaloniaFact]
+    public void FenceSwitch_IsHidden_WhenTheResponseHasNoMarkdownFence()
+    {
+        var panel = CreatePanel(out var viewModel);
+
+        viewModel.SetUpdate("# Just a heading\n\nno fences here\n", isStreaming: false);
+
+        Assert.False(panel.FindControl<ToggleButton>("BtnRenderFences").IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void FenceSwitch_IsVisible_WhenTheResponseHasAMarkdownFence()
+    {
+        var panel = CreatePanel(out var viewModel);
+
+        viewModel.SetUpdate("```markdown\n# Nested\n```\n", isStreaming: false);
+
+        Assert.True(panel.FindControl<ToggleButton>("BtnRenderFences").IsVisible);
+    }
+
+    [AvaloniaFact]
+    public void FenceSwitch_UncheckedThenNewContent_KeepsRenderingSource()
+    {
+        var panel = CreatePanel(out var viewModel);
+        viewModel.SetUpdate("```markdown\n# First\n```\n", isStreaming: false);
+
+        ToggleButton toggle = panel.FindControl<ToggleButton>("BtnRenderFences");
+        toggle.IsChecked = false;
+        toggle.RaiseEvent(new RoutedEventArgs(ToggleButton.ClickEvent));
+
+        // The choice lives on the view model, so the next content update must not undo it - that is
+        // the whole reason the switch is panel-level rather than per-block.
+        viewModel.SetUpdate("```markdown\n# Second\n```\n", isStreaming: false);
+
+        Assert.False(viewModel.RenderFencedMarkdown);
+        Assert.Contains(
+            "# Second",
+            panel.FindControl<StackPanel>("MarkdownHost").Children
+                .OfType<Control>()
+                .SelectMany(TextOf),
+            StringComparer.Ordinal);
+    }
+
+    private static IEnumerable<string> TextOf(Control control)
+    {
+        // Markers set Text directly; paragraphs and fenced-source bodies carry Inlines instead
+        // (see MarkdownRendererTests.TextOf) - both must be checked or raw fence source (which
+        // goes through Inlines) is invisible to this helper.
+        if (control is TextBlock block)
+        {
+            if (block.Text is { Length: > 0 } text)
+            {
+                yield return text;
+            }
+            else if (block.Inlines is { Count: > 0 } inlines)
+            {
+                var builder = new System.Text.StringBuilder();
+                foreach (Inline inline in inlines)
+                {
+                    if (inline is Run run)
+                    {
+                        builder.Append(run.Text);
+                    }
+                }
+
+                if (builder.Length > 0)
+                {
+                    yield return builder.ToString();
+                }
+            }
+        }
+
+        if (control is Panel panel)
+        {
+            foreach (Control child in panel.Children)
+            {
+                foreach (string nested in TextOf(child))
+                {
+                    yield return nested;
+                }
+            }
+        }
+
+        if (control is Border { Child: Control inner })
+        {
+            foreach (string nested in TextOf(inner))
+            {
+                yield return nested;
+            }
+        }
+
+        if (control is ContentControl { Content: Control content })
+        {
+            foreach (string nested in TextOf(content))
+            {
+                yield return nested;
+            }
+        }
     }
 }

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
@@ -118,6 +118,19 @@ public sealed class AgentOutputPanelTests
         Assert.False(AgentOutputPanel.IsSafeExternalUrl(url));
     }
 
+    [AvaloniaFact]
+    public void SetViewModel_SyncsTheToggle_FromTheViewModel()
+    {
+        // Unreachable today (the view model always starts true), but a latent desync otherwise:
+        // the XAML pins IsChecked="True" and nothing reconciled it with an already-false flag.
+        var viewModel = new AgentOutputViewModel { RenderFencedMarkdown = false };
+        var panel = new AgentOutputPanel();
+
+        panel.SetViewModel(viewModel);
+
+        Assert.False(panel.FindControl<ToggleButton>("BtnRenderFences").IsChecked);
+    }
+
     // ---------------------------------------------------------------- fence rendering switch
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputViewModelTests.cs
@@ -138,4 +138,24 @@ public sealed class AgentOutputViewModelTests
         Assert.Contains(nameof(AgentOutputViewModel.HasContent), names);
         Assert.Equal(2, names.Count);
     }
+
+    [Fact]
+    public void RenderFencedMarkdown_DefaultsToTrue()
+    {
+        var vm = new AgentOutputViewModel();
+
+        Assert.True(vm.RenderFencedMarkdown);
+    }
+
+    [Fact]
+    public void RenderFencedMarkdown_RaisesPropertyChanged_OnlyWhenItChanges()
+    {
+        var vm = new AgentOutputViewModel();
+
+        var names = Changed(vm, () => vm.RenderFencedMarkdown = false);
+        Assert.Contains(nameof(AgentOutputViewModel.RenderFencedMarkdown), names);
+
+        var again = Changed(vm, () => vm.RenderFencedMarkdown = false);
+        Assert.DoesNotContain(nameof(AgentOutputViewModel.RenderFencedMarkdown), again);
+    }
 }

--- a/tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs
@@ -15,8 +15,6 @@ namespace NovaTerminal.Tests.AgentOutput;
 /// </summary>
 public sealed class FenceBodyTests
 {
-    private static readonly Border Anchor = new();
-
     [Theory]
     [InlineData("markdown")]
     [InlineData("md")]
@@ -60,6 +58,10 @@ public sealed class FenceBodyTests
     [InlineData("diff --git a/x b/x", "Secondary")]
     [InlineData("index 1234567..89abcde 100644", "Secondary")]
     [InlineData(" context line", "Foreground")]
+    [InlineData("+++counter;", "NtGreen")]
+    [InlineData("---x;", "NtRed")]
+    [InlineData("+++", "Secondary")]
+    [InlineData("---", "Secondary")]
     public void DiffHandler_ColorsLinesByMarker(string line, string expectedRole)
     {
         var theme = MarkdownThemeProbe.WithDistinctBrushes();

--- a/tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Avalonia.Controls;
+using Avalonia.Controls.Documents;
+using Avalonia.Media;
+using NovaTerminal.AgentOutput;
+using NovaTerminal.AgentOutput.Fences;
+using Xunit;
+
+namespace NovaTerminal.Tests.AgentOutput;
+
+/// <summary>
+/// The fence-body seam: which info strings resolve, and what each handler makes of a body.
+/// </summary>
+public sealed class FenceBodyTests
+{
+    private static readonly Border Anchor = new();
+
+    [Theory]
+    [InlineData("markdown")]
+    [InlineData("md")]
+    [InlineData("MARKDOWN")]
+    [InlineData("Md")]
+    [InlineData("markdown title=\"README\"")]
+    [InlineData("  markdown  ")]
+    public void MarkdownAliases_Resolve(string info)
+        => Assert.NotNull(FenceBodyResolver.Resolve(info));
+
+    [Theory]
+    [InlineData("diff")]
+    [InlineData("patch")]
+    [InlineData("DIFF")]
+    public void DiffAliases_Resolve(string info)
+        => Assert.NotNull(FenceBodyResolver.Resolve(info));
+
+    [Theory]
+    [InlineData("csharp")]
+    [InlineData("bash")]
+    [InlineData("json")]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void UnrecognizedInfo_DoesNotResolve(string? info)
+        => Assert.Null(FenceBodyResolver.Resolve(info));
+
+    [Fact]
+    public void DiffHandler_IsNotATransform()
+    {
+        IFenceBody body = Assert.IsType<DiffFenceBody>(FenceBodyResolver.Resolve("diff"));
+        Assert.False(body.IsTransform);
+    }
+
+    [Theory]
+    [InlineData("+added line", "NtGreen")]
+    [InlineData("-removed line", "NtRed")]
+    [InlineData("@@ -1,2 +1,3 @@", "NtYellow")]
+    [InlineData("+++ b/file.cs", "Secondary")]
+    [InlineData("--- a/file.cs", "Secondary")]
+    [InlineData("diff --git a/x b/x", "Secondary")]
+    [InlineData("index 1234567..89abcde 100644", "Secondary")]
+    [InlineData(" context line", "Foreground")]
+    public void DiffHandler_ColorsLinesByMarker(string line, string expectedRole)
+    {
+        var theme = MarkdownThemeProbe.WithDistinctBrushes();
+        IFenceBody body = FenceBodyResolver.Resolve("diff")!;
+
+        Control control = body.Build(line, theme, Context(theme));
+
+        var text = Assert.IsType<SelectableTextBlock>(control);
+        Run run = text.Inlines!.OfType<Run>().Single();
+        Assert.Same(MarkdownThemeProbe.BrushFor(theme, expectedRole), run.Foreground);
+    }
+
+    [Fact]
+    public void DiffHandler_EmitsOneRunPerLine()
+    {
+        var theme = MarkdownThemeProbe.WithDistinctBrushes();
+        IFenceBody body = FenceBodyResolver.Resolve("diff")!;
+
+        Control control = body.Build("+one\n-two\n three", theme, Context(theme));
+
+        var text = Assert.IsType<SelectableTextBlock>(control);
+        Assert.Equal(3, text.Inlines!.OfType<Run>().Count());
+    }
+
+    private static FenceContext Context(MarkdownTheme theme)
+        => new(Depth: 0, RenderFencedMarkdown: true, RenderNested: (_, _) => new Border(), OnCopyText: null);
+}
+
+/// <summary>
+/// Builds a theme whose brushes are all distinct instances, so a test can assert which role a
+/// run was painted with by reference rather than by colour value.
+/// </summary>
+internal static class MarkdownThemeProbe
+{
+    private static readonly Dictionary<string, IBrush> Roles = new()
+    {
+        ["Foreground"] = new SolidColorBrush(Color.FromRgb(1, 1, 1)),
+        ["Secondary"] = new SolidColorBrush(Color.FromRgb(2, 2, 2)),
+        ["NtGreen"] = new SolidColorBrush(Color.FromRgb(3, 3, 3)),
+        ["NtRed"] = new SolidColorBrush(Color.FromRgb(4, 4, 4)),
+        ["NtYellow"] = new SolidColorBrush(Color.FromRgb(5, 5, 5)),
+    };
+
+    internal static IBrush BrushFor(MarkdownTheme theme, string role) => role switch
+    {
+        "Foreground" => theme.Foreground,
+        "Secondary" => theme.Secondary,
+        "NtGreen" => theme.Added,
+        "NtRed" => theme.Removed,
+        "NtYellow" => theme.Hunk,
+        _ => throw new ArgumentOutOfRangeException(nameof(role), role, "unknown role"),
+    };
+
+    internal static MarkdownTheme WithDistinctBrushes() => new()
+    {
+        Foreground = Roles["Foreground"],
+        Secondary = Roles["Secondary"],
+        CodeBackground = new SolidColorBrush(Color.FromRgb(6, 6, 6)),
+        PanelBackground = new SolidColorBrush(Color.FromRgb(7, 7, 7)),
+        Hairline = new SolidColorBrush(Color.FromRgb(8, 8, 8)),
+        Accent = new SolidColorBrush(Color.FromRgb(9, 9, 9)),
+        Added = Roles["NtGreen"],
+        Removed = Roles["NtRed"],
+        Hunk = Roles["NtYellow"],
+    };
+}

--- a/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
@@ -89,7 +89,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void Heading_BecomesBoldText_SizedByLevel()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("# Title\n\n### Sub", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("# Title\n\n### Sub", Anchor).Root;
 
         var headings = TextBlocks(root).ToList();
         Assert.Equal("Title", TextOf((TextBlock)root.Children[0]));
@@ -101,7 +101,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void Paragraph_WithBoldAndItalic_ProducesStyledRuns()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("plain **bold** and *slant* text", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("plain **bold** and *slant* text", Anchor).Root;
 
         var paragraph = (SelectableTextBlock)root.Children[0];
         var runs = paragraph.Inlines!.OfType<Span>().SelectMany(s => s.Inlines!.OfType<Run>()).ToList();
@@ -117,7 +117,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void FencedCodeBlock_RendersItsText_WithACopyButton()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("```csharp\nvar x = 1;\n```\n", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("```csharp\nvar x = 1;\n```\n", Anchor).Root;
 
         Control? copyButton = Descendants(root).FirstOrDefault(c => c is Button { Content: "Copy" });
         Assert.NotNull(copyButton);
@@ -129,7 +129,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void InlineCode_RendersAsAChip()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("run `npm test` now", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("run `npm test` now", Anchor).Root;
 
         var paragraph = (SelectableTextBlock)root.Children[0];
         bool hasChip = paragraph.Inlines!.OfType<InlineUIContainer>()
@@ -140,7 +140,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void Lists_RenderTheirItems_AndOrdering()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("1. first\n2. second\n\n- bullet\n", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("1. first\n2. second\n\n- bullet\n", Anchor).Root;
 
         var markers = TextBlocks(root)
             .Select(TextOf)
@@ -153,7 +153,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void TaskListItem_RendersACheckboxGlyph()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("- [x] done\n- [ ] pending\n", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("- [x] done\n- [ ] pending\n", Anchor).Root;
 
         string all = string.Concat(TextBlocks(root).Select(TextOf));
         Assert.Contains("\u2611", all, StringComparison.Ordinal);
@@ -163,7 +163,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void Table_RendersHeaderAndRows()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("| a | b |\n|---|---|\n| 1 | 2 |\n", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("| a | b |\n|---|---|\n| 1 | 2 |\n", Anchor).Root;
 
         Grid? grid = Descendants(root).OfType<Grid>()
             .FirstOrDefault(g => g.RowDefinitions.Count > 0);
@@ -180,7 +180,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void BlockQuote_RendersItsParagraphs()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("> quoted wisdom\n", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("> quoted wisdom\n", Anchor).Root;
 
         Assert.Contains("quoted wisdom", TextBlocks(root).Select(TextOf), StringComparer.Ordinal);
     }
@@ -188,7 +188,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void Link_RendersItsLabel_ForClicking()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("see [the docs](https://example.com) here", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("see [the docs](https://example.com) here", Anchor).Root;
 
         // The link renders as a TextBlock inside an InlineUIContainer of the paragraph, which
         // the Panel/Border walker does not cross - collect inline-hosted blocks explicitly.
@@ -208,7 +208,7 @@ public sealed class MarkdownRendererTests
         // DisableHtml keeps the tags from becoming structure. Whatever leaks through as literal
         // text is inert: the panel renders Avalonia text, never evaluates markup, so a stray
         // <script> in agent output is characters on screen and nothing else.
-        var root = (StackPanel)MarkdownRenderer.Build("before\n\n<script>alert(1)</script>\n\nafter", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("before\n\n<script>alert(1)</script>\n\nafter", Anchor).Root;
 
         string all = string.Concat(TextBlocks(root).Select(TextOf));
         Assert.Contains("before", all, StringComparison.Ordinal);
@@ -218,7 +218,7 @@ public sealed class MarkdownRendererTests
     [Fact]
     public void UnrecognizedFrontMatter_IsSkipped_WithoutCrashing()
     {
-        var root = (StackPanel)MarkdownRenderer.Build("---\ntitle: something\n---\n\nbody text", Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build("---\ntitle: something\n---\n\nbody text", Anchor).Root;
 
         string all = string.Concat(TextBlocks(root).Select(TextOf));
         Assert.Contains("body text", all, StringComparison.Ordinal);
@@ -229,7 +229,7 @@ public sealed class MarkdownRendererTests
     {
         // The grid reader hands the renderer already-joined logical lines; a very long paragraph
         // must flow through the text wrapper, not be re-broken by the renderer.
-        var root = (StackPanel)MarkdownRenderer.Build(new string('x', 500), Anchor);
+        var root = (StackPanel)MarkdownRenderer.Build(new string('x', 500), Anchor).Root;
 
         var paragraph = (SelectableTextBlock)root.Children[0];
         Assert.Equal(500, TextOf(paragraph).Length);
@@ -242,11 +242,20 @@ public sealed class MarkdownRendererTests
         var root = (StackPanel)MarkdownRenderer.Build(
             "```\nsome code\n```\n",
             Anchor,
-            onCopyText: text => copied = text);
+            onCopyText: text => copied = text).Root;
 
         var button = (Button)Descendants(root).First(c => c is Button);
         button.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
 
         Assert.Equal("some code", copied);
+    }
+
+    [Fact]
+    public void Build_ReportsNoTransformBlock_ForOrdinaryMarkdown()
+    {
+        MarkdownRenderResult result = MarkdownRenderer.Build("# Title\n\nbody\n", Anchor);
+
+        Assert.IsType<StackPanel>(result.Root);
+        Assert.False(result.HasTransformBlock);
     }
 }

--- a/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Controls.Documents;
 using Avalonia.Media;
@@ -323,5 +325,109 @@ public sealed class MarkdownRendererTests
         // subject. The surviving hash is what proves Copy yielded source rather than rendered text.
         Assert.NotNull(copied);
         Assert.Contains("# Nested Title", copied!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DiffFence_ThroughBuild_ColorsLines_AndIsNotATransform()
+    {
+        MarkdownRenderResult result = MarkdownRenderer.Build(
+            "```diff\n+added line\n-removed line\n```\n", Anchor);
+
+        var body = Descendants((StackPanel)result.Root).OfType<SelectableTextBlock>().Single();
+        var runs = body.Inlines!.OfType<Run>().ToList();
+
+        Assert.Equal(2, runs.Count);
+        Assert.NotEqual(runs[0].Foreground, runs[1].Foreground);
+
+        // A diff-only response colors its lines but hides nothing, so it must offer no switch.
+        Assert.False(result.HasTransformBlock);
+    }
+
+    [Fact]
+    public void MarkdownFence_LinkInside_ReachesTheLinkHandler()
+    {
+        string? opened = null;
+        MarkdownRenderResult result = MarkdownRenderer.Build(
+            "```markdown\n[x](https://example.com)\n```\n",
+            Anchor,
+            onOpenLink: url => opened = url);
+
+        TextBlock link = Descendants((StackPanel)result.Root)
+            .OfType<SelectableTextBlock>()
+            .SelectMany(t => t.Inlines!.OfType<InlineUIContainer>())
+            .Select(c => c.Child)
+            .OfType<TextBlock>()
+            .First(b => TextOf(b) == "x");
+
+        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        link.RaiseEvent(new PointerPressedEventArgs(
+            link,
+            pointer,
+            link,
+            new Point(0, 0),
+            0,
+            new PointerPointProperties(),
+            KeyModifiers.None,
+            1));
+
+        Assert.Equal("https://example.com", opened);
+    }
+
+    [Fact]
+    public void MarkdownFence_SwitchOff_CopyYieldsRawSource()
+    {
+        string? copied = null;
+        MarkdownRenderResult result = MarkdownRenderer.Build(
+            "```markdown\n# Heading\n```\n",
+            Anchor,
+            onCopyText: text => copied = text,
+            renderFencedMarkdown: false);
+
+        Button copy = Descendants((StackPanel)result.Root).OfType<Button>().First(b => b.Content as string == "Copy");
+        copy.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        Assert.NotNull(copied);
+        Assert.Contains("#", copied!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownFence_RawHtmlInside_StaysLiteral()
+    {
+        // Mirrors RawHtml_IsTreatedAsPlainText, one level deeper: the nested path runs a second
+        // Markdig.Parse, and DisableHtml must still be in effect there.
+        var root = (StackPanel)MarkdownRenderer.Build(
+            "```markdown\nbefore\n\n<script>alert(1)</script>\n\nafter\n```\n",
+            Anchor).Root;
+
+        string all = string.Concat(TextBlocks(root).Select(TextOf));
+        Assert.Contains("before", all, StringComparison.Ordinal);
+        Assert.Contains("after", all, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MarkdownFence_WhitespaceOnlyBody_RendersAsOrdinaryCodeBlock_WithNoSwitch()
+    {
+        MarkdownRenderResult result = MarkdownRenderer.Build("```markdown\n   \n```\n", Anchor);
+
+        Assert.False(result.HasTransformBlock);
+    }
+
+    [Fact]
+    public void MarkdownFence_SwitchOffSourceBody_MatchesTheUnhandledBody()
+    {
+        const string body = "# Heading\n";
+
+        var offRoot = (StackPanel)MarkdownRenderer.Build(
+            $"```markdown\n{body}```\n", Anchor, renderFencedMarkdown: false).Root;
+        var unrecognizedRoot = (StackPanel)MarkdownRenderer.Build(
+            $"```notalang\n{body}```\n", Anchor).Root;
+
+        var offBody = Descendants(offRoot).OfType<SelectableTextBlock>().Single();
+        var unrecognizedBody = Descendants(unrecognizedRoot).OfType<SelectableTextBlock>().Single();
+
+        Assert.Equal(unrecognizedBody.FontSize, offBody.FontSize);
+        Assert.Equal(unrecognizedBody.FontFamily, offBody.FontFamily);
+        Assert.Equal(unrecognizedBody.Foreground, offBody.Foreground);
+        Assert.Equal(unrecognizedBody.TextWrapping, offBody.TextWrapping);
     }
 }

--- a/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
@@ -258,4 +258,70 @@ public sealed class MarkdownRendererTests
         Assert.IsType<StackPanel>(result.Root);
         Assert.False(result.HasTransformBlock);
     }
+
+    [Fact]
+    public void MarkdownFence_RendersNestedBlocks_NotSource()
+    {
+        MarkdownRenderResult result = MarkdownRenderer.Build("```markdown\n# Nested Title\n```\n", Anchor);
+
+        // A rendered heading is a TextBlock with the heading's own size, not a monospace code run.
+        TextBlock? heading = TextBlocks((StackPanel)result.Root)
+            .FirstOrDefault(b => TextOf(b).Contains("Nested Title", StringComparison.Ordinal));
+        Assert.NotNull(heading);
+        Assert.True(heading!.FontSize > 12, "a rendered heading is larger than code text");
+        Assert.True(result.HasTransformBlock);
+    }
+
+    [Fact]
+    public void MarkdownFence_WithSwitchOff_RendersSource_ButStillReportsTransform()
+    {
+        MarkdownRenderResult result = MarkdownRenderer.Build(
+            "```markdown\n# Nested Title\n```\n",
+            Anchor,
+            renderFencedMarkdown: false);
+
+        TextBlock? source = TextBlocks((StackPanel)result.Root)
+            .FirstOrDefault(b => TextOf(b).Contains("# Nested Title", StringComparison.Ordinal));
+        Assert.NotNull(source);
+
+        // The switch must stay visible, or the choice is not reversible.
+        Assert.True(result.HasTransformBlock);
+    }
+
+    [Fact]
+    public void MarkdownFence_NestedInsideAnother_RendersTheInnerOneAsSource()
+    {
+        const string md = "````markdown\n# Outer\n\n```markdown\n# Inner\n```\n````\n";
+
+        MarkdownRenderResult result = MarkdownRenderer.Build(md, Anchor);
+
+        // Outer renders: its heading is a real heading.
+        TextBlock? outer = TextBlocks((StackPanel)result.Root)
+            .FirstOrDefault(b => TextOf(b).Contains("Outer", StringComparison.Ordinal));
+        Assert.NotNull(outer);
+        Assert.True(outer!.FontSize > 12);
+
+        // Inner does not: its hash survives as literal text at the depth cap.
+        TextBlock? inner = TextBlocks((StackPanel)result.Root)
+            .FirstOrDefault(b => TextOf(b).Contains("# Inner", StringComparison.Ordinal));
+        Assert.NotNull(inner);
+    }
+
+    [Fact]
+    public void MarkdownFence_KeepsCopyYieldingRawSource()
+    {
+        string? copied = null;
+        MarkdownRenderResult result = MarkdownRenderer.Build(
+            "```markdown\n# Nested Title\n```\n",
+            Anchor,
+            onCopyText: text => copied = text);
+
+        Button copy = Descendants((StackPanel)result.Root).OfType<Button>().First(b => b.Content as string == "Copy");
+        copy.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
+        // Contains, not Equal: whether GetLinesText keeps a trailing newline is not this test's
+        // subject. The surviving hash is what proves Copy yielded source rather than rendered text.
+        Assert.NotNull(copied);
+        Assert.Contains("# Nested Title", copied!, StringComparison.Ordinal);
+    }
 }


### PR DESCRIPTION
## What this changes

A fenced code block's info string (the `csharp` in ` ```csharp `) was captured and then used for exactly one thing — a text label. This makes it mean something: ` ```markdown ` / ` ```md ` renders as a nested document behind a panel switch, ` ```diff ` colours lines by leading marker, and **every other info string renders byte-identically to before**.

It came from a field report on #378: `claude -p "generate some markdown example"` wraps its whole answer in a ` ```markdown ` fence, so the panel showed a page of unrendered source. That rendering was *correct* — a fence means source — but it exposed that the panel had no way to tell "here is code" from "here is a document I wrote for you", a distinction agent CLIs make constantly.

**Stacked on #378, deliberately.** `main` has no `AgentOutput` subsystem yet, so this cannot branch from `main`; and #378 is five commits of review fixes deep and should land on its own rather than grow a sixth concern. Merge #378 first, then this rebases onto `main`.

Design: `docs/superpowers/specs/2026-09-03-fence-language-semantics-design.md`
Plan: `docs/superpowers/plans/2026-09-03-fence-language-semantics.md`

Fixes # n/a — follow-on work from #378

## Invariant and ownership

- **What invariant does this change affect?**

  Two. **"An unrecognized fence renders exactly as it did before"** — the resolver returning `null` must lead to the pre-existing flat-`Run` body, byte for byte. And **"Copy always yields the raw source"** — which this branch strengthens from a convention into a structural guarantee: `BuildCodeBlock` builds the Copy handler over the raw `code` *before* any handler is invoked, and never hands the button to a handler, so no present or future handler can break it.

  Also relevant, since agent output is untrusted text: recursion is bounded at one nested parse, enforced at the seam (`Math.Max(nestedDepth, depth + 1)`) rather than trusted to the handler; raw-HTML suppression holds on the new nested path because `BuildNested` reuses the same `DisableHtml()` pipeline; and the link scheme allowlist is not weakened by nesting, because one delegate is threaded by reference and every URL still funnels through `IsSafeExternalUrl`.

- **Which module owns that invariant?**

  `NovaTerminal.App` — `AgentOutput/` only. No layering change: the new `AgentOutput/Fences/` types are in the same assembly, and `NovaTerminal.Architecture.Tests` is green (56/56).

## Tests

- **What tests cover this change?**

  `tests/NovaTerminal.App.Tests/AgentOutput/`:
  - `FenceBodyTests.cs` (new, 29) — info-string resolution and aliases (`markdown`, `md`, `MARKDOWN`, `markdown title="README"`), that `csharp`/`bash`/`json`/empty resolve to nothing, diff marker precedence including that `+++ b/file.cs` is a header while `+++counter;` is an addition, and one `Run` per line.
  - `MarkdownRendererTests.cs` (extended) — a fence renders nested blocks not source; with the switch off it renders source *and still reports a transform* (so the switch cannot hide itself on first use); the depth cap renders an inner fence as source; Copy yields raw source in **both** switch positions; a diff fence leaves `HasTransformBlock` false so no switch appears; a link inside a rendered fence reaches the link handler; raw HTML inside a rendered fence stays literal at depth 1; a whitespace-only fence offers no switch; the switch-off body matches the unhandled body's `FontSize`/`FontFamily`/`Foreground`/`TextWrapping`.
  - `AgentOutputPanelTests.cs` (extended, `[AvaloniaFact]`) — the switch is hidden with no fence and shown with one; a choice made survives a *subsequent* content update (the test that justifies the switch being panel-level rather than per-block); `SetViewModel` syncs the toggle.
  - `AgentOutputViewModelTests.cs` (extended) — default true, and `PropertyChanged` only on real change.

  Pre-existing expectations are unchanged. The only edit to existing tests is mechanical: `.Root` appended at 13 `MarkdownRenderer.Build` call sites, because `Build` now returns `MarkdownRenderResult` instead of a bare `Control` (CS0050 forces that type public, since `Build` is public).

- **Which categories did you run locally?**

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  On the final tree: **App.Tests 1612 passed, 13 skipped, 0 failed** (AgentOutput + Controls + TerminalPane + CommandAssist), **VT 412/412**, **Architecture 56/56**. Not run: Replay, RenderMetrics, PtySmoke, Stress, GoldenSharedPng — this touches neither the renderer's frame path nor the PTY, and each has its own CI job.

## Impact

- **Does this affect cross-platform behavior?**

  No platform-specific code. Tested on Windows only. The one platform-adjacent detail is that `GetLinesText` builds with `AppendLine`, so `code` carries CRLF on Windows; `DiffFenceBody` normalises to LF for *display* while Copy still yields the original — which is what keeps Copy raw.

- **Does this change renderer metrics?**

  No. This is the Agent Output panel's Avalonia control tree, not the terminal grid renderer — no frame-time, cache or invalidation path is touched. Worst-case work is bounded: at most two parses of a document already hard-capped upstream at 400 logical lines / 128 KB / 2048 rows by `AgentOutputRegionTracker`, so the diff handler's one-`Run`-per-line is ~400 runs at worst. One incidental improvement: a redundant double re-render per toggle click was removed.

- **Does this change VT coverage?**

  No. No VT sequences added or changed; nothing reads or writes the grid. `docs/vt_coverage_matrix.md` and the conformance report are untouched.

## Accepted limitations

Documented in the spec rather than left to be rediscovered:

- The switch is **all-or-nothing per response**, and does not persist across panes or restarts — deliberately runtime state, not a `TerminalSettings` field (which would also need threading through `ApplySettings`'s whitelist and the MCP `SettingsTools` drift guard).
- A markdown fence nested inside another renders as source, by design.
- The depth cap gates **every** handler, so a ` ```diff ` inside a rendered ` ```markdown ` fence loses its colouring. Guarding at the lookup is safer than letting a handler opt out of the bound.
- `IsFileHeader` requires a trailing space, which fixes `+++counter;` but still mis-colours a removed line whose own text begins with `-- ` (deleting a SQL comment `-- note` yields `--- note`). Distinguishing those needs positional context — headers only after `diff --git`/`index `, or as a `---`/`+++` pair — which is out of scope here.

## Review notes

Every commit was reviewed individually before the next was written, plus a whole-branch review at the end. Three things a reviewer might reasonably challenge, with the reasoning already on the record:

1. **`IsTransform` stays `true` even when the switch is off.** Deliberate: it is what keeps the switch on screen. A flag-derived `IsTransform` would hide the switch the instant you used it — a one-way door.
2. **The switch is panel-level, not per-block.** The panel rebuilds its whole control tree on every `MarkdownText` change (every few hundred ms while streaming), so per-block state would be wiped each tick, and keying it by block ordinal would reattach a choice to the wrong block when a block arrives earlier in the stream.
3. **A whitespace-only body resolves no handler at all.** That is what makes an empty fence render as it always has instead of producing an empty bordered box with a switch over nothing — reachable on every streaming tick where a fence opener arrives before its body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
