### PR TITLE
fix(tests): run the AgentOutput suites on the headless session thread

### DIFF
--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputPanelTests.cs
@@ -2,6 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Avalonia.Controls;
+using Avalonia.Media;
+using Avalonia.Input;
+using Avalonia;
 using Avalonia.Controls.Documents;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
@@ -174,6 +177,86 @@ public sealed class AgentOutputPanelTests
                 .OfType<Control>()
                 .SelectMany(TextOf),
             StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// A link inside a rendered markdown fence reaches the link handler.
+    /// </summary>
+    /// <remarks>
+    /// <b>This lives here, not in <c>MarkdownRendererTests</c>, and the placement is the point.</b>
+    /// That class is plain <c>[Fact]</c> on purpose - it builds control trees without a headless
+    /// application. Synthesizing pointer input there touches Avalonia's input and ambient visual
+    /// state from a thread that owns none of it, which corrupts state shared with the
+    /// <c>[AvaloniaFact]</c> suites: unrelated classes then fail with "The calling thread cannot
+    /// access this object because a different thread owns it", non-deterministically, depending on
+    /// ordering. That is what turned main red after #397, and what
+    /// <c>AvaloniaBootLocatorHygieneTests.TheAmbientMediaContextBelongsToTheSessionDispatchThread</c>
+    /// exists to catch. Raising the event needs a session thread, so the test needs this class.
+    /// </remarks>
+    [AvaloniaFact]
+    public void MarkdownFence_LinkInside_ReachesTheLinkHandler()
+    {
+        var anchor = new Border();
+        string? opened = null;
+        MarkdownRenderResult result = MarkdownRenderer.Build(
+            "```markdown\n[x](https://example.com)\n```\n",
+            anchor,
+            onOpenLink: url => opened = url);
+
+        TextBlock link = Descendants(result.Root)
+            .OfType<SelectableTextBlock>()
+            .SelectMany(t => t.Inlines!.OfType<InlineUIContainer>())
+            .Select(c => c.Child)
+            .OfType<TextBlock>()
+            .First(b => b.Text == "x");
+
+        // Disposed, so the pressed pointer does not outlive the test and leak capture into the
+        // pointer-driven suites (the tab strip's drag-reorder tests) that share this session.
+        using var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
+        link.RaiseEvent(new PointerPressedEventArgs(
+            link,
+            pointer,
+            link,
+            new Point(0, 0),
+            0,
+            new PointerPointProperties(),
+            KeyModifiers.None,
+            1));
+
+        Assert.Equal("https://example.com", opened);
+    }
+
+    private static IEnumerable<Control> Descendants(Control control)
+    {
+        if (control is Panel panel)
+        {
+            foreach (Control child in panel.Children)
+            {
+                yield return child;
+                foreach (Control nested in Descendants(child))
+                {
+                    yield return nested;
+                }
+            }
+        }
+
+        if (control is Border { Child: Control inner })
+        {
+            yield return inner;
+            foreach (Control nested in Descendants(inner))
+            {
+                yield return nested;
+            }
+        }
+
+        if (control is ContentControl { Content: Control content })
+        {
+            yield return content;
+            foreach (Control nested in Descendants(content))
+            {
+                yield return nested;
+            }
+        }
     }
 
     private static IEnumerable<string> TextOf(Control control)

--- a/tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/FenceBodyTests.cs
@@ -6,6 +6,7 @@ using Avalonia.Controls.Documents;
 using Avalonia.Media;
 using NovaTerminal.AgentOutput;
 using NovaTerminal.AgentOutput.Fences;
+using Avalonia.Headless.XUnit;
 using Xunit;
 
 namespace NovaTerminal.Tests.AgentOutput;
@@ -13,9 +14,16 @@ namespace NovaTerminal.Tests.AgentOutput;
 /// <summary>
 /// The fence-body seam: which info strings resolve, and what each handler makes of a body.
 /// </summary>
+/// <remarks>
+/// <b><see cref="AvaloniaFactAttribute"/>, not <c>[Fact]</c>, on purpose.</b> The handlers build
+/// real Avalonia visuals, and Avalonia's ambient state has thread affinity to the headless
+/// session's dispatch thread. Building visuals from a plain <c>[Fact]</c> corrupts that state for
+/// every <c>[AvaloniaFact]</c> suite in the process - see the remarks on
+/// <c>MarkdownRendererTests</c> for the failure this caused on main.
+/// </remarks>
 public sealed class FenceBodyTests
 {
-    [Theory]
+    [AvaloniaTheory]
     [InlineData("markdown")]
     [InlineData("md")]
     [InlineData("MARKDOWN")]
@@ -25,14 +33,14 @@ public sealed class FenceBodyTests
     public void MarkdownAliases_Resolve(string info)
         => Assert.NotNull(FenceBodyResolver.Resolve(info));
 
-    [Theory]
+    [AvaloniaTheory]
     [InlineData("diff")]
     [InlineData("patch")]
     [InlineData("DIFF")]
     public void DiffAliases_Resolve(string info)
         => Assert.NotNull(FenceBodyResolver.Resolve(info));
 
-    [Theory]
+    [AvaloniaTheory]
     [InlineData("csharp")]
     [InlineData("bash")]
     [InlineData("json")]
@@ -42,14 +50,14 @@ public sealed class FenceBodyTests
     public void UnrecognizedInfo_DoesNotResolve(string? info)
         => Assert.Null(FenceBodyResolver.Resolve(info));
 
-    [Fact]
+    [AvaloniaFact]
     public void DiffHandler_IsNotATransform()
     {
         IFenceBody body = Assert.IsType<DiffFenceBody>(FenceBodyResolver.Resolve("diff"));
         Assert.False(body.IsTransform);
     }
 
-    [Theory]
+    [AvaloniaTheory]
     [InlineData("+added line", "NtGreen")]
     [InlineData("-removed line", "NtRed")]
     [InlineData("@@ -1,2 +1,3 @@", "NtYellow")]
@@ -74,7 +82,7 @@ public sealed class FenceBodyTests
         Assert.Same(MarkdownThemeProbe.BrushFor(theme, expectedRole), run.Foreground);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void DiffHandler_EmitsOneRunPerLine()
     {
         var theme = MarkdownThemeProbe.WithDistinctBrushes();

--- a/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/MarkdownRendererTests.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Avalonia;
 using Avalonia.Controls;
-using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Controls.Documents;
 using Avalonia.Media;
 using NovaTerminal.AgentOutput;
+using Avalonia.Headless.XUnit;
 using Xunit;
 
 namespace NovaTerminal.Tests.AgentOutput;
@@ -18,9 +17,22 @@ namespace NovaTerminal.Tests.AgentOutput;
 /// content, unknown blocks never crash the walk).
 /// </summary>
 /// <remarks>
-/// Plain control-tree construction, no layout or styling - so the tests run without a headless
-/// application. Colors resolve from a bare anchor with no theme resources, which exercises the
-/// fixed-fallback path: the same degradation an unthemed surface gets.
+/// Control-tree construction only - no layout, no styling. Colors resolve from a bare anchor with
+/// no theme resources, which exercises the fixed-fallback path: the same degradation an unthemed
+/// surface gets.
+///
+/// <para>
+/// <b><see cref="AvaloniaFactAttribute"/>, not <c>[Fact]</c>, and the distinction is load-bearing.</b>
+/// These tests build real Avalonia visuals, and Avalonia's ambient state - the media context most
+/// of all - has thread affinity to the headless session's dispatch thread. Constructing visuals
+/// from a plain <c>[Fact]</c> touches that state from a thread that owns none of it and corrupts it
+/// for every <c>[AvaloniaFact]</c> suite sharing the process, which then fails with "The calling
+/// thread cannot access this object because a different thread owns it" - non-deterministically,
+/// in unrelated classes, depending on test order. That is what turned main red after #397: the
+/// tab strip's pointer-driven tests died in a run whose only change was more tests here.
+/// <c>AvaloniaBootLocatorHygieneTests.TheAmbientMediaContextBelongsToTheSessionDispatchThread</c>
+/// is the guard for it. The session costs these tests a few seconds; do not trade it back.
+/// </para>
 /// </remarks>
 public sealed class MarkdownRendererTests
 {
@@ -88,7 +100,7 @@ public sealed class MarkdownRendererTests
         return builder.ToString();
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Heading_BecomesBoldText_SizedByLevel()
     {
         var root = (StackPanel)MarkdownRenderer.Build("# Title\n\n### Sub", Anchor).Root;
@@ -100,7 +112,7 @@ public sealed class MarkdownRendererTests
         Assert.Equal("Sub", TextOf(headings[1]));
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Paragraph_WithBoldAndItalic_ProducesStyledRuns()
     {
         var root = (StackPanel)MarkdownRenderer.Build("plain **bold** and *slant* text", Anchor).Root;
@@ -116,7 +128,7 @@ public sealed class MarkdownRendererTests
         Assert.Equal(FontStyle.Italic, ((Span)runs[1].Parent!).FontStyle);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void FencedCodeBlock_RendersItsText_WithACopyButton()
     {
         var root = (StackPanel)MarkdownRenderer.Build("```csharp\nvar x = 1;\n```\n", Anchor).Root;
@@ -128,7 +140,7 @@ public sealed class MarkdownRendererTests
         Assert.NotNull(code);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void InlineCode_RendersAsAChip()
     {
         var root = (StackPanel)MarkdownRenderer.Build("run `npm test` now", Anchor).Root;
@@ -139,7 +151,7 @@ public sealed class MarkdownRendererTests
         Assert.True(hasChip);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Lists_RenderTheirItems_AndOrdering()
     {
         var root = (StackPanel)MarkdownRenderer.Build("1. first\n2. second\n\n- bullet\n", Anchor).Root;
@@ -152,7 +164,7 @@ public sealed class MarkdownRendererTests
         Assert.Equal(new[] { "1.", "2.", "•" }, markers);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void TaskListItem_RendersACheckboxGlyph()
     {
         var root = (StackPanel)MarkdownRenderer.Build("- [x] done\n- [ ] pending\n", Anchor).Root;
@@ -162,7 +174,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("\u2610", all, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Table_RendersHeaderAndRows()
     {
         var root = (StackPanel)MarkdownRenderer.Build("| a | b |\n|---|---|\n| 1 | 2 |\n", Anchor).Root;
@@ -179,7 +191,7 @@ public sealed class MarkdownRendererTests
         Assert.DoesNotContain("---", all, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void BlockQuote_RendersItsParagraphs()
     {
         var root = (StackPanel)MarkdownRenderer.Build("> quoted wisdom\n", Anchor).Root;
@@ -187,7 +199,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("quoted wisdom", TextBlocks(root).Select(TextOf), StringComparer.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Link_RendersItsLabel_ForClicking()
     {
         var root = (StackPanel)MarkdownRenderer.Build("see [the docs](https://example.com) here", Anchor).Root;
@@ -204,7 +216,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("the docs", inlineBlocks);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void RawHtml_IsTreatedAsPlainText()
     {
         // DisableHtml keeps the tags from becoming structure. Whatever leaks through as literal
@@ -217,7 +229,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("after", all, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void UnrecognizedFrontMatter_IsSkipped_WithoutCrashing()
     {
         var root = (StackPanel)MarkdownRenderer.Build("---\ntitle: something\n---\n\nbody text", Anchor).Root;
@@ -226,7 +238,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("body text", all, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void SoftWrapDamage_InTheSource_IsJustText()
     {
         // The grid reader hands the renderer already-joined logical lines; a very long paragraph
@@ -237,7 +249,7 @@ public sealed class MarkdownRendererTests
         Assert.Equal(500, TextOf(paragraph).Length);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void CopyButton_ForwardsTheCodeText()
     {
         string? copied = null;
@@ -252,7 +264,7 @@ public sealed class MarkdownRendererTests
         Assert.Equal("some code", copied);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void Build_ReportsNoTransformBlock_ForOrdinaryMarkdown()
     {
         MarkdownRenderResult result = MarkdownRenderer.Build("# Title\n\nbody\n", Anchor);
@@ -261,7 +273,7 @@ public sealed class MarkdownRendererTests
         Assert.False(result.HasTransformBlock);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_RendersNestedBlocks_NotSource()
     {
         MarkdownRenderResult result = MarkdownRenderer.Build("```markdown\n# Nested Title\n```\n", Anchor);
@@ -274,7 +286,7 @@ public sealed class MarkdownRendererTests
         Assert.True(result.HasTransformBlock);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_WithSwitchOff_RendersSource_ButStillReportsTransform()
     {
         MarkdownRenderResult result = MarkdownRenderer.Build(
@@ -290,7 +302,7 @@ public sealed class MarkdownRendererTests
         Assert.True(result.HasTransformBlock);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_NestedInsideAnother_RendersTheInnerOneAsSource()
     {
         const string md = "````markdown\n# Outer\n\n```markdown\n# Inner\n```\n````\n";
@@ -309,7 +321,7 @@ public sealed class MarkdownRendererTests
         Assert.NotNull(inner);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_KeepsCopyYieldingRawSource()
     {
         string? copied = null;
@@ -327,7 +339,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("# Nested Title", copied!, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void DiffFence_ThroughBuild_ColorsLines_AndIsNotATransform()
     {
         MarkdownRenderResult result = MarkdownRenderer.Build(
@@ -343,37 +355,7 @@ public sealed class MarkdownRendererTests
         Assert.False(result.HasTransformBlock);
     }
 
-    [Fact]
-    public void MarkdownFence_LinkInside_ReachesTheLinkHandler()
-    {
-        string? opened = null;
-        MarkdownRenderResult result = MarkdownRenderer.Build(
-            "```markdown\n[x](https://example.com)\n```\n",
-            Anchor,
-            onOpenLink: url => opened = url);
-
-        TextBlock link = Descendants((StackPanel)result.Root)
-            .OfType<SelectableTextBlock>()
-            .SelectMany(t => t.Inlines!.OfType<InlineUIContainer>())
-            .Select(c => c.Child)
-            .OfType<TextBlock>()
-            .First(b => TextOf(b) == "x");
-
-        var pointer = new Pointer(Pointer.GetNextFreeId(), PointerType.Mouse, isPrimary: true);
-        link.RaiseEvent(new PointerPressedEventArgs(
-            link,
-            pointer,
-            link,
-            new Point(0, 0),
-            0,
-            new PointerPointProperties(),
-            KeyModifiers.None,
-            1));
-
-        Assert.Equal("https://example.com", opened);
-    }
-
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_SwitchOff_CopyYieldsRawSource()
     {
         string? copied = null;
@@ -390,7 +372,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("#", copied!, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_RawHtmlInside_StaysLiteral()
     {
         // Mirrors RawHtml_IsTreatedAsPlainText, one level deeper: the nested path runs a second
@@ -404,7 +386,7 @@ public sealed class MarkdownRendererTests
         Assert.Contains("after", all, StringComparison.Ordinal);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_WhitespaceOnlyBody_RendersAsOrdinaryCodeBlock_WithNoSwitch()
     {
         MarkdownRenderResult result = MarkdownRenderer.Build("```markdown\n   \n```\n", Anchor);
@@ -412,7 +394,7 @@ public sealed class MarkdownRendererTests
         Assert.False(result.HasTransformBlock);
     }
 
-    [Fact]
+    [AvaloniaFact]
     public void MarkdownFence_SwitchOffSourceBody_MatchesTheUnhandledBody()
     {
         const string body = "# Heading\n";


### PR DESCRIPTION
## What this changes

Unbreaks `main`. Merging #397 turned `Unit Tests (ubuntu-latest)` red — twice — with `System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it`, thrown inside `Avalonia.Headless.XUnit.AvaloniaTestRunner.Run`, in the **tab strip's** tests. #397 never touched those. Reverting #397 on a branch (#398) made ubuntu green again, so the trigger was ours.

**Cause.** `MarkdownRendererTests` and `FenceBodyTests` are plain `[Fact]` classes that build real Avalonia visuals. Avalonia's ambient state — the media context above all — has thread affinity to the headless session's dispatch thread. Building visuals from a plain `[Fact]` touches state that thread does not own and corrupts it for every `[AvaloniaFact]` suite in the process, which then fails non-deterministically, in unrelated classes, in whatever order the run took. That is why the failing set differed between runs: `TabRunningCommandTests` plus a few strip tests first, then all 18 of `VerticalTabStripTests`.

This was **latent before #397** — `MarkdownRendererTests` arrived as a plain `[Fact]` class in #378 — and #397 added enough off-session work to tip it over.

`AvaloniaBootLocatorHygieneTests.TheAmbientMediaContextBelongsToTheSessionDispatchThread` is the guard for exactly this, and it fails locally on the merged tree.

Fixes the ubuntu failure on `e371f06`.

## Invariant and ownership

- **What invariant does this change affect?**

  "Avalonia ambient state belongs to the headless session's dispatch thread." Test-only; no product code changes.

- **Which module owns that invariant?**

  `tests/NovaTerminal.App.Tests` — the headless harness, and the hygiene guard added in #395.

## Tests

- **What tests cover this change?**

  The change *is* to tests. Coverage of the invariant already exists: `AvaloniaBootLocatorHygieneTests.TheAmbientMediaContextBelongsToTheSessionDispatchThread`.

- **Which categories did you run locally?**

  - [ ] full unfiltered run (`scripts/build.sh test`)
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` (non-blocking in CI — check it yourself)
  - [ ] full local CI rehearsal (`ci/run.sh` / `ci/run.ps1`)

  A full unfiltered `App.Tests` run **cannot complete on Windows locally** — it aborts the host on the real-PTY window tests (#81), which is why the lane runs `continue-on-error` in CI. So this was verified on the interaction that actually reproduces the failure:

  | Run | Result |
  |---|---|
  | `VerticalTabStrip` + `TabRunningCommand` + hygiene guard, alone | **33/33 pass**, clean exit |
  | …plus `AgentOutput`, with only the pointer test moved | **crash** in `DragReorder_Commit_HorizontalStrip_ReordersAlongX_AndRestoresSelection` |
  | …plus `AgentOutput`, with both parts of this fix | **169/169 pass**, clean exit |

  The middle row is what shows the pointer-test move alone was necessary but not sufficient; the first row is what isolates the contamination to the AgentOutput suite rather than to the tab strip.

## Impact

- **Does this affect cross-platform behavior?**

  The failure was ubuntu-only in CI (Windows CI passed both times), but the defect is not platform-specific — thread affinity is thread affinity, and ubuntu's scheduling merely exposed it. Verified on Windows locally.

- **Does this change renderer metrics?**

  No. Test-only.

- **Does this change VT coverage?**

  No.

## The trade this accepts

Moving 29 tests onto the headless session costs them a session: that filtered subset goes from ~4s to ~20s. That is the correct price — the alternative is off-thread visual construction that corrupts unrelated suites — and the class remarks now say so, so nobody trades it back for speed. The comment claiming these tests "run without a headless application" was itself a statement of the violated invariant, and is replaced with the reason the session is required.

## Alternative on the table

#398 reverts #397 off `main` and is verified green on ubuntu. If this PR does not go green on ubuntu, that is the fallback — unbreak `main` first, fix afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
