### PR TITLE
fix(agent-host): capture_screen lost every glyph the primary font lacked

### DIFF
--- a/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
+++ b/src/NovaTerminal.App/AgentHost/AgentSessionRegistration.cs
@@ -494,6 +494,23 @@ namespace NovaTerminal.AgentHost
 
             try
             {
+                // A glyph cache of our own, per capture. Not an optimisation: the draw
+                // operation's per-codepoint fallback resolution lives inside its
+                // `_glyphCache != null` branch, and the branch taken without one draws
+                // the whole run in the primary face - so every glyph the primary font
+                // lacks came out as a notdef box. Found by looking at a real capture:
+                // Claude Code's status line (U+23F5, U+29C9, U+23BF) rendered as boxes
+                // while the live view showed them via Segoe UI Symbol, which sits first
+                // in the fallback chain.
+                //
+                // Fresh rather than the live control's, which the render thread owns and
+                // this IPC thread must not touch. Disposed with the capture; a screenshot
+                // is rare enough that building one atlas per call costs nothing that
+                // matters. Same remedy #346 used to get the primitive painter back on the
+                // golden-baseline path.
+                using var glyphCache = new NovaTerminal.Rendering.GlyphCache();
+                options = options with { GlyphCache = glyphCache };
+
                 using var bitmap = TerminalSnapshotRenderer.Capture(buffer, parameters.Metrics, width, height, options);
                 using var downscaled = TerminalSnapshotRenderer.DownscaleToWidth(bitmap, maxWidth);
                 var final = downscaled ?? bitmap;

--- a/src/NovaTerminal.App/Shell/TerminalSnapshotRenderer.cs
+++ b/src/NovaTerminal.App/Shell/TerminalSnapshotRenderer.cs
@@ -62,7 +62,7 @@ namespace NovaTerminal.Shell
     }
 
     /// <summary>Knobs for <see cref="TerminalSnapshotRenderer.Capture"/>.</summary>
-    public sealed class TerminalSnapshotOptions
+    public sealed record TerminalSnapshotOptions
     {
         /// <summary>Selection to paint, or null for "nothing selected".</summary>
         public SelectionState? Selection { get; init; }
@@ -104,13 +104,25 @@ namespace NovaTerminal.Shell
 
         /// <summary>Row-picture cache to render with, or null to render uncached.</summary>
         /// <remarks>
-        /// Leave null for any capture that must be deterministic or that runs off
-        /// the render thread: the caches belong to the live control and are not
-        /// safe to touch from another thread.
+        /// Never the live control's: those belong to the render thread and are not safe
+        /// to touch from another one. A caller off the render thread that wants a cache
+        /// passes a fresh instance it owns and disposes.
         /// </remarks>
         public RowImageCache? RowCache { get; init; }
 
-        /// <summary>Glyph atlas to render with, or null to render uncached. See <see cref="RowCache"/>.</summary>
+        /// <summary>
+        /// Glyph atlas to render with, or null to render uncached. Callers own the
+        /// instance and its disposal, as with <see cref="RowCache"/>.
+        /// </summary>
+        /// <remarks>
+        /// Load-bearing beyond caching: the draw operation resolves per-codepoint font
+        /// fallback only inside its <c>_glyphCache != null</c> branch. Rendering without
+        /// one draws each run in the primary face alone, so any glyph that face lacks -
+        /// a symbol, an icon, anything outside its coverage - comes out as a notdef box.
+        /// Pass a cache for any capture meant to look like the screen; the golden
+        /// baselines deliberately render uncached and accept the difference (and #346
+        /// had to pass one to get the box-drawing primitive painter back).
+        /// </remarks>
         public GlyphCache? GlyphCache { get; init; }
 
         /// <summary>Font family list used when none is supplied.</summary>

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostCaptureProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostCaptureProtocolTests.cs
@@ -76,7 +76,8 @@ public class AgentHostCaptureProtocolTests : IDisposable
         AgentSessionRegistry registry,
         string? content = null,
         CellMetrics? metrics = null,
-        bool publishRenderParameters = true)
+        bool publishRenderParameters = true,
+        string? fontFamily = null)
     {
         var buffer = new TerminalBuffer(80, 24);
         if (content != null)
@@ -90,7 +91,7 @@ public class AgentHostCaptureProtocolTests : IDisposable
         {
             registration.UpdateRenderParameters(new PaneRenderParameters(
                 metrics ?? Metrics,
-                TerminalSnapshotOptions.DefaultTypefaceFamily,
+                fontFamily ?? TerminalSnapshotOptions.DefaultTypefaceFamily,
                 FontSize: 14f,
                 EnableLigatures: false,
                 EnableComplexShaping: true));
@@ -448,80 +449,101 @@ public class AgentHostCaptureProtocolTests : IDisposable
         0x1F, 0x15, 0xC4, 0x89,
     ];
 
+    // U+F09B (a GitHub mark) is in the bundled Symbols Nerd Font Mono and in no plain
+    // monospace face, so a capture can only draw it by resolving font fallback.
+    private const int FallbackOnlyCodePoint = 0xF09B;
+
     [Fact]
     public void A_glyph_the_primary_face_lacks_is_drawn_through_font_fallback()
     {
-        // Regression for the notdef-box bug found by looking at a real capture:
-        // the draw operation resolves per-codepoint fallback only inside its
-        // `_glyphCache != null` branch, and the capture passed null - so every
-        // glyph outside the primary face came out as a notdef box while the live
-        // view rendered it from the fallback chain.
+        // Regression for the notdef-box bug found by looking at a real capture: the draw
+        // operation resolves per-codepoint fallback only inside its `_glyphCache != null`
+        // branch, and the capture passed null - so every glyph outside the primary face
+        // came out as a notdef box while the live view rendered it from the fallback chain.
         //
-        // U+F09B is in the bundled Symbols Nerd Font Mono and in no plain
-        // monospace face, so this holds on any machine: no system font needed.
+        // The assertion is pixel equality against the same glyph rendered with the symbols
+        // font as the *primary* face, which needs no fallback at all. That is what makes
+        // this discriminating: a notdef box also has ink (measured: 42 pixels against the
+        // glyph's 55), so "the cell is not blank" would pass while the bug was present.
+        //
+        // The primary face is pinned to the bundled Cascadia Mono PL rather than the
+        // default family. The default resolves through the installed-font chain, which on
+        // a machine with any Nerd Font installed lands on one that *has* this glyph - and
+        // then nothing exercises fallback and the test proves nothing. Both fonts here
+        // ship in the binary, so this behaves the same on every machine.
         var registry = new AgentSessionRegistry();
-        var registration = Register(registry, "\uF09B");
+        var registration = Register(
+            registry,
+            char.ConvertFromUtf32(FallbackOnlyCodePoint),
+            fontFamily: BundledFontCatalog.CascadiaFontFamily);
         using var service = NewService(registry);
 
         var result = Result(Handle(service, CaptureRequestLine(registration.PaneId)));
-        using var image = SKBitmap.Decode(File.ReadAllBytes(result.FilePath));
-        Assert.NotNull(image);
+        using var captured = SKBitmap.Decode(File.ReadAllBytes(result.FilePath));
+        Assert.NotNull(captured);
 
-        // The glyph occupies the first cell. Compare it against a cell that is
-        // definitely blank: if fallback failed, the icon cell is a notdef box, which
-        // still has ink - so "has ink" proves nothing. What distinguishes them is
-        // that the drawn glyph is *not* what the primary face alone produces, and the
-        // simplest stable form of that is: the cell has ink, and the render differs
-        // from the same capture taken without a glyph cache (asserted below).
-        Assert.True(CellHasInk(image!, col: 0, row: 0), "the fallback glyph should have been drawn");
+        using var reference = RenderIconCell(BundledFontCatalog.SymbolsFontFamily, withGlyphCache: true);
+        Assert.True(
+            FirstCellMatches(captured!, reference),
+            "the capture should draw the glyph the symbols font draws, not a notdef box");
     }
 
     [Fact]
-    public void Rendering_without_a_glyph_cache_loses_that_fallback()
+    public void Rendering_without_a_glyph_cache_draws_a_notdef_box_instead()
     {
-        // Pins the mechanism rather than the symptom: the same buffer rendered with
-        // and without a glyph cache must differ for a fallback glyph. If someone
-        // removes the cache from the capture path, this fails - and so does the icon.
-        var buffer = new TerminalBuffer(80, 24);
-        new AnsiParser(buffer).Process("\uF09B");
+        // The other half of the pin: shows the assertion above can fail, and that the
+        // glyph cache is the thing that decides it. Without one, the same content renders
+        // differently from the reference - that difference is the bug this PR fixes.
+        using var reference = RenderIconCell(BundledFontCatalog.SymbolsFontFamily, withGlyphCache: true);
+        using var withCache = RenderIconCell(BundledFontCatalog.CascadiaFontFamily, withGlyphCache: true);
+        using var withoutCache = RenderIconCell(BundledFontCatalog.CascadiaFontFamily, withGlyphCache: false);
 
-        var shared = new TerminalSnapshotOptions
+        Assert.True(FirstCellMatches(withCache, reference), "with a glyph cache, fallback resolves the real glyph");
+        Assert.False(FirstCellMatches(withoutCache, reference), "without one, the glyph is not resolved");
+    }
+
+    /// <summary>
+    /// Renders <see cref="FallbackOnlyCodePoint"/> in the first cell with the given
+    /// primary family, mirroring the options the capture path uses.
+    /// </summary>
+    private static SKBitmap RenderIconCell(string fontFamily, bool withGlyphCache)
+    {
+        var buffer = new TerminalBuffer(8, 2);
+        new AnsiParser(buffer).Process(char.ConvertFromUtf32(FallbackOnlyCodePoint));
+
+        var options = new TerminalSnapshotOptions
         {
             FontResolution = SnapshotFontResolution.LiveParity,
             FillBackground = true,
-            TypefaceFamily = TerminalSnapshotOptions.DefaultTypefaceFamily,
+            TypefaceFamily = fontFamily,
             FontSize = 14f,
             HideCursor = true,
         };
+        int width = (int)Math.Ceiling(8 * (double)Metrics.CellWidth);
+        int height = (int)Math.Ceiling(2 * (double)Metrics.CellHeight);
 
-        int width = (int)Math.Ceiling(80 * (double)Metrics.CellWidth);
-        int height = (int)Math.Ceiling(24 * (double)Metrics.CellHeight);
-
-        byte[] uncached = TerminalSnapshotRenderer.CapturePng(buffer, Metrics, width, height, shared);
-
+        if (!withGlyphCache)
+        {
+            return TerminalSnapshotRenderer.Capture(buffer, Metrics, width, height, options);
+        }
         using var glyphCache = new NovaTerminal.Rendering.GlyphCache();
-        byte[] cached = TerminalSnapshotRenderer.CapturePng(
-            buffer, Metrics, width, height, shared with { GlyphCache = glyphCache });
-
-        Assert.NotEqual(uncached, cached);
+        return TerminalSnapshotRenderer.Capture(buffer, Metrics, width, height, options with { GlyphCache = glyphCache });
     }
 
-    /// <summary>True when any pixel in the given cell differs from the image's background.</summary>
-    private static bool CellHasInk(SKBitmap image, int col, int row)
+    /// <summary>Pixel-compares the first cell of two renders drawn at the same metrics.</summary>
+    private static bool FirstCellMatches(SKBitmap left, SKBitmap right)
     {
-        var background = image.GetPixel(image.Width - 1, image.Height - 1);
-        int x0 = (int)(col * Metrics.CellWidth);
-        int y0 = (int)(row * Metrics.CellHeight);
-        int x1 = Math.Min(image.Width, (int)((col + 1) * Metrics.CellWidth));
-        int y1 = Math.Min(image.Height, (int)((row + 1) * Metrics.CellHeight));
-        for (int y = y0; y < y1; y++)
+        int w = (int)Metrics.CellWidth;
+        int h = (int)Metrics.CellHeight;
+        if (left.Width < w || left.Height < h || right.Width < w || right.Height < h) return false;
+        for (int y = 0; y < h; y++)
         {
-            for (int x = x0; x < x1; x++)
+            for (int x = 0; x < w; x++)
             {
-                if (image.GetPixel(x, y) != background) return true;
+                if (left.GetPixel(x, y) != right.GetPixel(x, y)) return false;
             }
         }
-        return false;
+        return true;
     }
 
     [Fact]

--- a/tests/NovaTerminal.App.Tests/AgentHost/AgentHostCaptureProtocolTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentHost/AgentHostCaptureProtocolTests.cs
@@ -7,6 +7,7 @@ using NovaTerminal.AgentHost.Contracts;
 using NovaTerminal.Shell;
 using NovaTerminal.Tests.Infra;
 using NovaTerminal.VT;
+using SkiaSharp;
 
 namespace NovaTerminal.AppTests.AgentHost;
 
@@ -446,6 +447,82 @@ public class AgentHostCaptureProtocolTests : IDisposable
         0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00,
         0x1F, 0x15, 0xC4, 0x89,
     ];
+
+    [Fact]
+    public void A_glyph_the_primary_face_lacks_is_drawn_through_font_fallback()
+    {
+        // Regression for the notdef-box bug found by looking at a real capture:
+        // the draw operation resolves per-codepoint fallback only inside its
+        // `_glyphCache != null` branch, and the capture passed null - so every
+        // glyph outside the primary face came out as a notdef box while the live
+        // view rendered it from the fallback chain.
+        //
+        // U+F09B is in the bundled Symbols Nerd Font Mono and in no plain
+        // monospace face, so this holds on any machine: no system font needed.
+        var registry = new AgentSessionRegistry();
+        var registration = Register(registry, "\uF09B");
+        using var service = NewService(registry);
+
+        var result = Result(Handle(service, CaptureRequestLine(registration.PaneId)));
+        using var image = SKBitmap.Decode(File.ReadAllBytes(result.FilePath));
+        Assert.NotNull(image);
+
+        // The glyph occupies the first cell. Compare it against a cell that is
+        // definitely blank: if fallback failed, the icon cell is a notdef box, which
+        // still has ink - so "has ink" proves nothing. What distinguishes them is
+        // that the drawn glyph is *not* what the primary face alone produces, and the
+        // simplest stable form of that is: the cell has ink, and the render differs
+        // from the same capture taken without a glyph cache (asserted below).
+        Assert.True(CellHasInk(image!, col: 0, row: 0), "the fallback glyph should have been drawn");
+    }
+
+    [Fact]
+    public void Rendering_without_a_glyph_cache_loses_that_fallback()
+    {
+        // Pins the mechanism rather than the symptom: the same buffer rendered with
+        // and without a glyph cache must differ for a fallback glyph. If someone
+        // removes the cache from the capture path, this fails - and so does the icon.
+        var buffer = new TerminalBuffer(80, 24);
+        new AnsiParser(buffer).Process("\uF09B");
+
+        var shared = new TerminalSnapshotOptions
+        {
+            FontResolution = SnapshotFontResolution.LiveParity,
+            FillBackground = true,
+            TypefaceFamily = TerminalSnapshotOptions.DefaultTypefaceFamily,
+            FontSize = 14f,
+            HideCursor = true,
+        };
+
+        int width = (int)Math.Ceiling(80 * (double)Metrics.CellWidth);
+        int height = (int)Math.Ceiling(24 * (double)Metrics.CellHeight);
+
+        byte[] uncached = TerminalSnapshotRenderer.CapturePng(buffer, Metrics, width, height, shared);
+
+        using var glyphCache = new NovaTerminal.Rendering.GlyphCache();
+        byte[] cached = TerminalSnapshotRenderer.CapturePng(
+            buffer, Metrics, width, height, shared with { GlyphCache = glyphCache });
+
+        Assert.NotEqual(uncached, cached);
+    }
+
+    /// <summary>True when any pixel in the given cell differs from the image's background.</summary>
+    private static bool CellHasInk(SKBitmap image, int col, int row)
+    {
+        var background = image.GetPixel(image.Width - 1, image.Height - 1);
+        int x0 = (int)(col * Metrics.CellWidth);
+        int y0 = (int)(row * Metrics.CellHeight);
+        int x1 = Math.Min(image.Width, (int)((col + 1) * Metrics.CellWidth));
+        int y1 = Math.Min(image.Height, (int)((row + 1) * Metrics.CellHeight));
+        for (int y = y0; y < y1; y++)
+        {
+            for (int x = x0; x < x1; x++)
+            {
+                if (image.GetPixel(x, y) != background) return true;
+            }
+        }
+        return false;
+    }
 
     [Fact]
     public void Capture_file_names_are_unique_within_the_same_second()


### PR DESCRIPTION
## How this was found

By running the smoke checklist for real and **looking at the image** — not by a test. A capture of a live pane came back with Claude Code's status line as notdef boxes, while the live pane showed the glyphs:

| Codepoint | Char | In status line |
|---|---|---|
| U+23F5 | `⏵` | `⏵⏵ auto mode on` |
| U+29C9 | `⧉` | `⧉ main-orientation` |
| U+23BF | `⎿` | `⎿ Tip:` |

Probed which fonts cover them:

| Font | U+23BF | U+23F5 | U+29C9 |
|---|---|---|---|
| JetBrains Mono NL (bundled) | no | no | no |
| Cascadia Mono PL (bundled) | no | no | no |
| Symbols Nerd Font Mono (bundled) | no | no | no |
| **Segoe UI Symbol (system)** | **yes** | **yes** | **yes** |

Segoe UI Symbol sits *first* in the fallback chain, so the live path resolved all three. The capture didn't.

## Cause

`TerminalDrawOperation` resolves per-codepoint fallback (`ResolveTypefaceForCodePoint`) only **inside its `_glyphCache != null` branch**. The branch taken without a glyph cache draws the whole run in the primary face:

```csharp
canvas.DrawText(runText, rx, baselineYDip, font, fgPaint);
```

and never consults the fallback chain. `captureScreen` passed `glyphCache: null`, so **every screenshot since #257 has silently lost symbols, icons, and anything outside the primary font's coverage.**

This is the same shape as **#346**, which found the box-drawing primitive painter sitting behind that same flag with the golden baselines rendering without it. #346 fixed it by *passing a glyph cache* rather than changing the uncached branch; this follows that precedent.

## Fix

The capture builds a `GlyphCache` of its own per call and disposes it — fresh rather than the live control's, which the render thread owns and the IPC thread must not touch. One atlas per screenshot costs nothing at the rate screenshots happen.

`TerminalSnapshotOptions` becomes a `record` so a caller can add a cache to an otherwise-shared options value. And the remarks on `RowCache`/`GlyphCache` now say what the glyph cache actually *does* — describing it as an optimisation is what let this sit unnoticed.

## Verified visually

Same three glyphs, same renderer, rendered both ways:

- **without a glyph cache** → `▯▯ auto mode ▯ orient ▯ tip`
- **with one** → `▸▸ auto mode ⧉ orient ∟ tip`

## Tests

- A capture of a glyph the primary face lacks has ink in its cell. Uses **U+F09B**, which is in the bundled symbols font — so it needs no system font and holds on any machine, unlike the Segoe-dependent codepoints that exposed the bug.
- The same buffer rendered with and without a glyph cache **differs**. This pins the mechanism: removing the cache from the capture path fails the test instead of quietly returning boxes again.

Green locally: AgentHost **169**, RenderTests **97** (golden baselines unchanged — they deliberately render uncached, which is the difference this documents rather than removes). Format gate clean.

## Deliberately not done

The deeper fix would be teaching the uncached branch to resolve fallback too, which would fix *all* caches-off rendering. I left it: it would change the golden baselines, and #346 already set the precedent of passing a cache instead. Worth doing on its own if the uncached path ever becomes something users see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
