### PR TITLE
fix(vt): return the cursor to column 0 after an inline image

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -1702,6 +1702,33 @@ namespace NovaTerminal.VT
             return false;
         }
 
+        /// <summary>
+        /// Ends an inline image placement with the cursor at column 0 of the row below the picture.
+        /// </summary>
+        /// <remarks>
+        /// Every image protocol reserves its cells the same way - write <c>width</c> spaces, newline,
+        /// repeat - and each one used to stop after the last row's spaces, leaving the cursor at
+        /// <c>CellX + width</c> on the image's own final row. Whatever the program wrote next started
+        /// from there: an indent beside a narrow image, and beside a wide one an overrun past the last
+        /// column that wrapped the text mid-word (#405).
+        ///
+        /// The newline is what puts the cursor on a fresh line. <see cref="_swallowNextNewline"/> then
+        /// absorbs the newline the emitting program almost always sends after its image, so the picture
+        /// is not followed by a blank line - wanting that is why the last row's newline was skipped in
+        /// the first place, but skipping it moved the text sideways instead of keeping it close.
+        /// Emitting our own and swallowing theirs gives both: no blank line, and text that resumes at
+        /// the left margin.
+        /// </remarks>
+        private void FinishImagePlacement()
+        {
+            // CR then LF, not LF alone: line feed only returns to column 0 when LNM is set, and it
+            // is off by default, so a bare '\n' would drop a row and keep the column - the very
+            // thing this exists to prevent.
+            _buffer.WriteChar('\r');
+            _buffer.WriteChar('\n');
+            _swallowNextNewline = true;
+        }
+
         private void HandleSixel(string dcs)
         {
             try
@@ -1741,6 +1768,8 @@ namespace NovaTerminal.VT
                                 for (int x = 0; x < img.CellX; x++) _buffer.WriteContent(" ", false);
                             }
                         }
+
+                        FinishImagePlacement();
                     }
                     finally
                     {
@@ -2668,6 +2697,8 @@ namespace NovaTerminal.VT
                                 for (int i = 0; i < img.CellX; i++) _buffer.WriteContent(" ", false);
                             }
                         }
+
+                        FinishImagePlacement();
                     }
                     finally
                     {
@@ -2827,6 +2858,9 @@ namespace NovaTerminal.VT
                     }
 
 
+                    // Before the delta below is measured, so the row this adds is counted in it.
+                    FinishImagePlacement();
+
                     // Accumulate vertical offset for ConPTY sync
                     // Use actual visual cursor delta instead of image height to account for scrolling/clamping
                     int endRow = _buffer.CursorRow;
@@ -2835,9 +2869,6 @@ namespace NovaTerminal.VT
                     // This maps PTY (Start) -> Visual (End).
                     _verticalOffset += delta;
 
-
-                    // Set flag to swallow the next newline if it comes immediately
-                    _swallowNextNewline = true;
                 }
                 finally
                 {

--- a/tests/NovaTerminal.VT.Tests/InlineImageCursorTests.cs
+++ b/tests/NovaTerminal.VT.Tests/InlineImageCursorTests.cs
@@ -1,0 +1,163 @@
+using System;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+// Regression tests for #405: after an inline image is placed, the cursor must be at column 0 of
+// the row below the picture, so whatever the program writes next — in practice the shell's next
+// prompt — starts at the left margin.
+//
+// All three image protocols reserved the image's cells by writing spaces row by row and
+// deliberately omitted the newline on the last row, leaving the cursor at `CellX + width` on the
+// image's own final row. The next prompt therefore resumed part-way across that row: an indent for
+// a narrow image, and for a wide one an overrun past the last column that wrapped the prompt
+// mid-word. iTerm2 made it worse by also setting the swallow-next-newline flag, eating the very
+// newline the shell sent to get itself onto a fresh line.
+public class InlineImageCursorTests
+{
+    private const int Cols = 40;
+    private const int Rows = 20;
+
+    // 30x40 pixels against the parser's default 10x20 cell = 3 cells wide, 2 tall. Small enough to
+    // sit well inside the buffer, and not square, so a width/height mix-up cannot pass by accident.
+    private const int PixelWidth = 30;
+    private const int PixelHeight = 40;
+
+    [Fact]
+    public void Sixel_leaves_the_cursor_at_column_zero_below_the_image()
+    {
+        (TerminalBuffer buffer, AnsiParser parser) = NewTerminal();
+
+        parser.Process("\x1bPq#0;2;0;0;0#0~~~\x1b\\");
+
+        AssertCursorBelowImageAtColumnZero(buffer, "sixel");
+    }
+
+    [Fact]
+    public void Iterm2_image_leaves_the_cursor_at_column_zero_below_the_image()
+    {
+        (TerminalBuffer buffer, AnsiParser parser) = NewTerminal();
+
+        parser.Process($"\x1b]1337;File=inline=1:{FakePayload()}\x07");
+
+        AssertCursorBelowImageAtColumnZero(buffer, "iterm2");
+    }
+
+    [Fact]
+    public void Kitty_image_leaves_the_cursor_at_column_zero_below_the_image()
+    {
+        // forceConPtyFiltering: false, so this exercises the placement path on every platform. A
+        // parser that believes ConPTY is filtering drops non-tunneled Kitty sequences before they
+        // reach placement at all, which on Windows would leave this test silently asserting nothing.
+        (TerminalBuffer buffer, AnsiParser parser) = NewTerminal(forceConPtyFiltering: false);
+
+        parser.Process($"\x1b_Ga=T,f=100;{FakePayload()}\x1b\\");
+
+        AssertCursorBelowImageAtColumnZero(buffer, "kitty");
+    }
+
+    // The behaviour the cursor position exists to produce, stated the way a user meets it: the text
+    // written after an image starts at the left margin rather than beside the picture. Sixel is the
+    // case that reaches WriteChar directly; the two OSC/APC protocols additionally set the
+    // swallow-next-newline flag, so they are covered separately below.
+    [Fact]
+    public void Text_after_a_sixel_image_starts_at_the_left_margin()
+    {
+        (TerminalBuffer buffer, AnsiParser parser) = NewTerminal();
+
+        parser.Process("\x1bPq#0;2;0;0;0#0~~~\x1b\\");
+        parser.Process("after");
+
+        Assert.Equal("a", GraphemeAt(buffer, col: 0, viewRow: CursorViewRow(buffer)));
+    }
+
+    // A program that emits an image normally follows it with its own newline. That newline is
+    // swallowed (the flag exists for exactly this) so the image is not followed by a blank line —
+    // and with the cursor already parked at column 0 of the next row, the following text still
+    // lands at the left margin rather than a row further down.
+    [Fact]
+    public void A_trailing_newline_after_an_iterm2_image_does_not_add_a_blank_line()
+    {
+        (TerminalBuffer buffer, AnsiParser parser) = NewTerminal();
+
+        parser.Process($"\x1b]1337;File=inline=1:{FakePayload()}\x07");
+        int rowAfterImage = CursorViewRow(buffer);
+
+        parser.Process("\r\n");
+
+        Assert.Equal(rowAfterImage, CursorViewRow(buffer));
+        Assert.Equal(0, buffer.CursorCol);
+    }
+
+    private static (TerminalBuffer, AnsiParser) NewTerminal(bool? forceConPtyFiltering = null)
+    {
+        var buffer = new TerminalBuffer(Cols, Rows);
+        var parser = new AnsiParser(buffer, forceConPtyFiltering) { ImageDecoder = new StubImageDecoder() };
+        return (buffer, parser);
+    }
+
+    /// <summary>
+    /// Any non-empty base64 body. <see cref="StubImageDecoder"/> ignores the bytes and reports a
+    /// fixed size, so the payload only has to survive <c>Convert.FromBase64String</c>.
+    /// </summary>
+    private static string FakePayload() => Convert.ToBase64String(new byte[] { 1, 2, 3, 4 });
+
+    private static int CursorViewRow(TerminalBuffer buffer)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            return buffer.CursorRow;
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    private static string GraphemeAt(TerminalBuffer buffer, int col, int viewRow)
+    {
+        buffer.Lock.EnterReadLock();
+        try
+        {
+            return buffer.GetGrapheme(col, viewRow);
+        }
+        finally
+        {
+            buffer.Lock.ExitReadLock();
+        }
+    }
+
+    private static void AssertCursorBelowImageAtColumnZero(TerminalBuffer buffer, string protocol)
+    {
+        TerminalImage image = Assert.Single(buffer.Images);
+
+        Assert.Equal(0, buffer.CursorCol);
+
+        // Compared in absolute buffer rows, the same coordinate space AnsiParser stamps onto
+        // TerminalImage.CellY, so this stays correct if the placement ever scrolls the viewport.
+        int absoluteCursorRow = CursorViewRow(buffer) + (buffer.TotalLines - buffer.Rows);
+        Assert.True(
+            absoluteCursorRow == image.CellY + image.CellHeight,
+            $"{protocol}: expected the cursor on absolute row {image.CellY + image.CellHeight} " +
+            $"(immediately below a {image.CellHeight}-row image starting at row {image.CellY}), " +
+            $"but it is on row {absoluteCursorRow} at column {buffer.CursorCol}.");
+    }
+
+    private sealed class StubImageDecoder : IImageDecoder
+    {
+        public object? DecodeImageBytes(byte[] imageData, out int pixelWidth, out int pixelHeight)
+        {
+            pixelWidth = PixelWidth;
+            pixelHeight = PixelHeight;
+            return new object();
+        }
+
+        public object? DecodeSixel(string sixelData, out int pixelWidth, out int pixelHeight)
+        {
+            pixelWidth = PixelWidth;
+            pixelHeight = PixelHeight;
+            return new object();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #405.

## The bug

All three image protocols reserve the picture's cells the same way — write `width` spaces, newline, repeat — and each one stopped after the last row's spaces *without* a final newline. That left the cursor at `CellX + width` on the image's own final row, so whatever the program wrote next started from there.

| Protocol | Where the next prompt landed |
|---|---|
| Sixel | column 8 — a visible indent |
| iTerm2 | column 74 of a 116-column pane, overrunning the right edge and wrapping `(feat/sixel-decoder)` mid-word |
| Kitty | identical code path, same defect |

iTerm2 compounded it by also setting `_swallowNextNewline`, eating the very newline the shell sent to get itself onto a fresh line.

## The fix

One shared `FinishImagePlacement()` closes all three placements.

Two details worth reviewing:

- **CR then LF, not LF alone.** `HandleControlCode` only returns to column 0 on LF when `LNM` is set, and it is off by default. A bare `\n` would drop a row and keep the column — the same bug, one row down. This cost me a test cycle; the first version of the fix changed nothing.
- **The swallow flag stays.** The emitting program almost always sends its own newline after an image; absorbing it is why the last row's newline was skipped originally. Emitting ours and swallowing theirs gives both — no blank line, and text at the left margin.

For iTerm2 the helper runs *before* the visual delta is measured, so the row it adds is counted into `_verticalOffset` and the PTY-to-visual row mapping stays correct.

## Tests

`tests/NovaTerminal.VT.Tests/InlineImageCursorTests.cs` — five tests, all failing before this change:

- cursor at column 0 on the row below the image, per protocol, compared in absolute buffer rows so it survives a placement that scrolls
- text written after an image starts at the left margin
- a trailing newline after an image does not add a blank line

The Kitty test passes `forceConPtyFiltering: false`. A parser that believes ConPTY is filtering drops non-tunneled Kitty sequences before placement, so on Windows that test would otherwise assert nothing.

- `test tests/NovaTerminal.VT.Tests` — 436 passed
- `test tests/NovaTerminal.App.Tests --filter "Image|Sixel|Kitty|ITerm"` — 95 passed

## End-to-end

Verified against the two real screenshot scenarios on `feat/shots-harness`, which are blocked on this and carry their own column-zero assertion. Both failed at columns 8 and 74 before; both pass now, and the captured images show the prompt at column 0 directly below the picture with no wrap and no blank line. That unblocks re-registering `sixel-graphics` and `iterm2-inline-image`, which is two lines in `ScenarioCatalog` once this lands.

## Noticed, not changed

`HandleITerm2Image` saves and restores `_buffer.IsHidden` but never sets it to `true`, unlike the sixel and Kitty paths. Its reservation spaces are therefore written with whatever SGR attributes are live. Harmless for plain spaces, visible if underline or inverse is active. Left alone as out of scope — happy to split it out if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)