### PR TITLE
fix(ssh): honour NOVATERM_APPDATA_ROOT when resolving SSH paths

### DIFF
--- a/src/NovaTerminal.Platform/PlatformAppPaths.cs
+++ b/src/NovaTerminal.Platform/PlatformAppPaths.cs
@@ -1,0 +1,58 @@
+namespace NovaTerminal.Platform;
+
+/// <summary>
+/// Where <c>NovaTerminal.Platform</c> keeps its on-disk state, honouring the
+/// <c>NOVATERM_APPDATA_ROOT</c> override.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>AppPaths</c> in <c>NovaTerminal.App</c> is the authority on this for the application, but
+/// <c>Platform</c> does not reference <c>App</c> (the dependency runs the other way), so code down
+/// here cannot call it. Two places resolved the root themselves instead and neither consulted the
+/// override: <c>JsonSshProfileStore</c> and <c>OpenSshConfigCompiler</c>. Both therefore read and
+/// wrote the machine's real <c>%LOCALAPPDATA%\NovaTerminal\ssh</c> even when the whole process had
+/// been redirected somewhere else — so a test, a portable install, or a capture harness got a
+/// correctly sandboxed <c>settings.json</c>, logs and sessions, and then reached straight past the
+/// sandbox for SSH data (#406).
+/// </para>
+/// <para>
+/// This mirrors what <c>AgentHostDiscovery</c> already does in <c>NovaTerminal.AgentHost.Contracts</c>
+/// for the same reason and in the same layer-independent way: read the variable directly rather than
+/// depend upwards. The variable name is repeated across the three assemblies deliberately — sharing
+/// it would mean a project reference in the direction the architecture forbids — so if it ever
+/// changes, all three move together.
+/// </para>
+/// </remarks>
+public static class PlatformAppPaths
+{
+    private const string AppName = "NovaTerminal";
+    private const string RootOverrideEnvVar = "NOVATERM_APPDATA_ROOT";
+
+    /// <summary>
+    /// The application data root: <c>NOVATERM_APPDATA_ROOT</c> when set, otherwise
+    /// <c>%LOCALAPPDATA%\NovaTerminal</c> (and the platform equivalent elsewhere).
+    /// </summary>
+    /// <remarks>
+    /// The override is used verbatim as the root, with no <c>NovaTerminal</c> segment appended —
+    /// matching <c>AppPaths.RootDirectory</c> and <c>AgentHostDiscovery.GetDefaultDirectory</c>, so
+    /// a single override value points every assembly at the same tree.
+    /// </remarks>
+    public static string RootDirectory
+    {
+        get
+        {
+            string? overrideRoot = Environment.GetEnvironmentVariable(RootOverrideEnvVar);
+            if (!string.IsNullOrWhiteSpace(overrideRoot))
+            {
+                return Path.GetFullPath(overrideRoot);
+            }
+
+            return Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                AppName);
+        }
+    }
+
+    /// <summary>The directory holding SSH profiles, generated OpenSSH config, and known-hosts.</summary>
+    public static string SshDirectory => Path.Combine(RootDirectory, "ssh");
+}

--- a/src/NovaTerminal.Platform/Ssh/OpenSsh/OpenSshConfigCompiler.cs
+++ b/src/NovaTerminal.Platform/Ssh/OpenSsh/OpenSshConfigCompiler.cs
@@ -304,11 +304,13 @@ public sealed class OpenSshConfigCompiler : IOpenSshConfigCompiler
         return $"nova_{profileId:N}";
     }
 
-    private static string GetDefaultSshRootDirectory()
-    {
-        string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(appData, "NovaTerminal", "ssh");
-    }
+    /// <remarks>
+    /// Resolved through <see cref="PlatformAppPaths"/> for the same reason as
+    /// <c>JsonSshProfileStore.GetDefaultStorePath</c>: reading LocalApplicationData directly ignored
+    /// NOVATERM_APPDATA_ROOT, so a redirected process still wrote generated OpenSSH config into the
+    /// machine's real ssh directory (#406).
+    /// </remarks>
+    private static string GetDefaultSshRootDirectory() => PlatformAppPaths.SshDirectory;
 
     private static SshProfile CloneProfile(SshProfile profile)
     {

--- a/src/NovaTerminal.Platform/Ssh/Storage/JsonSshProfileStore.cs
+++ b/src/NovaTerminal.Platform/Ssh/Storage/JsonSshProfileStore.cs
@@ -25,11 +25,13 @@ public sealed class JsonSshProfileStore : ISshProfileStore
 
     public string StoreFilePath => _storeFilePath;
 
+    /// <remarks>
+    /// Resolved through <see cref="PlatformAppPaths"/> so that redirecting NOVATERM_APPDATA_ROOT
+    /// moves SSH profiles with everything else. Reading LocalApplicationData directly here is what
+    /// let a redirected process write the machine's real profile file (#406).
+    /// </remarks>
     public static string GetDefaultStorePath()
-    {
-        string appData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-        return Path.Combine(appData, "NovaTerminal", "ssh", "profiles.json");
-    }
+        => Path.Combine(PlatformAppPaths.SshDirectory, "profiles.json");
 
     public IReadOnlyList<SshProfile> GetProfiles()
     {

--- a/tests/NovaTerminal.Platform.Tests/Ssh/SshPathSandboxCollection.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/SshPathSandboxCollection.cs
@@ -1,0 +1,10 @@
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+/// <summary>
+/// Serializes the tests that mutate <c>NOVATERM_APPDATA_ROOT</c>. The variable is process-wide, so
+/// two of them running at once would each see the other's value.
+/// </summary>
+[CollectionDefinition(nameof(SshPathSandboxCollection), DisableParallelization = true)]
+public sealed class SshPathSandboxCollection
+{
+}

--- a/tests/NovaTerminal.Platform.Tests/Ssh/SshPathSandboxTests.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/SshPathSandboxTests.cs
@@ -1,0 +1,129 @@
+using NovaTerminal.Platform;
+using NovaTerminal.Platform.Ssh.Storage;
+
+namespace NovaTerminal.Platform.Tests.Ssh;
+
+/// <summary>
+/// Regression tests for #406: everything <c>NovaTerminal.Platform</c> writes under the app-data
+/// root must move when <c>NOVATERM_APPDATA_ROOT</c> moves.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>JsonSshProfileStore</c> and <c>OpenSshConfigCompiler</c> each resolved
+/// <c>%LOCALAPPDATA%\NovaTerminal\ssh</c> themselves and neither consulted the override, so a
+/// redirected process — a test, a portable install, the screenshot harness — got a correctly
+/// sandboxed settings file, log directory and session store, and then reached straight past the
+/// sandbox for SSH data. It was found because a capture run wrote a fictional profile into a real
+/// machine's profiles.json.
+/// </para>
+/// <para>
+/// Serialized: these mutate a process-wide environment variable, so they cannot run beside anything
+/// that reads it.
+/// </para>
+/// </remarks>
+[Collection(nameof(SshPathSandboxCollection))]
+public sealed class SshPathSandboxTests
+{
+    private const string RootOverrideEnvVar = "NOVATERM_APPDATA_ROOT";
+
+    [Fact]
+    public void Profile_store_default_path_follows_the_appdata_root_override()
+    {
+        using var root = new TemporaryRoot();
+
+        string path = JsonSshProfileStore.GetDefaultStorePath();
+
+        Assert.StartsWith(root.Path, path, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(Path.Combine(root.Path, "ssh", "profiles.json"), path);
+    }
+
+    [Fact]
+    public void Ssh_directory_follows_the_appdata_root_override()
+    {
+        using var root = new TemporaryRoot();
+
+        Assert.Equal(Path.Combine(root.Path, "ssh"), PlatformAppPaths.SshDirectory);
+    }
+
+    /// <summary>
+    /// The property the whole issue reduces to, asserted directly rather than only through the two
+    /// call sites: no path handed out while the override is set may sit under the real per-machine
+    /// app-data directory.
+    /// </summary>
+    [Fact]
+    public void No_platform_ssh_path_escapes_to_the_real_appdata_directory()
+    {
+        string real = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "NovaTerminal");
+
+        using var root = new TemporaryRoot();
+
+        foreach (string path in new[]
+                 {
+                     PlatformAppPaths.RootDirectory,
+                     PlatformAppPaths.SshDirectory,
+                     JsonSshProfileStore.GetDefaultStorePath(),
+                 })
+        {
+            Assert.False(
+                path.StartsWith(real, StringComparison.OrdinalIgnoreCase),
+                $"'{path}' is inside the machine's real app-data directory '{real}' even though " +
+                $"{RootOverrideEnvVar} redirects it to '{root.Path}'.");
+        }
+    }
+
+    [Fact]
+    public void Without_the_override_the_default_root_is_the_real_appdata_directory()
+    {
+        string? saved = Environment.GetEnvironmentVariable(RootOverrideEnvVar);
+        Environment.SetEnvironmentVariable(RootOverrideEnvVar, null);
+        try
+        {
+            string expected = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "NovaTerminal");
+
+            Assert.Equal(expected, PlatformAppPaths.RootDirectory);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(RootOverrideEnvVar, saved);
+        }
+    }
+
+    /// <summary>
+    /// Points <c>NOVATERM_APPDATA_ROOT</c> at a fresh directory and restores whatever was there
+    /// before, so a developer's or CI's own override survives the test.
+    /// </summary>
+    private sealed class TemporaryRoot : IDisposable
+    {
+        private readonly string? _saved;
+
+        public TemporaryRoot()
+        {
+            _saved = Environment.GetEnvironmentVariable(RootOverrideEnvVar);
+            Path = System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "nova-ssh-sandbox-tests",
+                Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(Path);
+            Environment.SetEnvironmentVariable(RootOverrideEnvVar, Path);
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(RootOverrideEnvVar, _saved);
+            try
+            {
+                Directory.Delete(Path, recursive: true);
+            }
+            catch (IOException)
+            {
+                // A leftover temp directory is not worth failing a passing test over.
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #406.

## The bug

Two places in `NovaTerminal.Platform` built `%LOCALAPPDATA%\NovaTerminal\ssh` themselves, and neither consulted the override:

| Location | Writes |
|---|---|
| `JsonSshProfileStore.GetDefaultStorePath` | `ssh/profiles.json` |
| `OpenSshConfigCompiler.GetDefaultSshRootDirectory` | generated OpenSSH config |

The issue only named the first; the second turned up next to it and is the same defect, so both are fixed here.

A process redirected with `NOVATERM_APPDATA_ROOT` got a correctly sandboxed `settings.json`, log directory and session store — and then reached straight past the sandbox for SSH data, reading and writing the machine's real profile file. All five `JsonSshProfileStore` construction sites take the default path, so nothing had to opt in to be affected.

Found because a screenshot capture run, inside what was supposed to be a fully isolated demo world, wrote a fictional `edge-01.demo.internal` profile into a real machine's `profiles.json`. Anything else relying on the override for isolation — tests included — had the same exposure.

## The fix

`AppPaths` in `NovaTerminal.App` is the authority for the application, but `Platform` does not reference `App` (the dependency runs the other way), so code down there cannot call it. New `PlatformAppPaths` in `Platform` reads the variable directly, the way `AgentHostDiscovery` already does in `AgentHost.Contracts` for exactly the same layering reason, and both call sites go through it.

**One thing to push back on if you disagree:** the env var name now appears in three assemblies. Sharing a constant would mean a project reference in the direction the architecture forbids, so I duplicated it deliberately and left a note at each site saying the three move together. If you would rather have a tiny shared leaf project for it, say so and I will switch.

The override is used verbatim as the root with no `NovaTerminal` segment appended, matching `AppPaths.RootDirectory` and `AgentHostDiscovery.GetDefaultDirectory`, so one override value points every assembly at the same tree.

## Tests

`tests/NovaTerminal.Platform.Tests/Ssh/SshPathSandboxTests.cs` — four tests, serialized via their own collection since they mutate a process-wide variable and restore whatever was set before:

- the profile store's default path follows the override
- `PlatformAppPaths.SshDirectory` follows the override
- no path handed out under an override lands inside the real app-data directory — the property the issue reduces to, asserted directly rather than only through the call sites
- without the override, the root is still the real app-data directory

Reverting `JsonSshProfileStore` alone fails two of the four, so they are not vacuous.

- `test tests/NovaTerminal.Platform.Tests` — 175 passed, 30 skipped (Docker E2E, unchanged)
- `test tests/NovaTerminal.App.Tests --filter Ssh` — 260 passed
- `build -c Release NovaTerminal.sln` — 0 errors, no new warnings from the changed files

## Follow-on

This unblocks the `connection-manager` screenshot scenario, which is implemented and sitting unregistered in `tools/NovaTerminal.Shots/Scenarios/ConnectionManagerScenario.cs` on `feat/shots-harness` precisely because of this escape.

## Noticed, not changed

`ProfileImporter.cs:17` and `BackupTools.cs:100` also read `LocalApplicationData` directly. I did not touch either — the importer looks like it is deliberately reading *other* applications' config, and `BackupTools` needs its own read before I would call it wrong. Worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)