### PR TITLE
ci: fail the headless lane when a run is cut short, instead of summarising it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,11 +325,17 @@ jobs:
           SKIP_RUST_NATIVE_BUILD: '1'
         shell: bash
         run: |
+          mkdir -p tests/NovaTerminal.App.Tests/TestResults/main
+          # tee, because xUnit's "Catastrophic failure" aborts exist only in this output: they
+          # kill a whole collection without writing a result, so the trx cannot report them and
+          # the gate has to read the log to see them at all.
+          set -o pipefail
           dotnet test tests/NovaTerminal.App.Tests -c "$CONFIGURATION" --no-build --no-restore \
             --filter "Category!=Replay&Category!=RenderMetrics&Category!=PtySmoke&Category!=Stress&Category!=GoldenSharedPng&Lane!=PlatformBoot" \
             --blame-hang-timeout 5m --blame-hang-dump-type mini \
             --results-directory tests/NovaTerminal.App.Tests/TestResults/main \
-            --logger "trx;LogFileName=unit_app.trx"
+            --logger "trx;LogFileName=unit_app.trx" \
+            2>&1 | tee tests/NovaTerminal.App.Tests/TestResults/main/console.log
 
       # Lane!=PlatformBoot above, Lane=PlatformBoot here: these run in a SEPARATE PROCESS on
       # purpose, and the split is the fix for a real bug rather than tidiness.
@@ -350,16 +356,30 @@ jobs:
           SKIP_RUST_NATIVE_BUILD: '1'
         shell: bash
         run: |
+          mkdir -p tests/NovaTerminal.App.Tests/TestResults/platformboot
+          set -o pipefail
           dotnet test tests/NovaTerminal.App.Tests -c "$CONFIGURATION" --no-build --no-restore \
             --filter "Lane=PlatformBoot&Category!=GoldenSharedPng" \
             --blame-hang-timeout 5m --blame-hang-dump-type mini \
             --results-directory tests/NovaTerminal.App.Tests/TestResults/platformboot \
-            --logger "trx;LogFileName=unit_app_platformboot.trx"
+            --logger "trx;LogFileName=unit_app_platformboot.trx" \
+            2>&1 | tee tests/NovaTerminal.App.Tests/TestResults/platformboot/console.log
 
       # Gates the lane above on its own results: any failing test not named in
       # tests/app-tests-known-flaky.txt fails this job. A missing trx is the #81 hang and
       # only warns — there are no results to judge. Runs on failure too, so a non-zero
       # `dotnet test` still gets its results read.
+      # The gate decides whether this lane may report success, so its own branching is worth
+      # a second of CI: the truncation and abort rules are what stop another green-but-broken
+      # run, and getting them backwards would either red every PR or hide the next one.
+      - name: Self-test the App.Tests gate
+        if: always()
+        shell: bash
+        run: |
+          py=python3
+          command -v "$py" >/dev/null 2>&1 || py=python
+          "$py" scripts/tests/check_app_tests_baseline_tests.py
+
       - name: Check App.Tests failures against the flake allowlist
         if: always()
         shell: bash
@@ -372,14 +392,25 @@ jobs:
           # with one shared TestResults/ each lane would see the other's dump. That reported the
           # PlatformBoot lane as truncated when it had finished cleanly, and would have let a
           # leftover dump excuse a genuine crash in the other lane.
+          # The third field is the lane's floor for executed tests. A run below it that did not
+          # hang is rejected rather than summarised: 0962be8 executed 1,112 of 3,434 here, lost
+          # the rest to collection aborts, and reported "no failures" on a green job. The floors
+          # sit next to the --filter arguments above because changing a filter is what
+          # legitimately changes a count - and lowering one should be as deliberate as adding a
+          # line to the flake allowlist. Headroom is for OS skip differences (windows and ubuntu
+          # differ by a handful) and small churn, not for losing collections.
           status=0
-          for lane in main:unit_app platformboot:unit_app_platformboot; do
+          for lane in main:unit_app:3300 platformboot:unit_app_platformboot:40; do
             dir="${lane%%:*}"
-            trx="${lane##*:}"
+            rest="${lane#*:}"
+            trx="${rest%%:*}"
+            floor="${rest##*:}"
             echo "::group::$trx"
             "$py" scripts/check-app-tests-baseline.py \
               "tests/NovaTerminal.App.Tests/TestResults/$dir/$trx.trx" \
-              tests/app-tests-known-flaky.txt || status=1
+              tests/app-tests-known-flaky.txt \
+              "$floor" \
+              "tests/NovaTerminal.App.Tests/TestResults/$dir/console.log" || status=1
             echo "::endgroup::"
           done
           exit $status

--- a/scripts/check-app-tests-baseline.py
+++ b/scripts/check-app-tests-baseline.py
@@ -19,9 +19,15 @@ So the hang stays non-blocking and the *results* become blocking:
     collection aborts reported "no failures" and went green, minutes after the same branch
     had run all 3,434. Truncation is only tolerated for the one cause this lane exists to
     tolerate, the #81 teardown hang, which leaves a hang dump behind to prove itself.
-  * A catastrophic (runner-level) failure in the step log fails this step. Those aborts kill
-    whole collections without ever appearing in the trx, so the results file is silent about
-    them: the summary reads "no failures" precisely because the tests were never run.
+  * A catastrophic (runner-level) failure in the step log is surfaced with its count, but
+    does not block - yet. Those aborts kill whole collections without ever appearing in the
+    trx, which is why the summary can read "no failures" precisely because tests were never
+    run. They are not blocking because they are currently happening on every run, including
+    ones that complete the whole suite cleanly (21208fd: 3,434 executed, 0 failures, 10
+    aborts), so blocking on them would red every PR and teach everyone to ignore this lane -
+    the dynamic that let the truncation hide. Flip it to blocking once the remaining source
+    of thread-affine Avalonia state is fixed; the floor above is what protects coverage in
+    the meantime, and it discriminates properly (3,434 passes, 1,112 does not).
 
 Names are matched as substrings, so an allowlist entry without theory arguments covers
 every case of that theory.
@@ -171,12 +177,15 @@ def main() -> int:
     # case - a run cut short with nothing hung, which had no signal at all.
     truncated = executed < min_executed
     if aborts and not dumps:
+        # A warning, not an error: see the module docstring. These fire on healthy full runs
+        # too, so blocking here would red every PR rather than telling anyone anything new.
         summary(
-            f"::error::App.Tests hit {len(aborts)} runner-level abort(s) "
-            f"({len(set(aborts))} distinct) and no hang dump was "
-            f"written, so this is not the #81 hang. Each one kills a whole xUnit collection "
-            f"without writing a single result, which is why {trx.name} can report no failures "
-            f"while the suite lost most of its tests."
+            f"::warning::App.Tests hit {len(aborts)} runner-level abort(s) "
+            f"({len(set(aborts))} distinct) with no hang dump, so this is not the #81 hang. "
+            f"Each one kills a whole xUnit collection without writing a result, so they are "
+            f"invisible to {trx.name}. Not blocking yet - they occur on complete runs as well, "
+            f"and the executed-count floor is what guards coverage until the underlying "
+            f"thread-affine state is fixed."
         )
         for line in sorted(set(aborts)):
             summary(f"  - {line}")
@@ -189,7 +198,7 @@ def main() -> int:
             f"deliberately; do not let a truncated run report success."
         )
 
-    if (aborts or truncated) and not dumps:
+    if truncated and not dumps:
         # Reported before returning so the failure list is still visible: knowing which tests
         # failed in the part that did run is useful even when the run is being rejected.
         if failures:

--- a/scripts/check-app-tests-baseline.py
+++ b/scripts/check-app-tests-baseline.py
@@ -13,13 +13,26 @@ So the hang stays non-blocking and the *results* become blocking:
     present, which is the #81 signature and the one case continue-on-error exists for. A
     crash, a discovery failure, or a zero-result trx is otherwise indistinguishable from
     success, and that is exactly the "green but broken" shape this gate exists to stop.
-  * A truncated run (the hang aborts the run partway) is reported loudly, with the count,
-    because the tests it never reached cannot be said to have passed.
+  * A truncated run is reported loudly, with the count, because the tests it never reached
+    cannot be said to have passed - and, when nothing hung, it *fails*. Reporting alone was
+    not enough: a run that executed 1,112 of 3,434 tests and lost the rest to xUnit
+    collection aborts reported "no failures" and went green, minutes after the same branch
+    had run all 3,434. Truncation is only tolerated for the one cause this lane exists to
+    tolerate, the #81 teardown hang, which leaves a hang dump behind to prove itself.
+  * A catastrophic (runner-level) failure in the step log fails this step. Those aborts kill
+    whole collections without ever appearing in the trx, so the results file is silent about
+    them: the summary reads "no failures" precisely because the tests were never run.
 
 Names are matched as substrings, so an allowlist entry without theory arguments covers
 every case of that theory.
 
-Usage: check-app-tests-baseline.py <trx-path> <allowlist-path>
+Usage: check-app-tests-baseline.py <trx-path> <allowlist-path> <min-executed> [log-path]
+
+  min-executed  Floor for the executed count in this lane. Lowering it is a decision, the
+                same way growing the flake allowlist is: it means the lane legitimately has
+                fewer tests, not that a truncated run should be waved through.
+  log-path      Optional. The captured `dotnet test` output for this lane, scanned for
+                runner-level aborts that never reach the trx.
 """
 
 import os
@@ -70,6 +83,28 @@ def read_results(path: Path) -> tuple[list[str], int]:
     return sorted(set(failures)), executed
 
 
+def catastrophic_failures(log: Path) -> list[str]:
+    """
+    Runner-level aborts from the step log.
+
+    xUnit reports these as "Catastrophic failure: ..." and they take the whole collection with
+    them, so the affected tests never produce a UnitTestResult. Nothing about them is visible
+    in the trx - which is why a run can lose two thirds of the suite and still be summarised as
+    passing. Read from the log because that is the only place they exist.
+    """
+    if not log.is_file():
+        return []
+    found = []
+    for raw in log.read_text(encoding="utf-8", errors="replace").splitlines():
+        marker = "Catastrophic failure"
+        index = raw.find(marker)
+        if index >= 0:
+            found.append(raw[index:].strip())
+    # Deduplicated for display, but the caller is told how many times they fired: ten copies of
+    # one line is one finding, and also ten dead collections. Both numbers matter.
+    return found
+
+
 def hang_dumps(trx: Path) -> list[Path]:
     """Hang dumps written by --blame-hang-dump-type, i.e. the #81 signature."""
     results_dir = trx.parent
@@ -79,13 +114,24 @@ def hang_dumps(trx: Path) -> list[Path]:
 
 
 def main() -> int:
-    if len(sys.argv) != 3:
-        print(f"usage: {Path(sys.argv[0]).name} <trx-path> <allowlist-path>", file=sys.stderr)
+    if len(sys.argv) not in (4, 5):
+        print(
+            f"usage: {Path(sys.argv[0]).name} <trx-path> <allowlist-path> <min-executed> "
+            f"[log-path]",
+            file=sys.stderr,
+        )
         return 2
 
     trx = Path(sys.argv[1])
     allowlist_path = Path(sys.argv[2])
+    try:
+        min_executed = int(sys.argv[3])
+    except ValueError:
+        print(f"min-executed must be an integer, got {sys.argv[3]!r}", file=sys.stderr)
+        return 2
+    log_path = Path(sys.argv[4]) if len(sys.argv) == 5 else None
     dumps = hang_dumps(trx)
+    aborts = catastrophic_failures(log_path) if log_path else []
 
     if not trx.is_file():
         if dumps:
@@ -118,6 +164,39 @@ def main() -> int:
             f"({dumps[0].name}, the #81 teardown hang), so the run is truncated: tests it never "
             f"reached are neither passed nor failed. The failures below are judged as usual."
         )
+
+    # Both checks below are skipped when a hang dump is present, and that is deliberate rather
+    # than lenient: the #81 hang truncates runs on roughly one job-run in three, and this lane
+    # is non-blocking precisely so that cannot red unrelated PRs. What they close is the other
+    # case - a run cut short with nothing hung, which had no signal at all.
+    truncated = executed < min_executed
+    if aborts and not dumps:
+        summary(
+            f"::error::App.Tests hit {len(aborts)} runner-level abort(s) "
+            f"({len(set(aborts))} distinct) and no hang dump was "
+            f"written, so this is not the #81 hang. Each one kills a whole xUnit collection "
+            f"without writing a single result, which is why {trx.name} can report no failures "
+            f"while the suite lost most of its tests."
+        )
+        for line in sorted(set(aborts)):
+            summary(f"  - {line}")
+
+    if truncated and not dumps:
+        summary(
+            f"::error::App.Tests executed {executed} test(s), below this lane's floor of "
+            f"{min_executed}, and nothing hung. The missing tests did not pass - they never "
+            f"ran. If the lane legitimately has fewer tests now, lower the floor in ci.yml "
+            f"deliberately; do not let a truncated run report success."
+        )
+
+    if (aborts or truncated) and not dumps:
+        # Reported before returning so the failure list is still visible: knowing which tests
+        # failed in the part that did run is useful even when the run is being rejected.
+        if failures:
+            summary(f"Failures recorded before the run was cut short ({len(failures)}):")
+            for name in failures:
+                summary(f"  - {name}")
+        return 1
 
     if not failures:
         summary(f"App.Tests: {executed} executed, no failures in {trx.name}.")

--- a/scripts/tests/check_app_tests_baseline_tests.py
+++ b/scripts/tests/check_app_tests_baseline_tests.py
@@ -1,0 +1,87 @@
+"""
+Behaviour matrix for scripts/check-app-tests-baseline.py.
+
+The gate decides whether the headless App.Tests lane is allowed to report success, and it now
+has real branching: unlisted failures, an empty or missing trx, a truncated run, runner-level
+aborts, and the one truncation it must keep tolerating (the #81 teardown hang, evidenced by a
+hang dump). Getting any of those backwards either reds every PR or hides another
+green-but-broken run - the exact failure this gate was extended to stop, where a job executed
+1,112 of 3,434 tests and reported "no failures".
+
+Plain python with no test framework, matching the rest of scripts/. Run it directly:
+
+    python scripts/tests/check_app_tests_baseline_tests.py
+
+Exits non-zero if any case behaves differently from the table at the bottom.
+"""
+import io, os, shutil, subprocess, sys, tempfile
+from pathlib import Path
+
+GATE = Path("scripts/check-app-tests-baseline.py").resolve()
+ALLOW = Path("tests/app-tests-known-flaky.txt").resolve()
+
+
+def make_trx(path: Path, passed: int, failed_names=()):
+    results = "".join(
+        f'<UnitTestResult testName="Passing{i}" outcome="Passed" />' for i in range(passed)
+    ) + "".join(
+        f'<UnitTestResult testName="{n}" outcome="Failed" />' for n in failed_names
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        f'<TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010"><Results>{results}</Results></TestRun>',
+        encoding="utf-8",
+    )
+
+
+def run(case, trx, floor, log=None, dump=False):
+    root = Path(tempfile.mkdtemp())
+    trx_path = root / "lane" / "unit_app.trx"
+    make_trx(trx_path, trx["passed"], trx.get("failed", ()))
+    if dump:
+        (trx_path.parent / "testhost_1_hangdump.dmp").write_bytes(b"\x00")
+    args = [sys.executable, str(GATE), str(trx_path), str(ALLOW), str(floor)]
+    if log is not None:
+        log_path = trx_path.parent / "console.log"
+        log_path.write_text(log, encoding="utf-8")
+        args.append(str(log_path))
+    p = subprocess.run(args, capture_output=True, text=True)
+    shutil.rmtree(root, ignore_errors=True)
+    return p.returncode, (p.stdout + p.stderr)
+
+
+ABORT_LOG = (
+    "[xUnit.net 00:00:07.46]     [FATAL ERROR] System.InvalidOperationException\n"
+    "[xUnit.net 00:00:07.46] Catastrophic failure: System.InvalidOperationException : "
+    "The calling thread cannot access this object because a different thread owns it.\n"
+    "[xUnit.net 00:00:53.56] Catastrophic failure: System.InvalidOperationException : "
+    "The calling thread cannot access this object because a different thread owns it.\n"
+)
+
+cases = [
+    # name,                                   trx,                       floor, log,       dump,  expect
+    ("healthy full run",                      {"passed": 3434},          3300,  "",        False, 0),
+    ("truncated, nothing hung",               {"passed": 1112},          3300,  "",        False, 1),
+    ("truncated but hung (#81, tolerated)",   {"passed": 1112},          3300,  "",        True,  0),
+    ("aborts in log, nothing hung",           {"passed": 3434},          3300,  ABORT_LOG, False, 1),
+    ("aborts in log but hung (tolerated)",    {"passed": 3434},          3300,  ABORT_LOG, True,  0),
+    ("both: truncated and aborted",           {"passed": 1112},          3300,  ABORT_LOG, False, 1),
+    ("unlisted failure, full run",            {"passed": 3400, "failed": ["Totally.New.Test"]}, 3300, "", False, 1),
+    ("no log argument, healthy",              {"passed": 3434},          3300,  None,      False, 0),
+    ("no log argument, truncated",            {"passed": 10},            3300,  None,      False, 1),
+    ("platformboot lane, healthy",            {"passed": 46},            40,    "",        False, 0),
+]
+
+failures = 0
+for name, trx, floor, log, dump, expect in cases:
+    code, out = run(name, trx, floor, log, dump)
+    ok = code == expect
+    failures += 0 if ok else 1
+    print(f"{'PASS' if ok else 'FAIL'}  {name:<38} exit={code} (want {expect})")
+    if not ok:
+        print("      " + out.strip().replace("\n", "\n      ")[:600])
+
+print()
+print("all gate cases behaved" if failures == 0 else f"{failures} case(s) misbehaved")
+sys.exit(1 if failures else 0)

--- a/scripts/tests/check_app_tests_baseline_tests.py
+++ b/scripts/tests/check_app_tests_baseline_tests.py
@@ -64,9 +64,12 @@ cases = [
     ("healthy full run",                      {"passed": 3434},          3300,  "",        False, 0),
     ("truncated, nothing hung",               {"passed": 1112},          3300,  "",        False, 1),
     ("truncated but hung (#81, tolerated)",   {"passed": 1112},          3300,  "",        True,  0),
-    ("aborts in log, nothing hung",           {"passed": 3434},          3300,  ABORT_LOG, False, 1),
+    # Aborts warn rather than block: they fire on complete, clean runs too (21208fd ran all
+    # 3,434 with 10 of them), so blocking would red every PR and train everyone to ignore
+    # this lane. The floor is what guards coverage until the underlying cause is fixed.
+    ("aborts in log, full run, warns only",   {"passed": 3434},          3300,  ABORT_LOG, False, 0),
     ("aborts in log but hung (tolerated)",    {"passed": 3434},          3300,  ABORT_LOG, True,  0),
-    ("both: truncated and aborted",           {"passed": 1112},          3300,  ABORT_LOG, False, 1),
+    ("truncated and aborted, floor blocks",   {"passed": 1112},          3300,  ABORT_LOG, False, 1),
     ("unlisted failure, full run",            {"passed": 3400, "failed": ["Totally.New.Test"]}, 3300, "", False, 1),
     ("no log argument, healthy",              {"passed": 3434},          3300,  None,      False, 0),
     ("no log argument, truncated",            {"passed": 10},            3300,  None,      False, 1),


### PR DESCRIPTION
## Why

`0962be8` executed **1,112 of 3,434** tests, lost the rest to xUnit collection aborts, reported "no failures" and went green — minutes after the same branch had run all 3,434 clean. I merged #409 on the strength of the earlier run, not that one.

That's the same shape as the incident this gate was built for, one level down. The gate reads the trx; an abort kills a whole collection **without writing a single result**, so the file it judges is silent about every test that never ran. `if not failures: return 0` did the rest.

| Run, same branch | Executed | Reported |
|---|---|---|
| `21208fd` | 3,434 | no failures |
| `0962be8` | **1,112** | no failures ✅ |

## What now blocks

- **Executed count below a per-lane floor** — 3,300 for the shared pass, 40 for PlatformBoot. The floors sit beside the `--filter` arguments in `ci.yml`, because changing a filter is what legitimately changes a count. Lowering one should be as deliberate as adding a line to the flake allowlist.
## What warns but does not block

**`Catastrophic failure` in the step log.** These exist *only* in console output, so both test steps now `tee` to `console.log` and the gate reads it, reporting occurrences and distinct messages separately.

They are deliberately **not** blocking, and checking why changed this PR:

| Commit | Executed | Aborts |
|---|---|---|
| `21208fd` | **3,434** (whole suite, 0 failures) | **10** |
| `0962be8` | 1,112 (truncated) | 2 |

A run can complete every test cleanly and still log ten aborts — so blocking on them would red this PR and every one after it until the remaining thread-affine state is fixed. That is the same dynamic that hid the truncation: a lane that is always red gets ignored. The floor discriminates precisely where the abort count does not (3,434 passes, 1,112 fails), and the docstring records the condition for flipping aborts to blocking.

## What deliberately still passes

Both checks are **skipped when a hang dump is present**. That's not leniency — the workflow's own comment says the #81 teardown hang truncates roughly one job-run in three, and this lane is non-blocking precisely so that can't red unrelated PRs. What closes is the other case: a run cut short with nothing hung, which had no signal at all.

## Validated against both real shapes

Using job `101003892958`'s actual console log (10 aborts, no dump):

| trx paired with it | Result |
|---|---|
| 3,434 results — the full run's real count | **exit 0**, abort warning only |
| 1,112 results — the truncated run's count | **exit 1**, `executed 1112 ... below this lane's floor of 3300, and nothing hung` |

So the shape that went green an hour ago now fails, and the shape that was genuinely healthy still passes.

`scripts/tests/check_app_tests_baseline_tests.py` adds a behaviour matrix over ten cases — including the two that must keep passing, truncated-but-hung and aborted-but-hung — and CI runs it before the gate. The gate decides whether a lane may report success, so getting its rules backwards would either red every PR or hide the next silent run; that's worth one second of CI. Plain python, no framework, matching the rest of `scripts/`.

## Not fixed here

The aborts themselves. At least one source of thread-affine Avalonia state remains after #409 — they persisted locally with that class excluded. This change is what makes the next occurrence a named failure instead of a green tick, which is the prerequisite for hunting it rather than a substitute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
