### PR TITLE
fix(agent-output): contain the debounce tick, which was aborting CI collections

### DIFF
--- a/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
+++ b/src/NovaTerminal.App/AgentOutput/AgentOutputRegionTracker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading;
+using NovaTerminal.Shell;
 using NovaTerminal.VT;
 
 namespace NovaTerminal.AgentOutput;
@@ -298,6 +299,14 @@ public sealed class AgentOutputRegionTracker : IDisposable
         AdvanceGeneration();
     }
 
+    /// <remarks>
+    /// The timer goes first, and this does not route through <see cref="SetEnabled"/>: the
+    /// disabling branch there arms a <see cref="PresenceSoonDelay"/> tick, so disposing through it
+    /// scheduled a callback 250ms into the future and then immediately destroyed the timer that
+    /// owed it. The state it wants is set directly instead. Nothing is left to cancel, and the
+    /// window in which <see cref="ReadScheduled"/> can find itself running against a disposed
+    /// tracker is as narrow as <see cref="Timer"/> allows.
+    /// </remarks>
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0)
@@ -305,26 +314,59 @@ public sealed class AgentOutputRegionTracker : IDisposable
             return;
         }
 
-        SetEnabled(false);
         _debounceTimer.Dispose();
+        _enabled = false;
+        AdvanceGeneration();
     }
 
+    /// <remarks>
+    /// <para>
+    /// This is a <see cref="Timer"/> callback, so it owns two obligations that are easy to miss.
+    /// </para>
+    /// <para>
+    /// It must not run against a disposed tracker. <see cref="Timer.Dispose()"/> cancels pending
+    /// callbacks but does not join one already executing, so a tick can still be in flight when
+    /// the pane it reports to goes away - and everything downstream of here ends at a control on
+    /// that pane.
+    /// </para>
+    /// <para>
+    /// And it must not let an exception escape. An unhandled exception on a threadpool thread
+    /// terminates the process, so without this catch any throw on the read or presence path takes
+    /// the whole terminal down - which is what the headless test suite has been demonstrating
+    /// several times per run: a stale tick reached <c>AgentOutputToggle.IsVisible</c> across a
+    /// swapped dispatcher, Avalonia's <c>VerifyAccess</c> threw, and the escape killed an entire
+    /// xUnit collection with no result written for any test in it. The MD button's visibility is
+    /// not worth a process for.
+    /// </para>
+    /// </remarks>
     private void ReadScheduled(object? state)
     {
-        // While the panel is closed the timer drives markdown-presence detection instead of
-        // region reads: the MD button's visibility is the thing that needs updating, and
-        // ReadAndPostCore would refuse anyway. This covers the closed-panel ticks that now
-        // carry a remembered Enter row, which the earlier shape routed into that refusal.
-        if (!_enabled)
+        if (Volatile.Read(ref _disposed) != 0)
         {
-            CheckMarkdownPresence(Volatile.Read(ref _generation));
             return;
         }
 
-        ReadAndPostCore(
-            streaming: true,
-            Volatile.Read(ref _generation),
-            fallbackToRecentTail: Interlocked.Exchange(ref _recentTailFallback, 0) == 1);
+        try
+        {
+            // While the panel is closed the timer drives markdown-presence detection instead of
+            // region reads: the MD button's visibility is the thing that needs updating, and
+            // ReadAndPostCore would refuse anyway. This covers the closed-panel ticks that now
+            // carry a remembered Enter row, which the earlier shape routed into that refusal.
+            if (!_enabled)
+            {
+                CheckMarkdownPresence(Volatile.Read(ref _generation));
+                return;
+            }
+
+            ReadAndPostCore(
+                streaming: true,
+                Volatile.Read(ref _generation),
+                fallbackToRecentTail: Interlocked.Exchange(ref _recentTailFallback, 0) == 1);
+        }
+        catch (Exception ex)
+        {
+            AppLogger.Log($"[AgentOutputRegionTracker] read tick threw: {ex}");
+        }
     }
 
     private void ReadAndPostCore(bool streaming, int generation, bool fallbackToRecentTail = false)

--- a/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
+++ b/tests/NovaTerminal.App.Tests/AgentOutput/AgentOutputRegionTrackerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NovaTerminal.AgentOutput;
 using NovaTerminal.VT;
@@ -339,6 +340,52 @@ public sealed class AgentOutputRegionTrackerTests
         await WaitForAsync(() => h.PresenceChanges.Count > 0, timeoutMs: 6000);
 
         Assert.True(h.PresenceChanges[^1]);
+    }
+
+    [Fact]
+    public async Task APresenceCallbackThatThrows_IsContainedInsideTheTimerTick()
+    {
+        // ReadScheduled is a Timer callback, so an exception escaping it is unhandled on a
+        // threadpool thread - which terminates the process rather than failing a test. That is not
+        // hypothetical: the headless suite hit it several times per run, when a stale presence tick
+        // reached a pane's toggle across a dispatcher the test session had already swapped and
+        // Avalonia's VerifyAccess threw. The escape took out a whole xUnit collection, writing no
+        // result for any test in it, so the run reported "no failures" over a hole - which is how
+        // this stayed unattributed for weeks while looking like an upstream hang.
+        //
+        // Read what this does and does not guard. The assertion below proves the tick reached the
+        // callback and threw; it passes either way, because the increment happens before the throw
+        // and xUnit catches the escape at the runner level rather than in the test. A regression
+        // shows up as the run itself: "Catastrophic failure" in the console and a non-zero exit
+        // from dotnet test, which is verified both ways - reverting the catch reproduces exactly
+        // that line carrying this test's own message. So this case is the reproduction, and the
+        // abort check in scripts/check-app-tests-baseline.py is what makes it red; that check is
+        // a warning today only because these escapes were routine, which is the very thing being
+        // fixed here.
+        var buffer = new TerminalBuffer(40, 8);
+        var parser = new AnsiParser(buffer);
+        parser.Process(PromptStart + "$ " + PromptEnd + "\r\n## Title\r\n\r\n- one\r\n");
+
+        int throwingCalls = 0;
+        using var tracker = new AgentOutputRegionTracker(
+            () => buffer,
+            () => null,
+            // Inline, standing in for the pane's already-on-the-UI-thread fast path - the branch
+            // that was taken when the tick threw.
+            dispatch: action => action(),
+            onUpdate: (_, _) => { },
+            markdownPresenceChanged: _ =>
+            {
+                Interlocked.Increment(ref throwingCalls);
+                throw new InvalidOperationException("as a pane's toggle does on a dead dispatcher");
+            });
+
+        // The disabling branch arms the presence tick, which is the callback that reaches the pane.
+        tracker.SetEnabled(false);
+
+        await WaitForAsync(() => Volatile.Read(ref throwingCalls) > 0, timeoutMs: 6000);
+
+        Assert.Equal(1, Volatile.Read(ref throwingCalls));
     }
 
     [Fact]


### PR DESCRIPTION
## What this is

The `Catastrophic failure` aborts that #409 and #410 kept describing as "at least one more source of thread-affine Avalonia state" are **not a test-scheduling problem**. They are a product-code defect in `AgentOutputRegionTracker`, and CI has been reporting it several times per run for weeks as unattributed noise.

Running the headless lane locally with `verbosity=detailed` names it. All six aborts, one stack:

```
Avalonia.Threading.Dispatcher.ThrowVerifyAccess
Avalonia.Visual.set_IsVisible
TerminalPane.SetupCommon b__178_18            ← AgentOutputToggle.IsVisible = present
AgentOutputRegionTracker.CheckMarkdownPresence
AgentOutputRegionTracker.ReadScheduled
System.Threading.TimerQueueTimer.Fire
```

`ReadScheduled` is a `Timer` callback. A tick lands on a threadpool thread; the pane's dispatch closure finds `Dispatcher.UIThread.CheckAccess()` true and runs the action **inline**; the write to the toggle then fails `VerifyAccess`, because the headless session has swapped dispatchers since the tick was armed. The exception escapes the callback, and xUnit reports it as a catastrophic failure — **killing a whole test collection while writing no result for any test in it.**

That is the mechanism behind the symptom #410 was built for. The executed count swung 1,112 / 2,124 / 3,434 / 3,443 across runs while every one of them reported "no failures", because the trx is silent about tests that never ran.

## Why this is a real bug, not test-only

An unhandled exception on a threadpool thread **terminates the process**. So in the shipped app, any throw on the read or presence path takes the whole terminal down — for the sake of the MD button's visibility. The headless suite is where it became observable, because swapping dispatchers per test manufactures the throw reliably; it is not what makes it a defect.

## The two changes

| | |
|---|---|
| **`ReadScheduled` contains its exceptions** | Same containment `GlobalHotkey` already applies to its host callback, logging through `AppLogger` rather than swallowing. |
| **`ReadScheduled` bails on a disposed tracker, and `Dispose()` stops arming a timer it is about to destroy** | `Dispose()` ran through `SetEnabled(false)`, whose disabling branch schedules a `PresenceSoonDelay` tick. `Timer.Dispose()` cancels a *pending* callback but does not join one already *running*, so the tick could still reach a pane that was gone. |

## Verification

The baseline, before touching anything — the headless lane run locally on `6581d9b`:

```
6 × Catastrophic failure: System.InvalidOperationException
    The calling thread cannot access this object because a different thread owns it
Data collector 'Blame': the specified inactivity time of 5 minutes has elapsed
Test Run Aborted.
```

That is the CI shape reproduced exactly, dumps and all, which is what made the stack above readable at last.

The catch itself is verified in both directions on the isolated case: reverting it reproduces `Catastrophic failure: System.InvalidOperationException : as a pane's toggle does on a dead dispatcher` with `dotnet test` exiting 1, and restoring it exits 0.

**What CI decides here, not me:** whether the full lane's abort count is actually zero. My local re-run is the weaker instrument — the box is noisy enough that one clean pass would not settle it. The number to read is this PR's Unit Tests job.

## About the new test

`APresenceCallbackThatThrows_IsContainedInsideTheTimerTick` is the reproduction, and its comment says plainly what it does and does not guard: the assertion passes either way, because the increment happens before the throw and xUnit catches the escape at the runner level rather than in the test. A regression surfaces as the *run* — `Catastrophic failure` plus a non-zero exit — which is verified above in both directions.

Which means the thing that would actually make it red is the abort check in `scripts/check-app-tests-baseline.py`, and that check is a **warning** today only because these escapes were routine. That is the follow-up, deliberately not in this PR: land this, watch a few runs on main, and if the abort count holds at zero, flip the check to blocking — the condition already recorded in the script's docstring.

## Not claimed here

**That this also fixes the #81 teardown hang.** The local baseline did hang, and it went silent immediately after its last abort, which makes them look like one event. That is a correlation, not a demonstration. Nobody should lower the hang tolerance on the strength of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
