### PR TITLE
feat(app): About window with embedded manual update check

### DIFF
--- a/docs/plans/2026-09-04-about-window-design.md
+++ b/docs/plans/2026-09-04-about-window-design.md
@@ -1,0 +1,45 @@
+# About window + embedded update check — design
+
+Date: 2026-09-04
+Status: implemented
+
+## Problem
+
+NovaTerminal had no About surface anywhere: no way to see the running version without
+reading a log, and the manual update check existed only as the palette's
+"Update: Check for updates", answered through main-window toasts.
+
+## Decision
+
+One modal dialog, `UI/About/AboutWindow`, entered only from the "+" title-bar flyout
+("About NovaTerminal..."). The window shows the app icon, name, and version (resolved from
+`AssemblyInformationalVersionAttribute`, the same attribute-based resolution
+`BackupService` uses), an inline update-check result, a "Restart now" button when an update
+is staged, and repo/releases links.
+
+## How the check is shared
+
+The window does not own any update machinery. `MainWindow.ShowAboutWindowAsync` injects
+three delegates (property injection, the same way `SettingsWindow` is wired):
+
+- `RunUpdateCheck` → `CheckForUpdatesInteractiveAsync(about)` — so a check started from
+  About shares the coordinator, `_updateCheckInFlight` guard, and announce-once state with
+  the palette's manual check and the deferred startup check;
+- `ApplyStagedUpdate` → `MainWindow.ApplyStagedUpdate` (teardown included);
+- `StagedVersionProvider` → lets the window show an already-staged update on open and keep
+  the restart affordance visible if a re-check fails while an update is on disk.
+
+`CheckForUpdatesInteractiveAsync` gained an optional
+`NovaTerminal.Update.IUpdateCheckFeedback`. Without one it constructs
+`ToastUpdateCheckFeedback` (the pre-existing toast behavior, strings now sourced from
+`NovaTerminal.Update.UpdateCheckMessages`); the About window implements the interface to
+render inline. `UpdateCheckMessages` is UI-free so both surfaces cannot drift and the
+mapping is unit-tested in the gating loop
+(`tests/NovaTerminal.Architecture.Tests/Update/UpdateCheckMessagesTests.cs`).
+
+## Deliberately out of scope
+
+- No palette entry for About; the existing "Update: Check for updates" palette command is
+  unchanged.
+- No pinnable title-bar button, no new `TerminalSettings` fields (hence no `SettingsTools`
+  schema/drift-guard edits and no effective-settings whitelist change), no MCP app-info tool.

--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -245,6 +245,8 @@
                             <MenuItem Header="New SSH Connection..." Name="MenuNewSshConnection" />
                             <MenuItem Header="Manage Profiles..." Name="MenuManageProfiles" />
                             <MenuItem Header="Agent Activity..." Name="MenuAgentActivity" />
+                            <Separator />
+                            <MenuItem Header="About NovaTerminal..." Name="MenuAbout" />
                         </MenuFlyout>
                     </Button.Flyout>
                 </Button>

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -3534,6 +3534,12 @@ namespace NovaTerminal
                 await ShowAgentActivityJournalAsync();
             };
 
+            var menuAbout = this.FindControl<MenuItem>("MenuAbout");
+            if (menuAbout != null) menuAbout.Click += async (s, e) =>
+            {
+                await ShowAboutWindowAsync();
+            };
+
             // Wired once, here, and never again: PlaceAgentObserveIndicator re-parents this exact
             // instance on every RebuildTitleBar instead of recreating it, so this subscription
             // survives every rebuild. (BtnRecord's old wiring is gone - PR #342 moved Record into
@@ -8448,16 +8454,21 @@ namespace NovaTerminal
         /// what happened: the user asked a direct question and silence would read as a hang.
         /// Constructs the coordinator on demand (see <see cref="EnsureUpdateCoordinator"/>) so
         /// this works even in the first 10 seconds of the process's life, before the deferred
-        /// startup timer would otherwise have built it.
+        /// startup timer would otherwise have built it. Reporting goes through
+        /// <see cref="NovaTerminal.Update.IUpdateCheckFeedback"/> so the About window can run
+        /// this same pipeline and render the answer inline; without one, the answers surface
+        /// as toasts (see <see cref="ToastUpdateCheckFeedback"/>).
         /// </summary>
-        private async System.Threading.Tasks.Task CheckForUpdatesInteractiveAsync()
+        private async System.Threading.Tasks.Task CheckForUpdatesInteractiveAsync(NovaTerminal.Update.IUpdateCheckFeedback? feedback = null)
         {
+            feedback ??= new ToastUpdateCheckFeedback(this);
+
             EnsureUpdateCoordinator();
             if (_updateCoordinator == null)
             {
                 // Construction itself failed unexpectedly (see EnsureUpdateCoordinator) - distinct
                 // from Unsupported below, which is a healthy check reporting a non-Velopack host.
-                ShowRecordingToast("Update check failed", "Could not check for updates. See the debug log for details.", null, null, autoHide: true);
+                feedback.CoordinatorUnavailable();
                 return;
             }
 
@@ -8477,12 +8488,7 @@ namespace NovaTerminal
                 // could adopt its outcome is the fuller answer, but it is a lot of machinery
                 // for a ~10 s window, and it would make a background check's failure suddenly
                 // user-visible depending on timing. (Codex P2 on #340.)
-                ShowRecordingToast(
-                    "Checking for updates",
-                    "A check is already running in the background. If it finds a new version, you'll get a notification.",
-                    null,
-                    null,
-                    autoHide: true);
+                feedback.AlreadyRunning();
                 return;
             }
 
@@ -8494,7 +8500,7 @@ namespace NovaTerminal
                 // check does synchronous file I/O (staged-user-id read/write, nuspec parse of
                 // every local .nupkg) before its first await, and this runs from a palette
                 // click on the UI thread. The continuation resumes on the UI thread, which the
-                // ShowRecordingToast calls below require.
+                // feedback surfaces (toasts, or the About window's status area) require.
                 outcome = await Task.Run(() => _updateCoordinator.RunManualCheckAsync());
             }
             finally
@@ -8502,38 +8508,96 @@ namespace NovaTerminal
                 _updateCheckInFlight = false;
             }
 
-            switch (outcome)
+            feedback.Outcome(outcome, _updateCoordinator.StagedVersion);
+        }
+
+        /// <summary>
+        /// The palette's surface: the same answers every check gives, delivered as toasts. The
+        /// strings come from <see cref="NovaTerminal.Update.UpdateCheckMessages"/> so this and
+        /// the About window's inline rendering cannot drift apart.
+        /// </summary>
+        private sealed class ToastUpdateCheckFeedback : NovaTerminal.Update.IUpdateCheckFeedback
+        {
+            private readonly MainWindow _owner;
+
+            public ToastUpdateCheckFeedback(MainWindow owner)
             {
-                case NovaTerminal.Update.UpdateCheckOutcome.UpdateReady:
-                    // Show it here rather than relying on the coordinator's onUpdateReady
-                    // callback. That callback fires only when the staged version CHANGES (its
-                    // announce-once guard, which exists so a second check does not re-nag about
-                    // an update the user already dismissed). So for a user who dismissed the
-                    // toast and then asked again, the callback correctly stays silent - and
-                    // trusting it here left the manual check answering a direct question with
-                    // nothing at all, and no visible way to restart. Re-showing is idempotent:
-                    // when the callback did just fire, this sets the same text again.
-                    // (Codex P2 on #340.)
-                    ShowUpdateToast(_updateCoordinator.StagedVersion ?? string.Empty);
-                    break;
-                case NovaTerminal.Update.UpdateCheckOutcome.UpToDate:
-                    ShowRecordingToast("Up to date", "You are running the newest version.", null, null, autoHide: true);
-                    break;
-                case NovaTerminal.Update.UpdateCheckOutcome.Unsupported:
-                    ShowRecordingToast(
-                        "Updates unavailable",
-                        "This build was not installed by the NovaTerminal installer, so it cannot update itself. Download the installer from the releases page to get automatic updates.",
-                        null,
-                        null,
-                        autoHide: true);
-                    break;
-                case NovaTerminal.Update.UpdateCheckOutcome.Failed:
-                    ShowRecordingToast("Update check failed", "Could not reach GitHub. See the debug log for details.", null, null, autoHide: true);
-                    break;
-                case NovaTerminal.Update.UpdateCheckOutcome.Disabled:
-                    // Unreachable: a manual check ignores the automatic-checks setting.
-                    break;
+                _owner = owner;
             }
+
+            // A toast IS the announcement; there is no interim state to show.
+            public void Checking()
+            {
+            }
+
+            public void AlreadyRunning()
+            {
+                _owner.ShowRecordingToast(
+                    NovaTerminal.Update.UpdateCheckMessages.AlreadyRunningTitle,
+                    NovaTerminal.Update.UpdateCheckMessages.AlreadyRunningMessage,
+                    null,
+                    null,
+                    autoHide: true);
+            }
+
+            public void CoordinatorUnavailable()
+            {
+                _owner.ShowRecordingToast(
+                    NovaTerminal.Update.UpdateCheckMessages.CoordinatorUnavailableTitle,
+                    NovaTerminal.Update.UpdateCheckMessages.CoordinatorUnavailableMessage,
+                    null,
+                    null,
+                    autoHide: true);
+            }
+
+            public void Outcome(NovaTerminal.Update.UpdateCheckOutcome outcome, string? stagedVersion)
+            {
+                switch (outcome)
+                {
+                    case NovaTerminal.Update.UpdateCheckOutcome.UpdateReady:
+                        // Show it here rather than relying on the coordinator's onUpdateReady
+                        // callback. That callback fires only when the staged version CHANGES (its
+                        // announce-once guard, which exists so a second check does not re-nag about
+                        // an update the user already dismissed). So for a user who dismissed the
+                        // toast and then asked again, the callback correctly stays silent - and
+                        // trusting it here left the manual check answering a direct question with
+                        // nothing at all, and no visible way to restart. Re-showing is idempotent:
+                        // when the callback did just fire, this sets the same text again.
+                        // (Codex P2 on #340.)
+                        _owner.ShowUpdateToast(stagedVersion ?? string.Empty);
+                        break;
+                    case NovaTerminal.Update.UpdateCheckOutcome.UpToDate:
+                    case NovaTerminal.Update.UpdateCheckOutcome.Unsupported:
+                    case NovaTerminal.Update.UpdateCheckOutcome.Failed:
+                        _owner.ShowRecordingToast(
+                            NovaTerminal.Update.UpdateCheckMessages.OutcomeTitle(outcome),
+                            NovaTerminal.Update.UpdateCheckMessages.OutcomeMessage(outcome, stagedVersion),
+                            null,
+                            null,
+                            autoHide: true);
+                        break;
+                    case NovaTerminal.Update.UpdateCheckOutcome.Disabled:
+                        // Unreachable: a manual check ignores the automatic-checks setting.
+                        break;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The "+" flyout's "About NovaTerminal...". The window only renders and reports; the
+        /// update machinery stays here so a check started from About shares the coordinator, the
+        /// in-flight guard and the announce-once state with the palette's manual check and the
+        /// deferred startup check. Wiring is by property, the same way SettingsWindow is.
+        /// </summary>
+        private async System.Threading.Tasks.Task ShowAboutWindowAsync()
+        {
+            var about = new UI.About.AboutWindow();
+            about.RunUpdateCheck = () => CheckForUpdatesInteractiveAsync(about);
+            about.ApplyStagedUpdate = ApplyStagedUpdate;
+            about.StagedVersionProvider = () => _updateCoordinator?.StagedVersion;
+
+            ApplyThemeToDialogWindow(about);
+            await about.ShowDialog(this);
         }
 
         private void SyncRecordingButtonState()

--- a/src/NovaTerminal.App/UI/About/AboutWindow.axaml
+++ b/src/NovaTerminal.App/UI/About/AboutWindow.axaml
@@ -1,0 +1,59 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        x:Class="NovaTerminal.UI.About.AboutWindow"
+        Title="About NovaTerminal"
+        Width="480"
+        SizeToContent="Height"
+        CanResize="False"
+        ShowInTaskbar="False"
+        WindowStartupLocation="CenterOwner">
+    <Window.Styles>
+        <Style Selector="Button.link">
+            <Setter Property="Padding" Value="0" />
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Foreground" Value="#4C8DFF" />
+            <Setter Property="Cursor" Value="Hand" />
+            <Setter Property="HorizontalContentAlignment" Value="Left" />
+        </Style>
+        <Style Selector="Button.link:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Foreground" Value="#7FB0FF" />
+        </Style>
+    </Window.Styles>
+    <Border Padding="20">
+        <StackPanel Spacing="16">
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <Image Width="48" Height="48" Source="avares://NovaTerminal/Assets/nova_icon.png" />
+                <StackPanel VerticalAlignment="Center" Spacing="2">
+                    <TextBlock Text="NovaTerminal" FontSize="22" FontWeight="SemiBold" />
+                    <TextBlock Name="VersionText" Opacity="0.75" />
+                </StackPanel>
+            </StackPanel>
+
+            <Separator />
+
+            <StackPanel Spacing="10">
+                <StackPanel Orientation="Horizontal" Spacing="10" VerticalAlignment="Center">
+                    <Button Name="CheckForUpdatesButton" Content="Check for updates" Click="OnCheckForUpdatesClick" />
+                    <ProgressBar Name="CheckProgress" IsIndeterminate="True" Width="110" Height="6"
+                                 IsVisible="False" VerticalAlignment="Center" />
+                </StackPanel>
+                <TextBlock Name="StatusText" TextWrapping="Wrap" IsVisible="False" />
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <Button Name="RestartNowButton" Content="Restart now" IsVisible="False" Click="OnRestartNowClick" />
+                    <Button Name="OpenReleasesButton" Content="Open releases page" IsVisible="False" Click="OnOpenReleasesClick" />
+                </StackPanel>
+            </StackPanel>
+
+            <Separator />
+
+            <StackPanel Orientation="Horizontal" Spacing="16">
+                <Button Classes="link" Content="GitHub repository" Click="OnOpenRepoClick" />
+                <Button Classes="link" Content="Releases" Click="OnOpenReleasesClick" />
+            </StackPanel>
+
+            <Button Name="CloseButton" Content="Close" Width="96" HorizontalAlignment="Right" Click="OnCloseClick" />
+        </StackPanel>
+    </Border>
+</Window>

--- a/src/NovaTerminal.App/UI/About/AboutWindow.axaml.cs
+++ b/src/NovaTerminal.App/UI/About/AboutWindow.axaml.cs
@@ -1,0 +1,209 @@
+using System;
+using System.Reflection;
+using System.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Interactivity;
+using Avalonia.Markup.Xaml;
+using Avalonia.Media;
+using Avalonia.Platform;
+using NovaTerminal.Update;
+
+namespace NovaTerminal.UI.About;
+
+/// <summary>
+/// The "+" flyout's About dialog: identity (icon, name, version) plus the one question a user
+/// usually opens it to ask - "is there an update?". The window only renders; the check itself
+/// runs on MainWindow's shared pipeline (same coordinator, in-flight guard and announce-once
+/// state as the palette's manual check), injected as delegates by <c>ShowAboutWindowAsync</c>
+/// - property injection, the same way SettingsWindow is wired.
+/// </summary>
+public partial class AboutWindow : Window, IUpdateCheckFeedback
+{
+    private const string RepoUrl = "https://github.com/benyblack/NovaTerminal";
+    private const string ReleasesUrl = RepoUrl + "/releases";
+
+    public AboutWindow()
+    {
+        InitializeComponent();
+
+        try
+        {
+            Icon = new WindowIcon(AssetLoader.Open(new Uri("avares://NovaTerminal/Assets/nova_icon.ico")));
+        }
+        catch (Exception)
+        {
+            // A missing icon must not take the About window down; the title bar still reads fine.
+        }
+
+        var versionText = this.FindControl<TextBlock>("VersionText");
+        if (versionText != null)
+        {
+            versionText.Text = "Version " + ResolveAppVersion();
+        }
+
+        KeyDown += (_, e) =>
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+            }
+        };
+    }
+
+    /// <summary>Runs one interactive check on MainWindow's pipeline, reporting back via this window.</summary>
+    public Func<Task>? RunUpdateCheck { get; set; }
+
+    /// <summary>MainWindow's ApplyStagedUpdate, teardown included.</summary>
+    public Action? ApplyStagedUpdate { get; set; }
+
+    /// <summary>Reads the coordinator's staged version, so the window shows an already-staged update on open.</summary>
+    public Func<string?>? StagedVersionProvider { get; set; }
+
+    protected override void OnOpened(EventArgs e)
+    {
+        base.OnOpened(e);
+
+        // An update staged before this window opened (the user dismissed the main-window toast)
+        // should answer the window's central question without making them press the button and
+        // wait for a re-check that would only re-find what is already on disk.
+        if (StagedVersionProvider?.Invoke() is { } staged)
+        {
+            Outcome(UpdateCheckOutcome.UpdateReady, staged);
+        }
+    }
+
+    public void Checking()
+    {
+        var button = this.FindControl<Button>("CheckForUpdatesButton");
+        var progress = this.FindControl<ProgressBar>("CheckProgress");
+        var status = this.FindControl<TextBlock>("StatusText");
+        if (button != null) button.IsEnabled = false;
+        if (progress != null) progress.IsVisible = true;
+        if (status != null)
+        {
+            status.IsVisible = true;
+            status.Text = "Checking for updates…";
+        }
+    }
+
+    public void AlreadyRunning()
+    {
+        ShowStatus(UpdateCheckMessages.AlreadyRunningMessage);
+    }
+
+    public void CoordinatorUnavailable()
+    {
+        ShowStatus(UpdateCheckMessages.CoordinatorUnavailableMessage);
+    }
+
+    public void Outcome(UpdateCheckOutcome outcome, string? stagedVersion)
+    {
+        var button = this.FindControl<Button>("CheckForUpdatesButton");
+        var progress = this.FindControl<ProgressBar>("CheckProgress");
+        var restart = this.FindControl<Button>("RestartNowButton");
+        var releases = this.FindControl<Button>("OpenReleasesButton");
+        if (button != null) button.IsEnabled = true;
+        if (progress != null) progress.IsVisible = false;
+
+        ShowStatus(UpdateCheckMessages.OutcomeMessage(outcome, stagedVersion));
+
+        // Failed-while-staged must not hide the restart affordance: the staged update is still
+        // on disk even though the re-check could not reach the feed.
+        var stillStaged = outcome != UpdateCheckOutcome.UpdateReady && StagedVersionProvider?.Invoke() != null;
+        if (restart != null)
+        {
+            restart.IsVisible = UpdateCheckMessages.OutcomeOffersRestart(outcome) || stillStaged;
+        }
+
+        if (releases != null)
+        {
+            releases.IsVisible = outcome == UpdateCheckOutcome.Unsupported;
+        }
+    }
+
+    private void ShowStatus(string message)
+    {
+        var progress = this.FindControl<ProgressBar>("CheckProgress");
+        var status = this.FindControl<TextBlock>("StatusText");
+        if (progress != null) progress.IsVisible = false;
+        if (status != null)
+        {
+            status.IsVisible = true;
+            status.Text = message;
+        }
+    }
+
+    private async void OnCheckForUpdatesClick(object? sender, RoutedEventArgs e)
+    {
+        var run = RunUpdateCheck;
+        if (run == null)
+        {
+            return;
+        }
+
+        Checking();
+        try
+        {
+            await run();
+        }
+        catch (Exception ex)
+        {
+            // The pipeline reports every ordinary outcome through IUpdateCheckFeedback; this only
+            // catches a throw from the plumbing itself, so the window never looks hung.
+            NovaTerminal.VT.TerminalLogger.Log("About-window update check failed unexpectedly: " + ex);
+            Outcome(UpdateCheckOutcome.Failed, null);
+        }
+    }
+
+    private void OnRestartNowClick(object? sender, RoutedEventArgs e)
+    {
+        // MainWindow's ApplyStagedUpdate runs the full app teardown before handing off to
+        // Velopack and owns its own failure reporting; if it returns, the restart did not
+        // happen and this window is still usable.
+        ApplyStagedUpdate?.Invoke();
+    }
+
+    private void OnOpenRepoClick(object? sender, RoutedEventArgs e)
+    {
+        _ = OpenExternalUrlAsync(RepoUrl);
+    }
+
+    private void OnOpenReleasesClick(object? sender, RoutedEventArgs e)
+    {
+        _ = OpenExternalUrlAsync(ReleasesUrl);
+    }
+
+    private void OnCloseClick(object? sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private async Task OpenExternalUrlAsync(string url)
+    {
+        // Same boundary as AgentOutputPanel's link handling: only web URLs may reach the OS
+        // shell handler, and the launcher fails soft when no TopLevel is attached.
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != "http" && uri.Scheme != "https"))
+        {
+            return;
+        }
+
+        var topLevel = TopLevel.GetTopLevel(this);
+        if (topLevel is not null)
+        {
+            await topLevel.Launcher.LaunchUriAsync(uri);
+        }
+    }
+
+    /// <summary>The same attribute-based resolution BackupService uses; the informational version is what the build pins.</summary>
+    private static string ResolveAppVersion() =>
+        Assembly.GetEntryAssembly()?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? Assembly.GetEntryAssembly()?.GetName().Version?.ToString()
+        ?? "unknown";
+
+    private void InitializeComponent()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/src/NovaTerminal.App/UI/About/AboutWindow.axaml.cs
+++ b/src/NovaTerminal.App/UI/About/AboutWindow.axaml.cs
@@ -99,14 +99,10 @@ public partial class AboutWindow : Window, IUpdateCheckFeedback
 
     public void Outcome(UpdateCheckOutcome outcome, string? stagedVersion)
     {
-        var button = this.FindControl<Button>("CheckForUpdatesButton");
-        var progress = this.FindControl<ProgressBar>("CheckProgress");
+        ShowStatus(UpdateCheckMessages.OutcomeMessage(outcome, stagedVersion));
+
         var restart = this.FindControl<Button>("RestartNowButton");
         var releases = this.FindControl<Button>("OpenReleasesButton");
-        if (button != null) button.IsEnabled = true;
-        if (progress != null) progress.IsVisible = false;
-
-        ShowStatus(UpdateCheckMessages.OutcomeMessage(outcome, stagedVersion));
 
         // Failed-while-staged must not hide the restart affordance: the staged update is still
         // on disk even though the re-check could not reach the feed.
@@ -122,10 +118,19 @@ public partial class AboutWindow : Window, IUpdateCheckFeedback
         }
     }
 
+    /// <summary>
+    /// Shows a terminal answer and ends the check state. Every path that ends a check - a real
+    /// outcome, the already-running answer, or the broken-coordinator answer - comes through
+    /// here, because the pipeline returns early on the latter two without calling Outcome; each
+    /// of them must re-enable the button, or one early answer leaves the window looking stuck
+    /// mid-check forever.
+    /// </summary>
     private void ShowStatus(string message)
     {
+        var button = this.FindControl<Button>("CheckForUpdatesButton");
         var progress = this.FindControl<ProgressBar>("CheckProgress");
         var status = this.FindControl<TextBlock>("StatusText");
+        if (button != null) button.IsEnabled = true;
         if (progress != null) progress.IsVisible = false;
         if (status != null)
         {

--- a/src/NovaTerminal.App/Update/IUpdateCheckFeedback.cs
+++ b/src/NovaTerminal.App/Update/IUpdateCheckFeedback.cs
@@ -1,0 +1,35 @@
+namespace NovaTerminal.Update
+{
+    /// <summary>
+    /// Where one interactive update check reports its progress and its answer. Two surfaces share
+    /// a single check pipeline (<see cref="UpdateCoordinator"/>): the main window's toasts (the
+    /// palette's "Check for updates") and the About window's inline status area. Every call
+    /// arrives on the UI thread - the check's continuation resumes there by design.
+    /// </summary>
+    public interface IUpdateCheckFeedback
+    {
+        /// <summary>The check has started and is running.</summary>
+        void Checking();
+
+        /// <summary>
+        /// Another check (manual, or the deferred startup one) is already in flight, so no second
+        /// download was started.
+        /// </summary>
+        void AlreadyRunning();
+
+        /// <summary>
+        /// The coordinator could not be constructed at all - a broken install, not a check
+        /// result, so the wording differs from a <see cref="UpdateCheckOutcome.Failed"/> answer.
+        /// </summary>
+        void CoordinatorUnavailable();
+
+        /// <summary>The check finished with this answer.</summary>
+        /// <param name="outcome">How the check ended.</param>
+        /// <param name="stagedVersion">
+        /// The version waiting for a restart when <paramref name="outcome"/> is
+        /// <see cref="UpdateCheckOutcome.UpdateReady"/>; the coordinator's
+        /// <see cref="UpdateCoordinator.StagedVersion"/>, not necessarily this outcome's version.
+        /// </param>
+        void Outcome(UpdateCheckOutcome outcome, string? stagedVersion);
+    }
+}

--- a/src/NovaTerminal.App/Update/UpdateCheckMessages.cs
+++ b/src/NovaTerminal.App/Update/UpdateCheckMessages.cs
@@ -1,0 +1,48 @@
+namespace NovaTerminal.Update
+{
+    /// <summary>
+    /// The words every surface that answers "is there an update?" uses. The palette path shows
+    /// them in toasts, the About window shows them inline; sharing one source keeps the two from
+    /// drifting. UI-free by design so the mapping is unit-testable in the gating CI loop.
+    /// </summary>
+    public static class UpdateCheckMessages
+    {
+        public static string OutcomeTitle(UpdateCheckOutcome outcome) => outcome switch
+        {
+            UpdateCheckOutcome.UpdateReady => "Update ready",
+            UpdateCheckOutcome.UpToDate => "Up to date",
+            UpdateCheckOutcome.Unsupported => "Updates unavailable",
+            UpdateCheckOutcome.Failed => "Update check failed",
+            UpdateCheckOutcome.Disabled => "Automatic updates are off",
+            _ => "Update check",
+        };
+
+        public static string OutcomeMessage(UpdateCheckOutcome outcome, string? stagedVersion) => outcome switch
+        {
+            UpdateCheckOutcome.UpdateReady =>
+                $"NovaTerminal {stagedVersion ?? "(unknown version)"} is downloaded and will be applied when you restart.",
+            UpdateCheckOutcome.UpToDate => "You are running the newest version.",
+            UpdateCheckOutcome.Unsupported =>
+                "This build was not installed by the NovaTerminal installer, so it cannot update itself. " +
+                "Download the installer from the releases page to get automatic updates.",
+            UpdateCheckOutcome.Failed => "Could not reach GitHub. See the debug log for details.",
+
+            // Unreachable from a manual check - RunManualCheckAsync deliberately ignores the
+            // automatic-checks setting - but kept so the mapping is total over the enum.
+            UpdateCheckOutcome.Disabled => "Automatic update checks are switched off in settings.",
+            _ => "The update check ended without an answer.",
+        };
+
+        /// <summary>Whether this answer comes with a restart affordance.</summary>
+        public static bool OutcomeOffersRestart(UpdateCheckOutcome outcome)
+            => outcome == UpdateCheckOutcome.UpdateReady;
+
+        public const string AlreadyRunningTitle = "Checking for updates";
+        public const string AlreadyRunningMessage =
+            "A check is already running in the background. If it finds a new version, you'll get a notification.";
+
+        public const string CoordinatorUnavailableTitle = "Update check failed";
+        public const string CoordinatorUnavailableMessage =
+            "Could not check for updates. See the debug log for details.";
+    }
+}

--- a/tests/NovaTerminal.Architecture.Tests/Update/UpdateCheckMessagesTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/Update/UpdateCheckMessagesTests.cs
@@ -1,0 +1,76 @@
+using System;
+using NovaTerminal.Update;
+
+namespace NovaTerminal.Architecture.Tests;
+
+/// <summary>
+/// Same home as <see cref="UpdateCoordinatorTests"/> for the same reason: this project is in the
+/// gating CI loop that <c>ci.yml</c> and <c>release.yml</c> run, while <c>App.Tests</c> is not.
+/// These pin the wording contract shared by the palette's toasts and the About window's inline
+/// result - both render through <see cref="UpdateCheckMessages"/>, so a regression here blocks
+/// the build before either surface can drift from the other.
+/// </summary>
+public class UpdateCheckMessagesTests
+{
+    [Fact]
+    public void Update_ready_names_the_staged_version_and_offers_a_restart()
+    {
+        var message = UpdateCheckMessages.OutcomeMessage(UpdateCheckOutcome.UpdateReady, "0.8.0");
+
+        Assert.Equal("Update ready", UpdateCheckMessages.OutcomeTitle(UpdateCheckOutcome.UpdateReady));
+        Assert.Contains("0.8.0", message);
+        Assert.True(UpdateCheckMessages.OutcomeOffersRestart(UpdateCheckOutcome.UpdateReady));
+    }
+
+    [Fact]
+    public void Update_ready_tolerates_a_missing_staged_version()
+    {
+        // Outcome's contract guarantees a non-blank version, but the message is rendered from the
+        // coordinator's StagedVersion passed through callers that may hand back null; it must stay
+        // presentable rather than emit "NovaTerminal  is downloaded...".
+        var message = UpdateCheckMessages.OutcomeMessage(UpdateCheckOutcome.UpdateReady, null);
+
+        Assert.DoesNotContain("  ", message);
+    }
+
+    [Fact]
+    public void Unsupported_points_at_the_releases_page_and_offers_no_restart()
+    {
+        var message = UpdateCheckMessages.OutcomeMessage(UpdateCheckOutcome.Unsupported, null);
+
+        Assert.Contains("releases", message);
+        Assert.False(UpdateCheckMessages.OutcomeOffersRestart(UpdateCheckOutcome.Unsupported));
+    }
+
+    [Fact]
+    public void The_plain_answers_keep_their_words_and_no_restart()
+    {
+        Assert.Equal("Up to date", UpdateCheckMessages.OutcomeTitle(UpdateCheckOutcome.UpToDate));
+        Assert.Equal("You are running the newest version.",
+            UpdateCheckMessages.OutcomeMessage(UpdateCheckOutcome.UpToDate, null));
+        Assert.False(UpdateCheckMessages.OutcomeOffersRestart(UpdateCheckOutcome.UpToDate));
+
+        Assert.Equal("Update check failed", UpdateCheckMessages.OutcomeTitle(UpdateCheckOutcome.Failed));
+        Assert.Contains("GitHub", UpdateCheckMessages.OutcomeMessage(UpdateCheckOutcome.Failed, null));
+        Assert.False(UpdateCheckMessages.OutcomeOffersRestart(UpdateCheckOutcome.Failed));
+    }
+
+    [Fact]
+    public void Every_outcome_has_a_title_and_a_message()
+    {
+        foreach (UpdateCheckOutcome outcome in Enum.GetValues<UpdateCheckOutcome>())
+        {
+            Assert.False(string.IsNullOrWhiteSpace(UpdateCheckMessages.OutcomeTitle(outcome)), outcome.ToString());
+            Assert.False(string.IsNullOrWhiteSpace(UpdateCheckMessages.OutcomeMessage(outcome, "9.9.9")), outcome.ToString());
+        }
+    }
+
+    [Fact]
+    public void The_in_flight_and_broken_coordinator_answers_are_presentable()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(UpdateCheckMessages.AlreadyRunningTitle));
+        Assert.False(string.IsNullOrWhiteSpace(UpdateCheckMessages.AlreadyRunningMessage));
+        Assert.False(string.IsNullOrWhiteSpace(UpdateCheckMessages.CoordinatorUnavailableTitle));
+        Assert.False(string.IsNullOrWhiteSpace(UpdateCheckMessages.CoordinatorUnavailableMessage));
+    }
+}


### PR DESCRIPTION
## Summary

NovaTerminal had no About surface anywhere — no way to see the running version without reading a log — and the manual update check existed only as the palette's "Update: Check for updates", answered through main-window toasts. This adds a proper About window and embeds the check in it.

## Changes

- **`UI/About/AboutWindow`** (new): modal dialog with the app icon, name, and version (resolved from `AssemblyInformationalVersionAttribute`, the same attribute-based resolution `BackupService` uses). It carries a "Check for updates" button with an **inline** result: indeterminate progress while checking, then the outcome text — "Up to date", "Update ready" with a **Restart now** button, or an "Open releases page" button for non-installer builds. If an update is already staged when the window opens (e.g. the toast was dismissed), that state shows immediately; a failed re-check never hides the restart affordance while an update is still on disk. Repo/releases links open through Avalonia's launcher behind an https-only guard (same boundary as `AgentOutputPanel`).
- **Entry point**: "About NovaTerminal..." as the last item of the title-bar "+" flyout. No palette entry; the existing "Update: Check for updates" palette command is unchanged.
- **Shared pipeline**: `CheckForUpdatesInteractiveAsync` gains an optional `NovaTerminal.Update.IUpdateCheckFeedback`. Without one it constructs `ToastUpdateCheckFeedback` — the pre-existing toast behavior, strings now sourced from `UpdateCheckMessages`. The About window implements the interface to render inline. A check started from About shares the coordinator, the `_updateCheckInFlight` guard, and the announce-once state with the palette and startup checks, so there is no way to race a second download into the staging directory.
- **`UpdateCheckMessages`** (new, UI-free): single source for outcome → title/message/restart-affordance, so the toast path and the About window cannot drift; pinned by `UpdateCheckMessagesTests` in the gating Architecture loop.
- Design note: `docs/plans/2026-09-04-about-window-design.md`.

## Deliberately out of scope

No pinnable title-bar button, no new `TerminalSettings` fields (hence no `SettingsTools` schema/drift-guard edits and no effective-settings whitelist change), no MCP app-info tool.

## Verification

- `scripts/build.sh build src/NovaTerminal.App` — 0 errors.
- Full `scripts/build.sh test tests/NovaTerminal.Architecture.Tests` — 67/67 passed (includes the 6 new `UpdateCheckMessagesTests` plus the existing `UpdateCoordinatorTests` / `UpdateSettingsTests`).