### PR TITLE
fix(vt): stop the post-image newline swallow leaking past other output

### DIFF
--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -232,6 +232,22 @@ namespace NovaTerminal.VT
         {
             if (_textBuffer.Length > 0)
             {
+                // Printable output closes the window in which a post-image newline may be
+                // swallowed. The flag means "absorb the newline the image-emitting program sends
+                // immediately after its picture" - once anything else has been printed, a newline
+                // is the program's own line break and must not be eaten.
+                //
+                // ExecuteControl's single-character path already clears it for the same reason, but
+                // printable text does not go through there: it accumulates in _textBuffer and lands
+                // here, so the flag used to survive arbitrary output. Only HandleITerm2Image armed
+                // it, and imgcat-style emitters send their newline straight after the image, so the
+                // flag was always consumed before anything could reveal that. Arming it for sixel
+                // too (#405) surfaced it: `cat` of a sixel file sends no trailing newline, the flag
+                // stayed live across the whole next prompt, and it swallowed the line break between
+                // the following command's echo and its output - rendering `echo done` / `done` as
+                // `echo donedone`.
+                _swallowNextNewline = false;
+
                 _buffer.WriteContent(_textBuffer.ToString());
                 _textBuffer.Clear();
             }

--- a/tests/NovaTerminal.VT.Tests/InlineImageCursorTests.cs
+++ b/tests/NovaTerminal.VT.Tests/InlineImageCursorTests.cs
@@ -89,6 +89,43 @@ public class InlineImageCursorTests
         Assert.Equal(0, buffer.CursorCol);
     }
 
+    // The swallow-the-next-newline flag is scoped to "immediately after the image". A program that
+    // emits an image and sends no trailing newline - `cat` of a sixel file is the ordinary case -
+    // leaves the flag armed, and it must not then eat a line break belonging to whatever runs next.
+    // It did: the flag survived a whole shell prompt (printable text is buffered and flushed through
+    // WriteContent, which never cleared it) and swallowed the newline between the next command's
+    // echo and its output, rendering `echo done` / `done` as `echo donedone`.
+    [Fact]
+    public void A_newline_after_other_output_is_not_swallowed()
+    {
+        (TerminalBuffer buffer, AnsiParser parser) = NewTerminal();
+
+        parser.Process("\x1bPq#0;2;0;0;0#0~~~\x1b\\");
+        parser.Process("echo done");
+
+        int rowAfterText = CursorViewRow(buffer);
+        parser.Process("\r\n");
+
+        Assert.Equal(rowAfterText + 1, CursorViewRow(buffer));
+        Assert.Equal(0, buffer.CursorCol);
+    }
+
+    // The other half of the same contract, so a fix for the above cannot simply disarm the flag:
+    // a newline that really does arrive first is still absorbed, and the image is not followed by a
+    // blank line.
+    [Fact]
+    public void A_newline_arriving_first_is_still_swallowed_after_a_sixel_image()
+    {
+        (TerminalBuffer buffer, AnsiParser parser) = NewTerminal();
+
+        parser.Process("\x1bPq#0;2;0;0;0#0~~~\x1b\\");
+        int rowAfterImage = CursorViewRow(buffer);
+
+        parser.Process("\r\n");
+
+        Assert.Equal(rowAfterImage, CursorViewRow(buffer));
+        Assert.Equal(0, buffer.CursorCol);
+    }
     private static (TerminalBuffer, AnsiParser) NewTerminal(bool? forceConPtyFiltering = null)
     {
         var buffer = new TerminalBuffer(Cols, Rows);


### PR DESCRIPTION
Follow-up to #407, which I merged earlier today and which surfaced this. Caught while regenerating the screenshot assets against it — the sixel capture rendered `echo done` / `done` as **`echo donedone`**.

## What went wrong

#407 armed the swallow-next-newline flag for sixel and Kitty as well as iTerm2, so the newline an image-emitting program sends after its picture is absorbed and the image is not followed by a blank line. That was the right call, and it exposed a latent scoping bug in the flag.

`ExecuteControl`'s single-character path clears the flag as soon as anything other than a newline arrives — the intended "only if it comes immediately" scope. **Printable text never goes through there**: it accumulates in `_textBuffer` and is flushed via `WriteContent`, which left the flag untouched. So the flag could survive arbitrary output.

Nothing revealed that while only iTerm2 armed it, because imgcat-style emitters send their newline straight after the image and consume the flag at once. `cat` of a sixel file sends no trailing newline, so the flag stayed live across the whole following shell prompt and then ate the line break between the next command's echo and its output.

## The fix

One line in `FlushText`. Printable output ends the window in which a post-image newline may be swallowed; after it, a newline is the program's own line break.

## Tests

Both halves of the contract are pinned, so a future fix cannot just disarm the flag:

- `A_newline_after_other_output_is_not_swallowed` — the regression
- `A_newline_arriving_first_is_still_swallowed_after_a_sixel_image` — the behaviour #407 wanted

Removing the one-line fix fails the first and leaves the second passing. Full VT suite: 438 passed.

Verified end-to-end: the sixel capture that produced `donedone` now renders `echo done` / `done` correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)