### PR TITLE
ci(app-tests): a runner-level abort now fails the gate, hang or no hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,9 +366,11 @@ jobs:
             2>&1 | tee tests/NovaTerminal.App.Tests/TestResults/platformboot/console.log
 
       # Gates the lane above on its own results: any failing test not named in
-      # tests/app-tests-known-flaky.txt fails this job. A missing trx is the #81 hang and
-      # only warns — there are no results to judge. Runs on failure too, so a non-zero
-      # `dotnet test` still gets its results read.
+      # tests/app-tests-known-flaky.txt fails this job, as does a runner-level abort in the
+      # console log — those kill a whole collection without writing a result, so the trx
+      # cannot see them. A missing trx is the #81 hang and only warns; there are no results to
+      # judge, and that hang is the one thing this lane exists to tolerate. Runs on failure
+      # too, so a non-zero `dotnet test` still gets its results read.
       # The gate decides whether this lane may report success, so its own branching is worth
       # a second of CI: the truncation and abort rules are what stop another green-but-broken
       # run, and getting them backwards would either red every PR or hide the next one.
@@ -421,10 +423,14 @@ jobs:
         with:
           name: unit-tests-${{ runner.os }}
           retention-days: 5
-          # *.dmp captures the blame-hang minidump on a teardown hang (#81).
+          # *.dmp captures the blame-hang minidump on a teardown hang (#81). console.log is
+          # the tee'd App.Tests output, and it is here because it is the only place a
+          # runner-level abort exists: those now fail the gate, so the evidence for a red run
+          # has to outlive the job log rather than being buried in it.
           path: |
             **/*.trx
             **/*.dmp
+            **/TestResults/*/console.log
 
   # Native SSH end-to-end against a real sshd in a container.
   #

--- a/scripts/check-app-tests-baseline.py
+++ b/scripts/check-app-tests-baseline.py
@@ -19,15 +19,24 @@ So the hang stays non-blocking and the *results* become blocking:
     collection aborts reported "no failures" and went green, minutes after the same branch
     had run all 3,434. Truncation is only tolerated for the one cause this lane exists to
     tolerate, the #81 teardown hang, which leaves a hang dump behind to prove itself.
-  * A catastrophic (runner-level) failure in the step log is surfaced with its count, but
-    does not block - yet. Those aborts kill whole collections without ever appearing in the
-    trx, which is why the summary can read "no failures" precisely because tests were never
-    run. They are not blocking because they are currently happening on every run, including
-    ones that complete the whole suite cleanly (21208fd: 3,434 executed, 0 failures, 10
-    aborts), so blocking on them would red every PR and teach everyone to ignore this lane -
-    the dynamic that let the truncation hide. Flip it to blocking once the remaining source
-    of thread-affine Avalonia state is fixed; the floor above is what protects coverage in
-    the meantime, and it discriminates properly (3,434 passes, 1,112 does not).
+  * A catastrophic (runner-level) failure in the step log *fails* this step, hang or no hang.
+    Those aborts kill whole collections without ever appearing in the trx, which is why the
+    summary can read "no failures" precisely because tests were never run. They used to be
+    reported and tolerated, and the tolerance was earned: they fired on every run, including
+    ones that completed the whole suite cleanly (21208fd: 3,434 executed, 0 failures, 10
+    aborts), so blocking would have redded every PR and taught everyone to ignore this lane -
+    the dynamic that let the truncation hide in the first place. #411 removed their cause, a
+    Timer callback in AgentOutputRegionTracker that let exceptions escape onto a threadpool
+    thread, and the count went to zero on both OS lanes of a full run. The tolerance has been
+    spent, so it is withdrawn: zero is now the only acceptable number, and the next one to
+    appear is a regression rather than weather.
+
+    Unlike truncation, this check is not waived by a hang dump, because an abort is not
+    something the #81 teardown hang produces: the blame collector kills the testhost rather
+    than letting it print, and runs have been observed hanging with zero aborts, never the
+    reverse. Waiving it under a dump would reopen exactly the hole this gate was extended to
+    close, one job-run in three wide. If that reasoning is ever wrong it surfaces as a red PR
+    naming the abort, not as another green-but-broken run.
 
 Names are matched as substrings, so an allowlist entry without theory arguments covers
 every case of that theory.
@@ -119,25 +128,30 @@ def hang_dumps(trx: Path) -> list[Path]:
     return sorted(results_dir.rglob("*hangdump*.dmp"))
 
 
-def main() -> int:
-    if len(sys.argv) not in (4, 5):
-        print(
-            f"usage: {Path(sys.argv[0]).name} <trx-path> <allowlist-path> <min-executed> "
-            f"[log-path]",
-            file=sys.stderr,
-        )
-        return 2
+def report_aborts(aborts: list[str], trx: Path) -> None:
+    """
+    Announce runner-level aborts as the blocking failure they are.
 
-    trx = Path(sys.argv[1])
-    allowlist_path = Path(sys.argv[2])
-    try:
-        min_executed = int(sys.argv[3])
-    except ValueError:
-        print(f"min-executed must be an integer, got {sys.argv[3]!r}", file=sys.stderr)
-        return 2
-    log_path = Path(sys.argv[4]) if len(sys.argv) == 5 else None
+    Kept separate from the result judgement below, and applied to every exit path including
+    the tolerated ones, because an abort is independent evidence: it says a collection died
+    unread, which no trx and no hang dump can either confirm or excuse.
+    """
+    summary(
+        f"::error::App.Tests hit {len(aborts)} runner-level abort(s) "
+        f"({len(set(aborts))} distinct). Each one kills a whole xUnit collection without "
+        f"writing a result, so they are invisible to {trx.name} and the tests they took with "
+        f"them cannot be said to have passed. This is blocking as of #411, which fixed the "
+        f"cause and left both OS lanes at zero; a hang dump does not excuse it, because the "
+        f"#81 hang does not produce aborts. Find what threw and contain it at its source - do "
+        f"not reach for the allowlist, which cannot name a test that never reported."
+    )
+    for line in sorted(set(aborts)):
+        summary(f"  - {line}")
+
+
+def judge(trx: Path, allowlist_path: Path, min_executed: int) -> int:
+    """Judge the lane's recorded results. Aborts are the caller's verdict, not this one's."""
     dumps = hang_dumps(trx)
-    aborts = catastrophic_failures(log_path) if log_path else []
 
     if not trx.is_file():
         if dumps:
@@ -171,36 +185,21 @@ def main() -> int:
             f"reached are neither passed nor failed. The failures below are judged as usual."
         )
 
-    # Both checks below are skipped when a hang dump is present, and that is deliberate rather
-    # than lenient: the #81 hang truncates runs on roughly one job-run in three, and this lane
-    # is non-blocking precisely so that cannot red unrelated PRs. What they close is the other
-    # case - a run cut short with nothing hung, which had no signal at all.
-    truncated = executed < min_executed
-    if aborts and not dumps:
-        # A warning, not an error: see the module docstring. These fire on healthy full runs
-        # too, so blocking here would red every PR rather than telling anyone anything new.
-        summary(
-            f"::warning::App.Tests hit {len(aborts)} runner-level abort(s) "
-            f"({len(set(aborts))} distinct) with no hang dump, so this is not the #81 hang. "
-            f"Each one kills a whole xUnit collection without writing a result, so they are "
-            f"invisible to {trx.name}. Not blocking yet - they occur on complete runs as well, "
-            f"and the executed-count floor is what guards coverage until the underlying "
-            f"thread-affine state is fixed."
-        )
-        for line in sorted(set(aborts)):
-            summary(f"  - {line}")
-
-    if truncated and not dumps:
+    # The floor is waived when a hang dump is present, and that is deliberate rather than
+    # lenient: the #81 hang truncates runs on roughly one job-run in three, and this lane is
+    # non-blocking precisely so that cannot red unrelated PRs. What it closes is the other
+    # case - a run cut short with nothing hung, which had no signal at all. Note that the
+    # abort check in main() takes no such waiver; see the module docstring for why the two
+    # truncation causes are treated differently.
+    if executed < min_executed and not dumps:
         summary(
             f"::error::App.Tests executed {executed} test(s), below this lane's floor of "
             f"{min_executed}, and nothing hung. The missing tests did not pass - they never "
             f"ran. If the lane legitimately has fewer tests now, lower the floor in ci.yml "
             f"deliberately; do not let a truncated run report success."
         )
-
-    if truncated and not dumps:
-        # Reported before returning so the failure list is still visible: knowing which tests
-        # failed in the part that did run is useful even when the run is being rejected.
+        # Listed before returning so the failures are still visible: knowing which tests failed
+        # in the part that did run is useful even when the run is being rejected.
         if failures:
             summary(f"Failures recorded before the run was cut short ({len(failures)}):")
             for name in failures:
@@ -235,6 +234,36 @@ def main() -> int:
         f"Do not widen the list to make a red build green."
     )
     return 1
+
+
+def main() -> int:
+    if len(sys.argv) not in (4, 5):
+        print(
+            f"usage: {Path(sys.argv[0]).name} <trx-path> <allowlist-path> <min-executed> "
+            f"[log-path]",
+            file=sys.stderr,
+        )
+        return 2
+
+    trx = Path(sys.argv[1])
+    allowlist_path = Path(sys.argv[2])
+    try:
+        min_executed = int(sys.argv[3])
+    except ValueError:
+        print(f"min-executed must be an integer, got {sys.argv[3]!r}", file=sys.stderr)
+        return 2
+    log_path = Path(sys.argv[4]) if len(sys.argv) == 5 else None
+
+    aborts = catastrophic_failures(log_path) if log_path else []
+    code = judge(trx, allowlist_path, min_executed)
+
+    # Reported after the result judgement, and overriding it, so the log ends on the reason the
+    # step is red. A tolerated outcome above - the #81 hang, with or without a trx - still loses
+    # here: those are excuses for missing *results*, not for a collection that died unread.
+    if aborts:
+        report_aborts(aborts, trx)
+        return 1
+    return code
 
 
 if __name__ == "__main__":

--- a/scripts/tests/check_app_tests_baseline_tests.py
+++ b/scripts/tests/check_app_tests_baseline_tests.py
@@ -8,6 +8,10 @@ hang dump). Getting any of those backwards either reds every PR or hides another
 green-but-broken run - the exact failure this gate was extended to stop, where a job executed
 1,112 of 3,434 tests and reported "no failures".
 
+The two truncation causes are deliberately not symmetric, which is the pairing most worth
+pinning down here: a hang dump waives the executed-count floor and does *not* waive the abort
+check. Cases exist for both halves so that neither can be "simplified" into the other.
+
 Plain python with no test framework, matching the rest of scripts/. Run it directly:
 
     python scripts/tests/check_app_tests_baseline_tests.py
@@ -38,7 +42,11 @@ def make_trx(path: Path, passed: int, failed_names=()):
 def run(case, trx, floor, log=None, dump=False):
     root = Path(tempfile.mkdtemp())
     trx_path = root / "lane" / "unit_app.trx"
-    make_trx(trx_path, trx["passed"], trx.get("failed", ()))
+    if trx is None:
+        # No trx at all - a crash, a kill, or a testhost that never got to write one.
+        trx_path.parent.mkdir(parents=True, exist_ok=True)
+    else:
+        make_trx(trx_path, trx["passed"], trx.get("failed", ()))
     if dump:
         (trx_path.parent / "testhost_1_hangdump.dmp").write_bytes(b"\x00")
     args = [sys.executable, str(GATE), str(trx_path), str(ALLOW), str(floor)]
@@ -64,16 +72,24 @@ cases = [
     ("healthy full run",                      {"passed": 3434},          3300,  "",        False, 0),
     ("truncated, nothing hung",               {"passed": 1112},          3300,  "",        False, 1),
     ("truncated but hung (#81, tolerated)",   {"passed": 1112},          3300,  "",        True,  0),
-    # Aborts warn rather than block: they fire on complete, clean runs too (21208fd ran all
-    # 3,434 with 10 of them), so blocking would red every PR and train everyone to ignore
-    # this lane. The floor is what guards coverage until the underlying cause is fixed.
-    ("aborts in log, full run, warns only",   {"passed": 3434},          3300,  ABORT_LOG, False, 0),
-    ("aborts in log but hung (tolerated)",    {"passed": 3434},          3300,  ABORT_LOG, True,  0),
-    ("truncated and aborted, floor blocks",   {"passed": 1112},          3300,  ABORT_LOG, False, 1),
+    # Aborts block, and nothing waives them - not a clean full run, not a hang dump. They were
+    # tolerated while they fired on every run including complete ones (21208fd ran all 3,434
+    # with 10 of them); #411 fixed the cause and both OS lanes went to zero, so the next one is
+    # a regression. The pair below is the asymmetry: the same dump that excuses the count in
+    # "truncated but hung" does not excuse an abort.
+    ("aborts in log, full run, blocks",       {"passed": 3434},          3300,  ABORT_LOG, False, 1),
+    ("aborts in log and hung, still blocks",  {"passed": 3434},          3300,  ABORT_LOG, True,  1),
+    ("truncated and aborted, blocks",         {"passed": 1112},          3300,  ABORT_LOG, False, 1),
     ("unlisted failure, full run",            {"passed": 3400, "failed": ["Totally.New.Test"]}, 3300, "", False, 1),
     ("no log argument, healthy",              {"passed": 3434},          3300,  None,      False, 0),
     ("no log argument, truncated",            {"passed": 10},            3300,  None,      False, 1),
     ("platformboot lane, healthy",            {"passed": 46},            40,    "",        False, 0),
+    # Missing or empty results. The first is the one shape continue-on-error exists for; the
+    # rest are the crash-shaped ones a green job used to be indistinguishable from.
+    ("no trx, hung (#81, tolerated)",         None,                      3300,  "",        True,  0),
+    ("no trx, hung, but aborts logged",       None,                      3300,  ABORT_LOG, True,  1),
+    ("no trx, nothing hung",                  None,                      3300,  "",        False, 1),
+    ("trx with zero results",                 {"passed": 0},             3300,  "",        False, 1),
 ]
 
 failures = 0


### PR DESCRIPTION
## What this is

The follow-up #411 named: the gate's abort check goes from warning to blocking. That was the condition already written into `check-app-tests-baseline.py`'s docstring — *"flip it to blocking once the remaining source of thread-affine Avalonia state is fixed"* — and #411 fixed it.

The evidence it was waiting on, main's CI run on `b3979fe`:

| | Executed | Aborts | Failures | Hang |
|---|---|---|---|---|
| ubuntu | 3,435 / 3,435 | **0** | 0 | no |
| windows | 3,435 / 3,435 | **0** | 0 | no |

Both lanes complete, both at zero, and windows did not even hit #81 this time. That is the first run in this sequence where nothing had to be excused.

## The part that matters: no hang-dump waiver

The floor check is waived when a hang dump is present, because the #81 teardown hang truncates roughly one job-run in three and must not red unrelated PRs. **The abort check takes no such waiver**, and that asymmetry is the substance of this PR rather than a detail of it.

An abort is not something the #81 hang produces. The blame collector kills the testhost rather than letting it print, and across this thread runs were observed hanging with zero aborts — never the reverse. So a dump is evidence about missing *results*; it says nothing about a collection that died unread.

The waiver is also precisely where the hole was. Replaying the pre-fix local run — 6 aborts, and it hung — through both versions of the gate:

```
old gate:  exit 0   App.Tests: 1448 executed, no failures in local1.trx.
new gate:  exit 1   ::error::App.Tests hit 6 runner-level abort(s) (1 distinct) ...
```

The old gate did not merely tolerate that run. It printed **nothing at all** about the six dead collections, because the warning was itself gated on `not dumps`. A run that lost six collections to a real product defect reported "no failures" and went green. Had the check been flipped without also dropping the waiver, that exact run would still pass today.

## Everything else here is a consequence of blocking

| | |
|---|---|
| `judge()` split out of `main()` | The abort verdict has to apply on top of *every* exit path, including the two tolerated ones — a hang dump with no trx included. It could not stay inside the result judgement. |
| Two identical `if truncated and not dumps:` blocks merged | Pre-existing; they sat adjacent with nothing between them, and I was rewriting the neighbourhood anyway. |
| `console.log` joins the uploaded artifacts | It is the only place an abort exists. A gate that reds a PR should not send people digging through the job log for its own evidence. |

## Self-test

10 cases → 14. The four new ones cover branches that had none: a missing trx with a hang (the one shape `continue-on-error` exists for), a missing trx without one, a trx recording zero results, and — the pair worth having — a hung run *with* aborts, asserting the dump does not excuse them. The two flipped expectations are the change itself.

```
PASS  aborts in log, full run, blocks        exit=1 (want 1)
PASS  aborts in log and hung, still blocks   exit=1 (want 1)
PASS  no trx, hung (#81, tolerated)          exit=0 (want 0)
PASS  no trx, hung, but aborts logged        exit=1 (want 1)
...
all gate cases behaved
```

Real data too, not just the matrix: main's `unit_app.trx` from `b3979fe` passes the new gate on both lanes, and the pre-fix local run fails it.

## What this does not claim

**That the lane is now clean.** #81 still truncates it and is still tolerated; this PR does not touch that, and nobody should read a green Unit Tests job as meaning the whole suite ran. What changes is that the *other* truncation cause can no longer pass silently.

One loose end recorded rather than fixed: a `Test Case Cleanup Failure` on `TabRunningCommandTests.RefreshTabStatuses_...` appeared once in a local run with a `MediaContext.CommitCompositorsWithThrottling` stack — the #317/#409 family, not this one. It passed in two other local runs and in neither CI lane. If it recurs it is its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
