### PR TITLE
test(command-assist): wait on the pass's commit point, not a property it sets early

### DIFF
--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
@@ -45,8 +45,13 @@ public sealed class CommandAssistPassiveBubbleTests
         controller.NotifyInputActivity();
         delay.ReleaseAll();
 
-        await WaitForAsync(() => controller.ViewModel.TopSuggestionText == "git status");
-        Assert.True(controller.ViewModel.IsVisible);
+        // Waited on IsVisible rather than on the row text, because ApplyRefreshOutcome sets it
+        // last: publishing the rows, resetting the selection and shutting the popup all happen
+        // earlier in that method, so this is the one poll that cannot land mid-pass. Waiting on
+        // the text instead let this test observe rows-published/not-yet-visible and fail on the
+        // line below - rarely, and only on CI.
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
+        Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
         Assert.False(controller.ViewModel.IsPopupOpen);
         Assert.Equal(0, controller.ViewModel.SelectedIndex);
     }
@@ -158,7 +163,9 @@ public sealed class CommandAssistPassiveBubbleTests
         controller.NotifyInputActivity();
         delay.ReleaseAll();
 
-        await WaitForAsync(() => controller.ViewModel.QueryText.Length > 0);
+        // IsVisible, not QueryText: the pass writes the query before it publishes the rows, so
+        // waiting on the query and then reading the top row is the same mid-pass race as above.
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
         Assert.Equal("ec", controller.ViewModel.QueryText);
         Assert.Equal(new[] { "ec" }, history.SearchQueries);
         Assert.Equal("echo hello", controller.ViewModel.TopSuggestionText);
@@ -210,7 +217,8 @@ public sealed class CommandAssistPassiveBubbleTests
         controller.NotifyInputActivity();
         delay.ReleaseAll();
 
-        await WaitForAsync(() => controller.ViewModel.QueryText == "echo h");
+        // See above: the pass commits on IsVisible, and the query it writes first settles nothing.
+        await WaitForAsync(() => controller.ViewModel.IsVisible);
         Assert.Equal(new[] { "echo h" }, history.SearchQueries);
         Assert.Equal("echo hello", controller.ViewModel.TopSuggestionText);
     }


### PR DESCRIPTION
## What this is

`Typing_WithTwoCharacters_ShowsTheTopRankedHistoryRowWithoutOpeningThePopup` failed on windows CI in #414, on `Assert.True(controller.ViewModel.IsVisible)`. It blocked that PR, and it is unrelated to it.

**Not a slow machine.** `WaitForAsync` throws `TimeoutException` on timeout, so the wait genuinely observed `TopSuggestionText == "git status"` — and one line later `IsVisible` was still `false`.

## The seam

`ApplyRefreshOutcome` writes the view-model in a fixed order:

```csharp
ViewModel.QueryText = outcome.Query;      // 1. the query, first
...
_suggestions.AddRange(outcome.Suggestions);
SyncSuggestionViewModel();                // 2. the rows -> TopSuggestionText
...
ViewModel.IsPopupOpen = false;
ViewModel.IsVisible = ...;                // 3. the commit, last
```

The test polled every 10 ms from a `Task.Delay` loop, so a poll could land at (2) and assert against a state the pass had not finished writing.

**The controller is not at fault and is untouched here.** On the UI thread `ApplyRefreshOutcome` runs as one unit and no observer can see its middle. The test was reading through a seam only a concurrent poller can reach.

## The fix

Wait on `IsVisible` — the commit point, and already what 20 of the 32 `WaitForAsync` calls in this file use — then assert the row text:

```csharp
await WaitForAsync(() => controller.ViewModel.IsVisible);
Assert.Equal("git status", controller.ViewModel.TopSuggestionText);
```

That is also a better failure than what it replaced: a wrong top row now reports an equality mismatch instead of a timeout.

**Two more tests had the same defect at an earlier seam** — waiting on `QueryText`, the *first* thing the pass writes, then asserting the rows. Neither has been seen to fail, but the window is strictly wider than the one that did. Both are hardened the same way.

## Both windows demonstrated

I did not want to assert three races on the strength of one observed failure, so each window was widened with a temporary 50 ms sleep in `ApplyRefreshOutcome` and the tests run **as they were**:

| Widened window | Result with the old waits |
|---|---|
| before the rows are published | **2 fail** — exactly the two `QueryText` waits |
| before `IsVisible` is set | **1 fail** — exactly the test CI caught |
| both, with this change applied | **29 pass** |

The failure under the second sleep is the CI failure reproduced: same test, same assertion, deterministic. The sleeps were temporary; the controller is byte-for-byte unchanged in this diff.

## Note for #414

This unblocks #414, which is otherwise verified: 0 aborts on both OS lanes, gate self-test 14/14, ubuntu green at 3,435 executed.

Worth saying plainly, since it is the reason this was ever a red build rather than a shrug: the gate did the right thing. A green-by-flake merge is what the whole #409/#410/#411 sequence was built to stop, and the first thing it caught after being tightened was a genuine test defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
