### PR TITLE
fix(command-assist): stop a stray pass from claiming Avalonia's UI-thread identity (#81)

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1210,6 +1210,34 @@ namespace NovaTerminal.Controls
             TerminalSettings settings = _settings!;
             CommandAssistServices services = RequireCommandAssistServices();
             services.ApplyHistoryRetentionLimit(settings.CommandAssistMaxHistoryEntries);
+
+            // This pane's own dispatcher, not Dispatcher.UIThread, and not read inside the
+            // dispatch delegate below either. Both halves of that matter (#81).
+            //
+            // Dispatcher.UIThread is a mutable static whose getter binds the UI-thread identity
+            // to *the calling thread* whenever the backing field is null (Dispatcher.cs, the
+            // `s_uiThread ?? CurrentDispatcher` slow path). Under headless test isolation that
+            // field is nulled by ResetGlobalState() at every test boundary, so *any* read of it
+            // off the dispatch thread can decide who the UI thread is - and both directions of
+            // that have now been observed. A suggestion pass still in flight from a finished
+            // test reached this delegate in the gap between two tests and made a threadpool
+            // thread the UI thread, after which the next test's Compositor ctor ->
+            // DefaultRenderLoop.Add -> VerifyAccess() threw inside EnsureIsolatedApplication(),
+            // which sits outside the try/catch in HeadlessUnitTestSession.DispatchCore, killing
+            // the one dispatcher loop the assembly shares. And reading the static *eagerly*
+            // here is no safer: it leaves s_uiThread pointing at whichever thread built the
+            // pane, and the plain-[Fact] tests that marshal onto Dispatcher.UIThread rely on
+            // finding it null so they can be their own UI thread - see the note in
+            // TestAppBuilder.cs, and SshInteractionServiceTests, which hangs forever otherwise.
+            //
+            // AvaloniaObject.Dispatcher costs nothing on either count. It is captured by every
+            // AvaloniaObject at construction (`= Dispatcher.CurrentDispatcher`), so the pane
+            // already holds it before this line runs: reading it binds nothing that `new
+            // TerminalPane()` had not already bound. A late pass then posts to the dispatcher
+            // the pane was born with - inert once that test is over - and no read of the global
+            // happens at all. It is also the more correct reading in production, where a pane
+            // belongs to one dispatcher for its whole life.
+            Dispatcher paneDispatcher = Dispatcher;
             _commandAssistController = new CommandAssistController(
                 services.HistoryStore,
                 services.SecretsFilter,
@@ -1233,13 +1261,13 @@ namespace NovaTerminal.Controls
                 renderedSurfaceProbe: () => IsCommandAssistOverlayRendered,
                 dispatch: action =>
                 {
-                    if (Dispatcher.UIThread.CheckAccess())
+                    if (paneDispatcher.CheckAccess())
                     {
                         action();
                     }
                     else
                     {
-                        Dispatcher.UIThread.Post(action);
+                        paneDispatcher.Post(action);
                     }
                 });
 
@@ -4123,6 +4151,12 @@ namespace NovaTerminal.Controls
             }
 
             CloseRemoteFilesSidebar();
+
+            // Cancels any suggestion pass still in flight. Without this a debounced pass
+            // outlives the pane that owns it and publishes into a surface that is being torn
+            // down; see the dispatcher note in InitializeCommandAssist for what that cost.
+            _commandAssistController?.Dispose();
+
 
             // Detach handlers on the reused TermView so a disposed pane stops reacting.
             if (_onTermViewResize != null) TermView.OnResize -= _onTermViewResize;

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -43,7 +43,7 @@ namespace NovaTerminal.CommandAssist.Application;
 /// reconstruct from pixels, and it gates history capture and insertion rather than the query.
 /// </para>
 /// </remarks>
-public sealed class CommandAssistController
+public sealed class CommandAssistController : IDisposable
 {
     private readonly AssistSessionStateMachine _state = new();
     private readonly AssistSessionContext _context = new();
@@ -634,6 +634,29 @@ public sealed class CommandAssistController
     {
         ViewModel.ShortcutHintLabels = labels;
     }
+
+    /// <summary>
+    /// Cancels any suggestion pass still in flight, so nothing this controller started can
+    /// publish after its owner has let go of it.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately not <see cref="Dismiss"/>: dismissing is a user-visible act that writes to
+    /// the view model, and by the time an owner disposes us the surface it would write to is
+    /// already going away. The only thing worth doing here is stopping the work - a pass that
+    /// lands after its owner is gone reaches a dispatch delegate whose UI is no longer there,
+    /// which is one half of what made #81 possible.
+    /// </remarks>
+    public void Dispose()
+    {
+        _suggestionOrchestrator.CancelPending();
+    }
+
+    /// <summary>
+    /// Whether a ranking pass is still running. Exposed for the lifetime tests, which have to let an
+    /// abandoned pass finish before they can say it published nothing - asserting any earlier would
+    /// pass against a pass that had simply not got there yet.
+    /// </summary>
+    internal bool HasSuggestionPassInFlight => _suggestionOrchestrator.HasPassInFlight;
 
     public void Dismiss()
     {

--- a/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
+++ b/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
@@ -396,6 +396,16 @@ internal sealed class SuggestionOrchestrator
 
     private void Publish(SuggestionRefreshOutcome outcome, CancellationToken token)
     {
+        // Checked before the dispatch as well as inside it. The inner check is what keeps a
+        // superseded outcome off the surface, and it has to stay - the pass can be cancelled
+        // between the two. The outer one is about not calling _dispatch at all: a pass whose
+        // owner is already gone has nothing to publish, and handing it to a dispatch delegate
+        // anyway is how a dead pass ends up touching live UI machinery (#81).
+        if (token.IsCancellationRequested)
+        {
+            return;
+        }
+
         _dispatch(() =>
         {
             if (token.IsCancellationRequested)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
@@ -846,12 +846,123 @@ public sealed class CommandAssistPassiveBubbleTests
 
     // ------------------------------------------------------------------ helpers
 
+    // ------------------------------------------------- a pass must not outlive its owner (#81)
+
+    /// <summary>
+    /// A pass whose owner let go of it while it was running must not reach the dispatch delegate
+    /// at all - not even to be turned away by the token check inside it.
+    /// </summary>
+    /// <remarks>
+    /// This is the test-visible half of #81. The dispatch delegate a real pane supplies reads
+    /// <c>Dispatcher.UIThread</c>, and under headless test isolation that static is nulled at every
+    /// test boundary and re-bound to whichever thread touches it first. A pass that outlived its
+    /// test therefore did not merely publish somewhere harmless: it could make a threadpool thread
+    /// the UI thread, after which the next test's Avalonia setup threw <c>VerifyAccess</c> from
+    /// inside the one place Avalonia does not guard, killing the dispatcher loop the whole assembly
+    /// shares and hanging every test that had not run yet.
+    ///
+    /// The pane no longer reads that static, which is the fix. This covers the other half: a dead
+    /// pass has nothing to say, so it should not be calling dispatch delegates in the first place.
+    /// The hold point is the query read rather than the debounce, deliberately - cancelling during
+    /// the debounce unwinds the pass through <c>OperationCanceledException</c> and never reaches
+    /// <c>Publish</c>, so it would prove nothing.
+    /// </remarks>
+    [Fact]
+    public async Task APassDismissedAfterItsDebounce_NeverReachesTheDispatchDelegate()
+    {
+        int dispatchCalls = await RunPassAndAbandonIt(static controller => controller.Dismiss());
+
+        Assert.Equal(0, dispatchCalls);
+    }
+
+    /// <summary>
+    /// Disposing the controller has the same effect as dismissing it, which is the point of it
+    /// being disposable: an owner tearing down has no surface left to publish to, and
+    /// <see cref="CommandAssistController.Dismiss"/> would write to a view model that is going away.
+    /// </summary>
+    [Fact]
+    public async Task APassAbandonedByDisposingTheController_NeverReachesTheDispatchDelegate()
+    {
+        int dispatchCalls = await RunPassAndAbandonIt(static controller => controller.Dispose());
+
+        Assert.Equal(0, dispatchCalls);
+    }
+
+    /// <summary>
+    /// Starts a passive pass, holds it at the query read - past its debounce, so cancelling from
+    /// here reaches <c>Publish</c> rather than unwinding through the delay - then lets
+    /// <paramref name="abandon"/> have the controller and releases the pass. Returns how many times
+    /// the pass called the dispatch delegate, which should be none.
+    /// </summary>
+    private static async Task<int> RunPassAndAbandonIt(Action<CommandAssistController> abandon)
+    {
+        var history = new RecordingHistoryStore();
+        history.Seed("git status");
+        var grid = new FakeGrid();
+        var delay = new GatedDelay();
+
+        var readReached = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var releaseRead = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        int dispatchCalls = 0;
+        int readCalls = 0;
+
+        CommandAssistController controller = CreateController(
+            history,
+            grid,
+            delay,
+            dispatch: action =>
+            {
+                Interlocked.Increment(ref dispatchCalls);
+                action();
+            },
+            queryProvider: () =>
+            {
+                // Only the ranking pass is held. OpenPrompt and the shell-integration plumbing read
+                // the grid too, and blocking those would deadlock the setup rather than test it.
+                if (Interlocked.Increment(ref readCalls) == FirstRankingRead)
+                {
+                    readReached.TrySetResult();
+                    releaseRead.Task.GetAwaiter().GetResult();
+                }
+
+                return grid.Read();
+            });
+
+        grid.SetLine("gi");
+        Interlocked.Exchange(ref readCalls, 0);
+        Interlocked.Exchange(ref dispatchCalls, 0);
+
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+
+        await readReached.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // The pass is now past its debounce and inside the read, which is the only window in which
+        // "abandoned mid-flight" is a state rather than a race.
+        abandon(controller);
+        releaseRead.SetResult();
+
+        // The pass has to be given the chance to publish, or this asserts on a pass that simply had
+        // not got there yet. HasPassInFlight drops in RunPassAsync's finally, after Publish.
+        await WaitForAsync(() => !controller.HasSuggestionPassInFlight);
+
+        return Volatile.Read(ref dispatchCalls);
+    }
+
+    /// <summary>
+    /// Which grid read belongs to the ranking pass. The reads before it are session setup, and the
+    /// pass resolves its query with exactly one.
+    /// </summary>
+    private const int FirstRankingRead = 1;
+
     private static CommandAssistController CreateController(
         RecordingHistoryStore history,
         FakeGrid grid,
         GatedDelay? delay = null,
         IPathSuggestionProvider? pathProvider = null,
-        TimeSpan? debounce = null)
+        TimeSpan? debounce = null,
+        Action<Action>? dispatch = null,
+        Func<AssistQuerySnapshot?>? queryProvider = null)
     {
         var controller = new CommandAssistController(
             history,
@@ -863,9 +974,9 @@ public sealed class CommandAssistPassiveBubbleTests
             errorInsightService: null,
             modeRouter: null,
             resultBuilder: null,
-            queryProvider: grid.Read,
+            queryProvider: queryProvider ?? grid.Read,
             renderedSurfaceProbe: null,
-            dispatch: null,
+            dispatch: dispatch,
             passiveRefreshDebounce: debounce ?? (delay == null ? TimeSpan.Zero : CommandAssistController_DefaultDebounce),
             refreshDelay: delay == null ? null : delay.Delay);
 


### PR DESCRIPTION
## What #81 actually is

Not threadpool starvation, and not the upstream Avalonia teardown deadlock. Four hang dumps agree:

| dump | live managed threads | blocked | dispatcher loop | leaked PTY sessions |
|---|---|---|---|---|
| local1 | 139 | 1 | **gone** | 28 |
| local2 | 53 | 1 | **gone** | 9 |
| local3 | 183 | 1 | **gone** | 40 |
| live (heap) | 6 | 1 | **gone** | 0 |

In every one, the only Avalonia frame in the whole process is a single thread parked in `AvaloniaTestCase.Run`'s `GetAwaiter().GetResult()`, and `HeadlessUnitTestSession`'s dispatcher loop — the only thing that can complete the `TaskCompletionSource` that thread waits on — is not running. Once it is gone, every remaining test in the assembly waits forever and **reports nothing**, which is exactly how a truncated run reaches the gate looking green.

The pool is never starved: one of these dumps has 17 idle workers.

## The exception that kills the loop

The fourth process was still alive, so it could be dumped **with its heap** rather than as a `--blame-hang` mini. The killing exception was still on it:

```
System.InvalidOperationException: The calling thread cannot access this object because a different thread owns it.
   Avalonia.Threading.Dispatcher.VerifyAccess()
   Avalonia.Rendering.DefaultRenderLoop.Add(IRenderLoopTask)
   Avalonia.Rendering.Composition.Server.ServerCompositor..ctor(...)
   Avalonia.Rendering.Composition.Compositor..ctor(...)
   Avalonia.Headless.AvaloniaHeadlessPlatform.Initialize(...)
   Avalonia.AppBuilder.SetupUnsafe()
   Avalonia.Headless.HeadlessUnitTestSession.EnsureIsolatedApplication()
   Avalonia.Headless.HeadlessUnitTestSession+<>c.<StartNew>b__18_1(Object)
   ExceptionDispatchInfo.Throw()
   Avalonia.Headless.HeadlessUnitTestSession+<>c__DisplayClass18_0.<StartNew>b__0()   <-- the loop
   ExecutionContext.RunFromThreadPoolDispatchLoop(...)
```

`EnsureIsolatedApplication()` is called on the line *before* `DispatchCore`'s `try`, so this throw is not caught, not recorded against any test, and unwinds the `while` loop in `StartNew` — which only catches `OperationCanceledException`. One exception, and the assembly's single dispatcher is gone.

## Why `VerifyAccess` fails there — and this half is ours

`Dispatcher.UIThread` is a mutable static whose getter binds UI-thread identity to **the calling thread** when the backing field is null:

```csharp
public static Dispatcher UIThread => s_uiThread ?? GetUIThreadDispatcherSlow();
//  slow path:  lock (s_globalLock) { return s_uiThread ?? CurrentDispatcher; }
//  ctor path:  if (s_uiThread == null) s_uiThread = this;

private static void ResetGlobalState() { ... s_uiThread = null; }   // Dispatcher.cs:1623
```

`ResetGlobalState()` runs at **every test boundary** under `AvaloniaTestIsolationLevel.PerTest`, which `TestAppBuilder.cs:8` deliberately keeps. So between tests the field is null and the first thread to touch it wins.

The other two exceptions on that heap name who was touching it:

```
CommandAssistController.SyncSuggestionViewModel()  /  ClearSuggestionSurface()
CommandAssistController.ApplyRefreshOutcome(...)
SuggestionOrchestrator+<>c__DisplayClass25_0.<Publish>b__0()
NovaTerminal.Controls.TerminalPane+<>c.<InitializeCommandAssist>b__194_1(Action)
SuggestionOrchestrator.Publish(...)
SuggestionOrchestrator+<RunPassCoreAsync>d__24.MoveNext()
```

— a suggestion pass on a threadpool thread, after the test that started it had ended, going through the pane's dispatch delegate:

```csharp
dispatch: action =>
{
    if (Dispatcher.UIThread.CheckAccess()) { action(); }
    else { Dispatcher.UIThread.Post(action); }
});
```

A pass landing in the gap between two tests made a threadpool thread the UI thread. The next test then built its Avalonia application on the dispatcher loop's thread and threw against the hijacked identity.

That accounts for everything the gate work exposed: an arbitrary victim test (the live one died in `CommandAssistGridTruthTests.BetweenCommands_AReadableGridIsStillNotAQuery`), no OS dependence, executed counts anywhere from 391 to 3,435, and silence in the trx.

## The changes

Either one breaks the chain; both are worth making.

1. **`TerminalPane` holds the `Dispatcher` instance**, captured once on the UI thread at construction, instead of reading the static inside the delegate. A late pass now posts to the dispatcher it was born with — inert once that test is over — and touches no global state on the way. It is also the more correct reading in production, where a pane belongs to one dispatcher for its whole life.
2. **A cancelled pass no longer calls the dispatch delegate at all.** The check inside the delegate stays (the pass can be cancelled between the two); the new one outside is about a dead pass having no business reaching live UI machinery. `CommandAssistController` becomes `IDisposable` so an owner can say it is done, and `TerminalPane.DetachFromUiThread()` does.

## Evidence

Same machine, same command, back to back:

| | executed | outcome |
|---|---|---|
| unfixed | 1,218 / 3,568 | **hung**, blame dump |
| fixed | 3,568 | completed, 2m47s |

Two new tests cover change 2 directly. They hold a pass at its **query read** — past the debounce, so cancelling there reaches `Publish` rather than unwinding through `OperationCanceledException`, which would prove nothing — then abandon the controller via `Dismiss()` and via `Dispose()`, and assert the dispatch delegate is never called. Both fail with the guard removed and pass with it; `CommandAssistPassiveBubbleTests` is 31/31.

**Change 1 is not covered by a test, deliberately.** Reproducing it means nulling `Dispatcher`'s private static and racing a background thread against the session's setup. That is Avalonia's internal state, and a test that got it slightly wrong would hijack the identity itself. Its evidence is the dump and Avalonia's source, both quoted above.

## What this does not fix, and what it supersedes

- Two earlier readings of #81 are left in place and should be revisited separately: `TestHostThreadPoolConfig` ("part 2", threadpool starvation) and the dedicated-thread comment in `RustPtySession.cs:768` ("part 1"). Neither matches the dumps — the pool has idle workers in all four.
- **A separate, real PTY leak.** Instrumenting `RustPtySession` with a live-instance registry named it precisely: `TestMainWindowFactory.Create()` runs the real `MainWindow` constructor, and `Window.Close()` does not call `DisposeControlTree`, so every test using that factory leaks a `cmd.exe` session — `AgentIndicatorTabRollupTests`, `VerticalTabStripTests`, `MainWindowTitleBarTests` and others, 53 live sessions by the end of a full run, with orphaned `cmd.exe` processes surviving the test host. Twelve files use that factory and none dispose. Not in this PR; the instrumentation is kept for it.
- **The fixed run had 15 failures**, clustered on `MediaContext`/dispatcher thread ownership — including the repo's own guard for that invariant, `AvaloniaBootLocatorHygieneTests.TheAmbientMediaContextBelongsToTheSessionDispatchThread`, whose "actual" thread is dead. Every one of them runs after 2:14, so the unfixed run (dead at 1,218) never reached them and cannot be compared against. A baseline run on the unmodified parent commit is in flight to classify them; the working read is that they are pre-existing contamination the hang was hiding — the same family as the `TabRunningCommandTests` / `CommitCompositorsWithThrottling` flake — but that is a hypothesis until the baseline says so, and this note will be updated with the answer either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7tAwn18it2PotNSiLkRTD
