### PR TITLE
test(app): dispose the windows the tests build, and the shells behind them

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -2471,6 +2471,55 @@ namespace NovaTerminal
             _pendingVisualRefreshTabs.Clear();
         }
 
+        /// <summary>
+        /// Disposes every pane this window owns, and with them the PTY and child shell behind
+        /// each one. For tests, which build a real window and then abandon it.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Nothing else reclaims them. <c>Window.Close()</c> runs <see cref="PerformAppTeardown"/>,
+        /// which saves the session and stops timers but never walks the tabs, and a test that only
+        /// drops its reference leaves the shells running - a full run finished with 53 of them
+        /// alive. Tests cannot call <c>Close()</c> instead: that path also stops the process-wide
+        /// <c>AgentHostService</c> singleton, which the next test would inherit.
+        /// </para>
+        /// <para>
+        /// Zoom is why this cannot be a walk of <c>ti.Content</c> from outside. Zooming moves the
+        /// tab's real root off the visual tree into <c>_paneZoomStateByTab</c> and puts the zoomed
+        /// pane in its place, so disposing the content of a zoomed tab reaches exactly one pane and
+        /// abandons its siblings. <see cref="CloseTab"/> exits zoom first for the same reason, and
+        /// this mirrors it.
+        /// </para>
+        /// </remarks>
+        internal void DisposeAllPanesForTest()
+        {
+            var tabs = this.FindControl<TabControl>("Tabs");
+            if (tabs == null) return;
+
+            foreach (var ti in tabs.Items.Cast<TabItem>().ToList())
+            {
+                if (_paneZoomStateByTab.ContainsKey(ti))
+                {
+                    ExitPaneZoom(ti, publishEvent: false);
+                }
+
+                if (ti.Content is Control content)
+                {
+                    DisposeControlTree(content);
+                }
+            }
+
+            // Whatever the walk above did not reach is still registered here, because
+            // DisposeControlTree unwires every pane it disposes and unwiring is what removes it
+            // from this map. That is how a pane whose tab has left the collection is still found:
+            // MainWindowStartupTests calls tabs.Items.Clear() to build its own strip, and the
+            // constructor's live tab - shell and all - goes with it.
+            foreach (var orphan in _paneOwnerTab.Keys.ToList())
+            {
+                DisposeControlTree(orphan);
+            }
+        }
+
         private void DisposeAllTabs(TabControl tabs)
         {
             foreach (var item in tabs.Items.Cast<TabItem>().ToList())

--- a/tests/NovaTerminal.App.Tests/Core/AgentIndicatorTabRollupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/AgentIndicatorTabRollupTests.cs
@@ -33,8 +33,14 @@ namespace NovaTerminal.Tests.Core;
 /// before creating its window and diffs against that snapshot afterwards, so
 /// the assertion is about what *this* window added, not the global count.
 /// </summary>
-public sealed class AgentIndicatorTabRollupTests
+public sealed class AgentIndicatorTabRollupTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     [Theory]
     // WritesOnly (the default): only a write reaches the tab strip.
     [InlineData("WritesOnly", AgentAttentionTier.Idle, false)]

--- a/tests/NovaTerminal.App.Tests/Core/AgentObserveIndicatorTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/AgentObserveIndicatorTests.cs
@@ -22,8 +22,14 @@ namespace NovaTerminal.Tests.Core;
 /// long poll names no pane, and a read landing on a pane that carries no agent
 /// segment of its own would otherwise be invisible everywhere.
 /// </summary>
-public class AgentObserveIndicatorTests
+public class AgentObserveIndicatorTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     [Theory]
     // Observe off: invisible, and nothing else matters.
     [InlineData(false, false, false, false, false)]

--- a/tests/NovaTerminal.App.Tests/Core/AgentWindowVisibilityTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/AgentWindowVisibilityTests.cs
@@ -19,8 +19,14 @@ namespace NovaTerminal.Tests.Core;
 /// AgentAttentionRegistrationTests; this file covers the wiring — that the
 /// window actually pushes, and that a pane registered later is seeded.
 /// </summary>
-public class AgentWindowVisibilityTests
+public class AgentWindowVisibilityTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     private sealed class FakeClock
     {
         public DateTimeOffset Now { get; private set; } = new(2026, 8, 21, 12, 0, 0, TimeSpan.Zero);

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowBackupPaletteTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowBackupPaletteTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Avalonia.Headless.XUnit;
 using NovaTerminal.Shell;
@@ -16,8 +17,14 @@ namespace NovaTerminal.Tests.Core;
 /// <c>SetupCommandPalette()</c>, which is lazy (runs on palette-open / settings-save) - starting it
 /// there would mean automatic snapshots only begin after the user's first palette open.
 /// </summary>
-public sealed class MainWindowBackupPaletteTests
+public sealed class MainWindowBackupPaletteTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     [AvaloniaFact]
     public void CommandPalette_IncludesTheThreeBackupEntries_AllRoutedToOpenSettingsToBackupPage()
     {

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowCustomizeTitleBarSettingsTargetTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowCustomizeTitleBarSettingsTargetTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -22,8 +23,14 @@ namespace NovaTerminal.Tests.Core;
 /// inlining the tuple, so asserting on its result is asserting on what production actually runs -
 /// not a parallel duplicate that could drift from the real click handler.
 /// </remarks>
-public sealed class MainWindowCustomizeTitleBarSettingsTargetTests
+public sealed class MainWindowCustomizeTitleBarSettingsTargetTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     [AvaloniaFact]
     public void CustomizeTitleBarSettingsTarget_RequestsTheAppearanceTabAndTitleBarSection()
     {

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowPaneWiringTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowPaneWiringTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
@@ -21,8 +22,14 @@ namespace NovaTerminal.Tests.Core;
 /// throw into "[ERROR] Failed to spawn process", and the session was never created: restoring a
 /// workspace produced a window full of dead panes.
 /// </remarks>
-public sealed class MainWindowPaneWiringTests
+public sealed class MainWindowPaneWiringTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     [AvaloniaFact]
     public void InitializeRestoredTabs_InjectsCommandAssistServicesIntoRestoredPanes()
     {
@@ -80,7 +87,7 @@ public sealed class MainWindowPaneWiringTests
                 CommandAssist = TestCommandAssistServices.Instance
             };
 
-            var window = new NovaTerminal.MainWindow(bundle);
+            var window = TestMainWindowFactory.Create(bundle);
             TabControl tabs = window.FindControl<TabControl>("Tabs")!;
             var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
                 .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reflection;
 using Avalonia.Controls;
 using Avalonia.Headless.XUnit;
@@ -52,8 +53,14 @@ namespace NovaTerminal.Tests.Core;
 /// <c>TabClosePolicyTests</c>), and the declined branch remains uncovered for the modal-deadlock
 /// reason described above.
 /// </remarks>
-public sealed class MainWindowShellExitTests
+public sealed class MainWindowShellExitTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     [AvaloniaFact]
     public async Task ClosePaneAsync_ClosesTheGivenPanesTab_NotTheSelectedOne()
     {
@@ -232,7 +239,7 @@ public sealed class MainWindowShellExitTests
         public static TwoTabFixture Create()
         {
             AppServiceBundle bundle = AppServices.BuildForDesigner();
-            var window = new NovaTerminal.MainWindow(bundle);
+            var window = TestMainWindowFactory.Create(bundle);
             TabControl tabs = window.FindControl<TabControl>("Tabs")!;
             var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
                 .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
@@ -352,7 +359,7 @@ public sealed class MainWindowShellExitTests
         public static SplitPaneFixture Create()
         {
             AppServiceBundle bundle = AppServices.BuildForDesigner();
-            var window = new NovaTerminal.MainWindow(bundle);
+            var window = TestMainWindowFactory.Create(bundle);
             TabControl tabs = window.FindControl<TabControl>("Tabs")!;
             var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
                 .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -1,3 +1,4 @@
+using System;
 using NovaTerminal.Shell;
 using NovaTerminal.Pty;
 using Avalonia.Headless.XUnit;
@@ -14,8 +15,14 @@ using System.Reflection;
 
 namespace NovaTerminal.Tests.Core;
 
-public sealed class MainWindowStartupTests
+public sealed class MainWindowStartupTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     [AvaloniaFact]
     public void MainWindow_CanBeConstructed()
     {
@@ -128,7 +135,7 @@ public sealed class MainWindowStartupTests
     public void MainWindow_CommandPaletteShowsSettingsShortcut()
     {
         CommandRegistry.Clear();
-        var window = new NovaTerminal.MainWindow();
+        var window = TestMainWindowFactory.Create();
         var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
 
         toggleMethod!.Invoke(window, null);
@@ -141,7 +148,7 @@ public sealed class MainWindowStartupTests
     public void MainWindow_CommandPaletteIncludesConnections()
     {
         CommandRegistry.Clear();
-        var window = new NovaTerminal.MainWindow();
+        var window = TestMainWindowFactory.Create();
         var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
 
         toggleMethod!.Invoke(window, null);
@@ -153,7 +160,7 @@ public sealed class MainWindowStartupTests
     public void MainWindow_CommandPalettePrefersMostUsedCommandsWhenOpened()
     {
         CommandRegistry.Clear();
-        var window = new NovaTerminal.MainWindow();
+        var window = TestMainWindowFactory.Create();
         var toggleMethod = typeof(NovaTerminal.MainWindow).GetMethod("ToggleCommandPalette", BindingFlags.Instance | BindingFlags.NonPublic);
         var usageField = typeof(NovaTerminal.MainWindow).GetField("_commandPaletteUsage", BindingFlags.Instance | BindingFlags.NonPublic);
 
@@ -177,7 +184,7 @@ public sealed class MainWindowStartupTests
     [AvaloniaFact]
     public async Task MainWindow_CustomCommandAssistHelpShortcut_UsesConfiguredBinding()
     {
-        var window = new NovaTerminal.MainWindow();
+        var window = TestMainWindowFactory.Create();
         var settingsField = typeof(NovaTerminal.MainWindow).GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic);
         var currentPaneField = typeof(NovaTerminal.MainWindow).GetField("_currentPaneValue", BindingFlags.Instance | BindingFlags.NonPublic);
 

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowTabLookupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowTabLookupTests.cs
@@ -18,8 +18,14 @@ namespace NovaTerminal.Tests.Core;
 /// answering "no tab", which is why the bell indicator never appeared and why a split tab
 /// resolved the wrong pane.
 /// </summary>
-public sealed class MainWindowTabLookupTests
+public sealed class MainWindowTabLookupTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     /// <summary>
     /// #319: the cached active pane was discarded on every call, because the staleness check
     /// compared <c>null == tabItem</c>. The fallback then returned the *first* pane in the tab,
@@ -91,7 +97,7 @@ public sealed class MainWindowTabLookupTests
         public static SplitTabFixture Create()
         {
             AppServiceBundle bundle = AppServices.BuildForDesigner();
-            var window = new NovaTerminal.MainWindow(bundle);
+            var window = TestMainWindowFactory.Create(bundle);
             TabControl tabs = window.FindControl<TabControl>("Tabs")!;
             var settings = (TerminalSettings)typeof(NovaTerminal.MainWindow)
                 .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowTitleBarTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowTitleBarTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -26,8 +27,14 @@ namespace NovaTerminal.Tests.Core;
 /// runtime by TitleBarViewFactory, so they are never registered into it - FindControl returns null
 /// for them both here and in the shipped app. See task-10-report.md for the production-code impact.
 /// </summary>
-public sealed class MainWindowTitleBarTests
+public sealed class MainWindowTitleBarTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     // TabOverflowBadge is inserted immediately after the Tab List button by
     // MainWindow.PlaceTabOverflowBadge - see
     // RebuildTitleBar_DefaultSettings_BadgeSitsImmediatelyAfterTabListButton below for the dedicated

--- a/tests/NovaTerminal.App.Tests/Core/TabRunningCommandTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TabRunningCommandTests.cs
@@ -34,8 +34,14 @@ namespace NovaTerminal.Tests.Core;
 /// unregisters the diffed registration explicitly. Without that, the driven
 /// status machine would stay reachable through the shared registry forever.
 /// </summary>
-public sealed class TabRunningCommandTests
+public sealed class TabRunningCommandTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     private static TerminalSettings GetSettings(MainWindow window)
         => (TerminalSettings)typeof(MainWindow)
             .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!

--- a/tests/NovaTerminal.App.Tests/Core/TestMainWindowFactory.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TestMainWindowFactory.cs
@@ -1,11 +1,84 @@
-using NovaTerminal.Shell;
+using System;
+using System.Collections.Generic;
 using NovaTerminal.Platform;
+using NovaTerminal.Shell;
 using NovaTerminal.VT;
 
 namespace NovaTerminal.Tests.Core;
 
 internal static class TestMainWindowFactory
 {
-    public static NovaTerminal.MainWindow Create()
-        => new NovaTerminal.MainWindow(AppServices.BuildForDesigner());
+    private static readonly object Gate = new();
+    private static readonly List<NovaTerminal.MainWindow> Created = new();
+
+    public static NovaTerminal.MainWindow Create() => Create(AppServices.BuildForDesigner());
+
+    /// <summary>
+    /// For the tests that need their own service bundle. Same tracking, so their windows are torn
+    /// down with everyone else's — a window built with a custom bundle still opens a real tab with
+    /// a real shell behind it.
+    /// </summary>
+    public static NovaTerminal.MainWindow Create(AppServiceBundle services)
+    {
+        var window = new NovaTerminal.MainWindow(services);
+
+        lock (Gate)
+        {
+            Created.Add(window);
+        }
+
+        return window;
+    }
+
+    /// <summary>
+    /// Disposes the panes of every window this factory has handed out since the last call, which
+    /// is what actually kills the PTY and its child shell. Call it from the test class's
+    /// <see cref="IDisposable.Dispose"/>, so it runs after each test.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The real <c>MainWindow</c> constructor opens a tab, and a tab is a real terminal pane with
+    /// a real shell behind it — <c>cmd.exe</c> here, <c>/bin/bash</c> on CI. Nothing was reaping
+    /// them: <c>Window.Close()</c> does not dispose the control tree, and no test closed its
+    /// window anyway. A full local run finished with 53 live sessions — 212 threads and 53 child
+    /// processes — and they stayed alive alongside every test that ran after them.
+    /// </para>
+    /// <para>
+    /// The walk itself lives in <c>MainWindow</c> rather than here, because a correct one has to
+    /// know that zoom stashes a tab's real root off the visual tree; a reimplementation from
+    /// outside missed exactly that and left the zoom tests' panes behind.
+    /// </para>
+    /// </remarks>
+    public static void DisposeCreatedWindows()
+    {
+        NovaTerminal.MainWindow[] windows;
+        lock (Gate)
+        {
+            windows = Created.ToArray();
+            Created.Clear();
+        }
+
+        foreach (NovaTerminal.MainWindow window in windows)
+        {
+            // Guarded on the window's own dispatcher, never Dispatcher.UIThread: reading that
+            // static off the dispatch thread binds UI-thread identity to the caller, which is the
+            // mechanism behind #81, and a teardown that runs at a test boundary is precisely where
+            // that would bite. Not on the window's thread means skipping — which leaks, the status
+            // quo this replaces, and better than trading a leak for a hang.
+            if (!window.Dispatcher.CheckAccess())
+            {
+                continue;
+            }
+
+            try
+            {
+                window.DisposeAllPanesForTest();
+            }
+            catch (Exception)
+            {
+                // A window that refuses to tear down is not this helper's problem to report: it
+                // would fail whichever unrelated test happens to be finishing.
+            }
+        }
+    }
 }

--- a/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using NovaTerminal.AgentHost;
+using NovaTerminal.Controls;
+using NovaTerminal.Pty;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// That <see cref="TestMainWindowFactory.DisposeCreatedWindows"/> actually tears panes down, in
+/// each of the shapes that defeated an earlier version of it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The teardown is deliberately quiet — it skips a window whose dispatcher is not ours and
+/// swallows what disposal throws, because failing there would redden whichever unrelated test
+/// happened to be finishing. That quiet is the problem this file solves: without it, a traversal
+/// that stopped finding panes would leak shells again and nothing would say so.
+/// </para>
+/// <para>
+/// Observed through <see cref="AgentSessionRegistry"/> rather than through the PTY. Every pane
+/// registers itself and <c>DetachFromUiThread</c> removes the entry, so the registry answers
+/// "was this pane torn down" without depending on a shell having spawned — which it has not, in a
+/// window that was never shown. The registry is process-wide, so each test diffs against a
+/// snapshot rather than asserting a total, the same way <c>AgentIndicatorTabRollupTests</c> does.
+/// </para>
+/// </remarks>
+public sealed class TestWindowTeardownTests : IDisposable
+{
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
+    [AvaloniaFact]
+    public void AWindowsPanes_AreGoneAfterTeardown()
+    {
+        HashSet<Guid> before = RegisteredPaneIds();
+        TestMainWindowFactory.Create();
+
+        Guid[] added = RegisteredPaneIds().Except(before).ToArray();
+        Assert.NotEmpty(added);
+
+        TestMainWindowFactory.DisposeCreatedWindows();
+
+        Assert.Empty(RegisteredPaneIds().Intersect(added));
+    }
+
+    /// <summary>
+    /// Zoom moves the tab's real root off the visual tree and leaves only the zoomed pane in
+    /// <c>ti.Content</c>, so a teardown that walks the content of a zoomed tab reaches the zoomed
+    /// pane and abandons its siblings. That is exactly what an earlier version of this cleanup did,
+    /// which is why the sibling is what this asserts on.
+    /// </summary>
+    [AvaloniaFact]
+    public void TheHiddenSiblingOfAZoomedPane_IsGoneAfterTeardown()
+    {
+        HashSet<Guid> before = RegisteredPaneIds();
+        MainWindow window = TestMainWindowFactory.Create();
+        (TabItem tab, TerminalPane zoomed, TerminalPane sibling) = AddSplitTab(window);
+
+        EnterZoom(window, tab, zoomed);
+
+        // The zoom is real: the tab now shows the zoomed pane alone, and the sibling is off-tree.
+        Assert.Same(zoomed, tab.Content);
+        Guid[] added = RegisteredPaneIds().Except(before).ToArray();
+        Assert.Contains(sibling.PaneId, added);
+
+        TestMainWindowFactory.DisposeCreatedWindows();
+
+        Assert.DoesNotContain(sibling.PaneId, RegisteredPaneIds());
+        Assert.Empty(RegisteredPaneIds().Intersect(added));
+    }
+
+    /// <summary>
+    /// A pane whose tab has left the collection is invisible to a walk of <c>Tabs.Items</c>;
+    /// <c>MainWindowStartupTests</c> clears the collection outright to build its own strip.
+    /// </summary>
+    [AvaloniaFact]
+    public void ThePanesOfARemovedTab_AreGoneAfterTeardown()
+    {
+        HashSet<Guid> before = RegisteredPaneIds();
+        MainWindow window = TestMainWindowFactory.Create();
+
+        Guid[] added = RegisteredPaneIds().Except(before).ToArray();
+        Assert.NotEmpty(added);
+
+        window.FindControl<TabControl>("Tabs")!.Items.Clear();
+
+        TestMainWindowFactory.DisposeCreatedWindows();
+
+        Assert.Empty(RegisteredPaneIds().Intersect(added));
+    }
+
+    private static HashSet<Guid> RegisteredPaneIds()
+        => AgentSessionRegistry.Instance.GetRegistrations().Select(r => r.PaneId).ToHashSet();
+
+    /// <summary>Adds a two-pane split tab, the shape zoom needs. Mirrors AgentObserveIndicatorTests.</summary>
+    private static (TabItem Tab, TerminalPane First, TerminalPane Second) AddSplitTab(MainWindow window)
+    {
+        var settings = (TerminalSettings)typeof(MainWindow)
+            .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+
+        string shell = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh";
+        var session = new TabSession
+        {
+            Title = "Split",
+            Root = new PaneNode
+            {
+                Type = NodeType.Split,
+                SplitOrientation = 0,
+                Children =
+                {
+                    new PaneNode { Type = NodeType.Leaf, Command = shell, Arguments = string.Empty, PaneId = Guid.NewGuid().ToString() },
+                    new PaneNode { Type = NodeType.Leaf, Command = shell, Arguments = string.Empty, PaneId = Guid.NewGuid().ToString() }
+                },
+                Sizes = { "1*", "1*" }
+            }
+        };
+
+        TabItem tab = SessionManager.CreateRestoredTabItem(session, settings)!;
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        tabs.Items.Add(tab);
+
+        typeof(MainWindow)
+            .GetMethod("InitializeRestoredTabs", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(window, new object[] { tabs });
+
+        // RestorePaneTree builds [child0, GridSplitter, child1]; OfType drops the splitter and
+        // preserves order.
+        List<TerminalPane> panes = ((Grid)tab.Content!).Children.OfType<TerminalPane>().ToList();
+        Assert.Equal(2, panes.Count);
+        return (tab, panes[0], panes[1]);
+    }
+
+    private static void EnterZoom(MainWindow window, TabItem tab, TerminalPane pane)
+    {
+        var entered = (bool)typeof(MainWindow)
+            .GetMethod("EnterPaneZoom", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .Invoke(window, new object[] { tab, pane, false })!;
+
+        Assert.True(entered, "Test setup failed: EnterPaneZoom refused to zoom the pane.");
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/ThemeApplicationRegressionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/ThemeApplicationRegressionTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 using Avalonia.Controls;
@@ -22,8 +23,14 @@ namespace NovaTerminal.Tests.Core;
 ///   the theme foregrounds an earlier ApplyThemeToUI had applied were lost - white icons under the
 ///   app's default Dark variant, invisible on light themes. The rebuild now re-applies them.
 /// </summary>
-public sealed class ThemeApplicationRegressionTests
+public sealed class ThemeApplicationRegressionTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     // The Default theme's ANSI blue - the "eye killer".
     private static TermColor PureBlue => TermColor.FromRgb(0, 0, 238);
 

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Reflection;
 using Avalonia;
@@ -12,8 +13,14 @@ using Xunit;
 
 namespace NovaTerminal.Tests.Core;
 
-public sealed class VerticalTabStripTests
+public sealed class VerticalTabStripTests : IDisposable
 {
+    /// <summary>
+    /// Disposes the panes of every window this class asked for, and with them the real shells
+    /// behind them. xUnit builds a fresh instance per test, so this runs after each one.
+    /// </summary>
+    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+
     private static TerminalSettings GetSettings(NovaTerminal.MainWindow window)
         => (TerminalSettings)typeof(NovaTerminal.MainWindow)
             .GetField("_settings", BindingFlags.Instance | BindingFlags.NonPublic)!


### PR DESCRIPTION
## The leak

`TestMainWindowFactory.Create()` runs the real `MainWindow` constructor. A real `MainWindow` opens a tab, and a tab is a real `TerminalPane` with a real shell behind it — `cmd.exe` on Windows, `/bin/bash` on CI. Nothing reaped them:

- `Window.Close()` does not dispose the control tree. `PerformAppTeardown()` saves the session and stops timers, but never walks the tabs.
- No test closed its window anyway. Ten test classes across 52 call sites simply dropped the reference.

A full local run finished with **53 live sessions — 212 threads and 53 child processes** — and the children outlived the test host, so the machine accumulates orphaned shells across runs. Beyond the waste, it is the same class of ambient-state contamination the headless lane has been fighting: leftover work from a finished test that the next one inherits.

Found by instrumenting `RustPtySession` with a live-instance registry that attributed each session to the test that built it. That instrumentation is **not** in this PR.

## The fix

`MainWindow.DisposeAllPanesForTest()`, called from each test class's `IDisposable.Dispose()` via the factory, which tracks what it hands out.

The walk lives in `MainWindow` rather than in the test helper on purpose. A correct one has to know that `EnterPaneZoom` moves a tab's real root **off the visual tree** into `_paneZoomStateByTab` and leaves only the zoomed pane in `ti.Content` — so disposing the content of a zoomed tab reaches one pane and abandons its siblings. `CloseTab` already exits zoom first for exactly that reason, and this mirrors it. My first attempt reimplemented the walk from outside the class, did not know that, and left the zoom tests' split panes behind.

The `_paneOwnerTab` sweep afterwards closes a second reachability gap: a walk of `Tabs.Items` cannot see a pane whose tab has left the collection, and `MainWindowStartupTests` calls `tabs.Items.Clear()` to build its own strip. It leans on an invariant that already holds — `DisposeControlTree` unwires every pane it disposes, and unwiring removes it from that map — so whatever remains is exactly what the walk missed.

The factory guards on `window.Dispatcher.CheckAccess()`, never `Dispatcher.UIThread`. Reading that static off the dispatch thread binds UI-thread identity to the caller, which is the #81 mechanism fixed in #416, and a teardown that runs at a test boundary is precisely where it would bite next. Failing the guard skips — which leaks, the status quo — rather than trading a leak for a hang.

## Verification

Under CI's own filter (`Lane!=PlatformBoot` plus the category exclusions):

| | live sessions at exit | executed | failures | hang |
|---|---|---|---|---|
| before | 53 | 3,437 | 0 | none |
| after | **0** | 3,437 | 0 | none |

## Two things deliberately not done

**Session disposal stays asynchronous.** `DisposeControlTree` hands it to `Task.Run` so a UI close does not block on a PTY teardown. That means the last test in a host can exit before a queued disposal runs, orphaning one shell — measured at about one across three runs. Making it synchronous instead blocks the dispatch thread for up to two seconds per pane while the render loop is still committing, which produced **23 cleanup failures** (`MediaContext.CommitCompositorsWithThrottling`, cross-thread) and fixed nothing. The orphan is the smaller problem, and the offload is deliberate in production.

**No current test leaks through the `_paneOwnerTab` gap.** The tests that clear the tab collection never call `Show()`, so `TermView` has no size, `InitializeSession` returns early, and no shell is spawned. Measured both with and without the sweep: zero either way. The sweep is kept so the fix does not quietly regress if one of them ever shows its window — not because it fixes an observed leak.

## Also noticed, not touched

`DisposeAllTabs`, on the `ApplySessionSnapshot` path, has the same zoom blind spot and does not exit zoom before disposing. Whether it is reachable while zoomed is unverified, so it is left alone rather than changed on a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7tAwn18it2PotNSiLkRTD
