### PR TITLE
fix(command-assist): make disposal terminal, not just a cancellation

### DIFF
--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -51,6 +51,7 @@ public sealed class CommandAssistController : IDisposable
     private readonly SuggestionOrchestrator _suggestionOrchestrator;
     private readonly List<AssistSuggestion> _suggestions = new();
     private readonly Action<Action> _dispatch;
+    private volatile bool _isDisposed;
 
     /// <summary>
     /// The AI content-provider seam (V2 Phase 5). Every Help row and every Fix row on the surface
@@ -568,7 +569,23 @@ public sealed class CommandAssistController : IDisposable
         }
         finally
         {
-            ResetSubmissionState();
+            // Guarded, because this is on the far side of an await that does history I/O and the
+            // pane starts the whole method fire-and-forget: close a pane while an append is in
+            // flight and the continuation used to write six view-model fields into a surface that
+            // was already gone (local codex review, P2-1).
+            //
+            // Guarded rather than routed through DispatchSurfaceWrite, which was the first attempt
+            // and hung the headless lane. Every other caller of that gate was already dispatching;
+            // this one was not, and posting it instead puts a finished test's leftover reset on the
+            // dispatcher queue the whole assembly shares, to be run inside whichever test comes
+            // next. That run stopped at SshInteractionServiceTests, the plain-[Fact] class
+            // TestAppBuilder.cs warns about, in the same place the #81 regression stopped. Whether
+            // this write belongs on the pane's dispatcher at all is a real question, and a separate
+            // one from the disposal it is here to fix.
+            if (!_isDisposed)
+            {
+                ResetSubmissionState();
+            }
         }
     }
 
@@ -636,19 +653,74 @@ public sealed class CommandAssistController : IDisposable
     }
 
     /// <summary>
-    /// Cancels any suggestion pass still in flight, so nothing this controller started can
-    /// publish after its owner has let go of it.
+    /// Cancels any suggestion pass still in flight and stops this controller starting another, so
+    /// nothing it began can publish after its owner has let go of it.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Deliberately not <see cref="Dismiss"/>: dismissing is a user-visible act that writes to
     /// the view model, and by the time an owner disposes us the surface it would write to is
     /// already going away. The only thing worth doing here is stopping the work - a pass that
     /// lands after its owner is gone reaches a dispatch delegate whose UI is no longer there,
     /// which is one half of what made #81 possible.
+    /// </para>
+    /// <para>
+    /// Cancelling alone was not enough, which is what this used to do (#416 review). Every entry
+    /// point on this class stays callable after disposal, and several of them are reached by
+    /// something other than the user: a shell-integration event, a command that finishes, a
+    /// keystroke whose debounce is still running. Any one of those queues a fresh pass through
+    /// <see cref="QueueRefreshSuggestions"/>, and cancelling the previous pass says nothing about
+    /// the next. The orchestrator's disposal is terminal for exactly that reason, and the guard
+    /// lives there rather than here so it covers every route into a pass rather than the routes
+    /// this method happens to know about.
+    /// </para>
     /// </remarks>
     public void Dispose()
     {
-        _suggestionOrchestrator.CancelPending();
+        _isDisposed = true;
+        _suggestionOrchestrator.Dispose();
+    }
+
+    /// <summary>
+    /// Dispatches a write to the assist surface, unless this controller has been disposed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The ranking pass is not the only thing that publishes late. Help, Fix and the
+    /// command-accepted reset all await a provider or a pipeline and then post a view-model write
+    /// to the pane's dispatcher, and an owner can let go of the controller inside any of those
+    /// awaits. Checked on both sides of the post for the same reason
+    /// <see cref="SuggestionOrchestrator"/> does: the outer check is about not posting at all, and
+    /// the inner one covers a disposal that happens while the write sits in the queue.
+    /// </para>
+    /// <para>
+    /// Check-then-call, not an atomic admission, and deliberately so (local codex review, P2-2). A
+    /// caller can pass the outer check, be preempted while <see cref="Dispose"/> runs, and still
+    /// reach <c>_dispatch</c>. What survives that window is one enqueue of a delegate that does
+    /// nothing: the dispatch the host injects captured the pane's own <c>Dispatcher</c> at
+    /// construction and only calls <c>CheckAccess</c>/<c>Post</c> on it - it never reads
+    /// <c>Dispatcher.UIThread</c>, the static whose late read is what made #81 possible - and the
+    /// inner check drops the write when the queued action runs. Closing the window means holding a
+    /// lock across <c>_dispatch</c>, which runs the action inline whenever the caller is already on
+    /// the dispatch thread, so it would trade an inert enqueue for arbitrary work under a lock.
+    /// </para>
+    /// </remarks>
+    private void DispatchSurfaceWrite(Action write)
+    {
+        if (_isDisposed)
+        {
+            return;
+        }
+
+        _dispatch(() =>
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            write();
+        });
     }
 
     /// <summary>
@@ -882,7 +954,7 @@ public sealed class CommandAssistController : IDisposable
             ? AssistEmptyStates.NoLocalHelp
             : AssistEmptyStates.ForMissingProvider(AssistCapabilities.EnrichDocs);
 
-        _dispatch(() => ApplyHelperSuggestions(
+        DispatchSurfaceWrite(() => ApplyHelperSuggestions(
             _modeRouter.ChooseModeForHelpRequest(),
             effectiveQuery,
             suggestions,
@@ -969,7 +1041,7 @@ public sealed class CommandAssistController : IDisposable
 
         if (mode == CommandAssistMode.Fix)
         {
-            _dispatch(() => ApplyHelperSuggestions(
+            DispatchSurfaceWrite(() => ApplyHelperSuggestions(
                 CommandAssistMode.Fix,
                 context.CommandText,
                 suggestions,
@@ -987,7 +1059,7 @@ public sealed class CommandAssistController : IDisposable
             return false;
         }
 
-        _dispatch(() => ApplyHelperSuggestions(
+        DispatchSurfaceWrite(() => ApplyHelperSuggestions(
             CommandAssistMode.Fix,
             context.CommandText,
             suggestions,
@@ -1024,7 +1096,7 @@ public sealed class CommandAssistController : IDisposable
     /// the line that just ran stayed on screen over the running command's output.</item>
     /// </list>
     /// <para>
-    /// The surface write goes through <see cref="_dispatch"/>: this runs on the pane's serialized event
+    /// The surface write goes through <see cref="DispatchSurfaceWrite"/>: this runs on the pane's serialized event
     /// dispatcher, which is not the UI thread, and the view-model is bound.
     /// </para>
     /// </remarks>
@@ -1038,7 +1110,7 @@ public sealed class CommandAssistController : IDisposable
                 break;
             case ShellIntegrationEventType.CommandAccepted:
                 _context.CloseCommandInputWindow();
-                _dispatch(ResetSubmissionState);
+                DispatchSurfaceWrite(ResetSubmissionState);
                 break;
             case ShellIntegrationEventType.CommandFinished:
                 _context.CloseCommandInputWindow();

--- a/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
+++ b/src/NovaTerminal.CommandAssist/Application/SuggestionOrchestrator.cs
@@ -145,6 +145,7 @@ internal sealed class SuggestionOrchestrator
 
     private CancellationTokenSource? _refreshCts;
     private int _passesInFlight;
+    private volatile bool _isDisposed;
 
     public SuggestionOrchestrator(
         IHistoryStore historyStore,
@@ -182,7 +183,23 @@ internal sealed class SuggestionOrchestrator
     /// </param>
     public void Refresh(CommandAssistMode requestedMode, bool isExplicitSession, bool isTypingTriggered = false)
     {
+        if (_isDisposed)
+        {
+            return;
+        }
+
         CancellationToken token = BeginPass();
+
+        // Checked again on the far side of BeginPass, because the two lines above are where a
+        // disposal can slip through: read the flag as false, have Dispose set it and cancel what
+        // was current, then install a fresh source of our own that nothing will ever cancel. The
+        // second check hands that source to CancelPending instead of starting a pass on it.
+        if (_isDisposed)
+        {
+            CancelPending();
+            return;
+        }
+
         SuggestionScope scope = ResolveScope(requestedMode, isExplicitSession);
         Interlocked.Increment(ref _passesInFlight);
         _ = RunPassAsync(scope, requestedMode, isExplicitSession, isTypingTriggered, token);
@@ -240,6 +257,26 @@ internal sealed class SuggestionOrchestrator
     {
         CancellationTokenSource? previous = Interlocked.Exchange(ref _refreshCts, null);
         Cancel(previous);
+    }
+
+    /// <summary>
+    /// Cancels the pass in flight and refuses every pass after it. Unlike
+    /// <see cref="CancelPending"/>, which the surface calls routinely - dismiss, Escape, alt-screen -
+    /// and which the very next keystroke is meant to undo, this one is terminal.
+    /// </summary>
+    /// <remarks>
+    /// The distinction is the whole point (#416 review). An owner that has let go of us can still be
+    /// called back: a shell-integration event, a debounced keystroke, a command that finishes after
+    /// the pane is gone. Any of those reaches <c>Refresh</c> through the controller, and cancelling
+    /// the previous pass does nothing to stop the next one from starting - it just leaves a pass
+    /// running with nowhere to publish, which is the shape that made #81 possible.
+    /// </remarks>
+    public void Dispose()
+    {
+        // Flag first, then cancel. The other order leaves a window where a Refresh already past its
+        // own check installs a source after CancelPending has run.
+        _isDisposed = true;
+        CancelPending();
     }
 
     private CancellationToken BeginPass()

--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistContentProviderSeamTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistContentProviderSeamTests.cs
@@ -434,6 +434,35 @@ public sealed class AssistContentProviderSeamTests
             controller.Suggestions.Select(s => s.DisplayText).ToArray());
     }
 
+    /// <summary>
+    /// The ranking pass is not the only thing that can publish after its owner has gone. Help asks
+    /// its providers and then posts the rows to the surface, and a pane can be torn down inside that
+    /// await - the same shape as #81, on a path the pass's own cancellation says nothing about.
+    /// </summary>
+    /// <remarks>
+    /// The disposal happens inside the provider rather than on a timer, so there is no window to get
+    /// right: the controller is gone before the await that follows it has resumed.
+    /// </remarks>
+    [Fact]
+    public async Task Controller_WhenDisposedWhileHelpIsBeingAnswered_PublishesNothing()
+    {
+        var provider = new RecordingProvider(
+            "p.docs",
+            AssistCapabilities.EnrichDocs,
+            docs: [Doc("ssh")],
+            recipes: [Doc("ssh -p 2222 user@host")]);
+        CommandAssistController controller = CreateController(new AssistContentProviderRegistry([provider]));
+        provider.OnQuery = controller.Dispose;
+
+        await controller.OpenHelpAsync("ssh user@host");
+
+        // The provider did answer - this is not a test that the query was skipped - and the answer
+        // went nowhere.
+        Assert.Single(provider.Requests);
+        Assert.Empty(controller.Suggestions);
+        Assert.False(controller.ViewModel.IsVisible);
+    }
+
     [Fact]
     public async Task Controller_WhenAProviderAnswersHelpWithNothing_SaysWeLooked()
     {
@@ -589,6 +618,9 @@ public sealed class AssistContentProviderSeamTests
         }
 
         public List<AssistContentRequest> Requests { get; } = [];
+
+        /// <summary>Runs inside the query, i.e. while the caller is still awaiting it.</summary>
+        public Action? OnQuery { get; set; }
         public int QueryCount => Requests.Count;
         public string Id { get; }
         public string DisplayName => Id;
@@ -599,6 +631,7 @@ public sealed class AssistContentProviderSeamTests
         public Task<AssistContentResult> QueryAsync(AssistContentRequest request, CancellationToken cancellationToken = default)
         {
             Requests.Add(request);
+            OnQuery?.Invoke();
             return Task.FromResult(new AssistContentResult(
                 Id,
                 request.Capability,

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
@@ -704,6 +704,37 @@ public sealed class CommandAssistPassiveBubbleTests
         Assert.Empty(history.Entries);
     }
 
+    /// <summary>
+    /// Enter is the one late write that reaches the surface without a provider behind it: the pane
+    /// starts <see cref="CommandAssistController.HandleEnterAsync"/> fire-and-forget, and its
+    /// <c>finally</c> resets six view-model fields on the far side of a history append. A pane closed
+    /// mid-append used to land that reset on a surface that was already gone.
+    /// </summary>
+    /// <remarks>
+    /// Disposed from inside the append, so there is no window to time: the controller is gone before
+    /// the continuation runs. The surface is given sentinel values first because the reset's own
+    /// effect - an emptied, invisible bubble - is otherwise indistinguishable from the state a fresh
+    /// controller is already in, and a test that cannot tell them apart passes either way.
+    /// </remarks>
+    [Fact]
+    public async Task DisposalWhileASubmissionIsBeingCaptured_KeepsTheResetOffTheSurface()
+    {
+        var history = new RecordingHistoryStore();
+        var grid = new FakeGrid();
+        CommandAssistController controller = CreateController(history, grid);
+
+        controller.ViewModel.QueryText = "sentinel";
+        controller.ViewModel.IsVisible = true;
+        history.OnAppend = controller.Dispose;
+
+        await controller.HandleEnterAsync("git status");
+
+        // The capture itself ran - this is not a test that Enter was dropped.
+        Assert.Single(history.Entries);
+        Assert.Equal("sentinel", controller.ViewModel.QueryText);
+        Assert.True(controller.ViewModel.IsVisible);
+    }
+
     /// <summary>And with it on, the same submission is captured - so the test above is not vacuous.</summary>
     [Fact]
     public async Task HandleEnterAsync_WithHistoryEnabled_Captures()
@@ -886,6 +917,61 @@ public sealed class CommandAssistPassiveBubbleTests
         int dispatchCalls = await RunPassAndAbandonIt(static controller => controller.Dispose());
 
         Assert.Equal(0, dispatchCalls);
+    }
+
+    /// <summary>
+    /// Disposal is terminal, not a dismissal that the next trigger undoes. Cancelling the pass in
+    /// flight was all this used to do (#416 review), and it says nothing about the pass after it:
+    /// every entry point on the controller stays callable once its owner has let go, and several are
+    /// reached by something other than a keystroke - a shell-integration event, a command that
+    /// finishes, a debounce that was already running.
+    /// </summary>
+    /// <remarks>
+    /// Asserted at the debounce rather than at the dispatch delegate, because the two answer
+    /// different questions.
+    /// <see cref="APassAbandonedByDisposingTheController_NeverReachesTheDispatchDelegate"/> says
+    /// nothing was published, which a pass that runs to completion and drops its own outcome would
+    /// also satisfy. This says no pass was started: the injected delay is only ever asked to wait
+    /// from inside one.
+    /// </remarks>
+    [Fact]
+    public async Task ATriggerAfterDisposal_StartsNoFurtherPass()
+    {
+        var history = new RecordingHistoryStore();
+        history.Seed("git status");
+        var grid = new FakeGrid();
+        var delay = new GatedDelay();
+        int dispatchCalls = 0;
+
+        CommandAssistController controller = CreateController(
+            history,
+            grid,
+            delay,
+            dispatch: action =>
+            {
+                Interlocked.Increment(ref dispatchCalls);
+                action();
+            });
+
+        // Baselines rather than zeroes: opening the prompt is itself session setup, and what this
+        // test is about is what happens after the disposal, not what happened before it.
+        int passesBeforeDisposal = delay.RequestCount;
+        int dispatchesBeforeDisposal = Volatile.Read(ref dispatchCalls);
+
+        controller.Dispose();
+
+        grid.SetLine("gi");
+        controller.NotifyInputActivity();
+        delay.ReleaseAll();
+
+        // There is nothing to wait on when the guard holds - no pass, so no HasPassInFlight to watch
+        // fall - which means a broken one has to be given time to get somewhere before this can say
+        // it did not.
+        await Task.Delay(100);
+
+        Assert.False(controller.HasSuggestionPassInFlight);
+        Assert.Equal(passesBeforeDisposal, delay.RequestCount);
+        Assert.Equal(dispatchesBeforeDisposal, Volatile.Read(ref dispatchCalls));
     }
 
     /// <summary>
@@ -1198,6 +1284,9 @@ public sealed class CommandAssistPassiveBubbleTests
             }
         }
 
+        /// <summary>Runs inside the append, i.e. while the capture is still being awaited.</summary>
+        public Action? OnAppend { get; set; }
+
         public Task AppendAsync(CommandHistoryEntry entry, CancellationToken cancellationToken = default)
         {
             lock (_gate)
@@ -1205,6 +1294,7 @@ public sealed class CommandAssistPassiveBubbleTests
                 _entries.Add(entry);
             }
 
+            OnAppend?.Invoke();
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
Closes the P2 Greptile left on #416: `CommandAssistController.Dispose()` cancelled the pass in flight and recorded nothing, so the next callback started a fresh one.

## What was wrong

Cancelling says nothing about the pass *after* it. Every entry point on the controller stays callable once its owner has let go, and several are reached by something other than a keystroke — a shell-integration event, a command that finishes, a debounce already running. Any of those queued a new pass against a surface that was going away: the shape #416 fixed, arriving one call later.

## The guard

It lives in `SuggestionOrchestrator`, not in `Dispose`, so it covers every route into a pass rather than the routes `Dispose` happens to know about. `Refresh` checks on **both** sides of `BeginPass` — the lines between them are where a disposal slips through: read the flag as false, have `Dispose` set it and cancel what was current, then install a fresh source nothing will ever cancel. The second check hands that source to `CancelPending` instead of starting a pass on it. `Dispose` sets the flag before cancelling for the same reason, and stays distinct from `CancelPending`, which the surface calls routinely (dismiss, Escape, alt-screen) and which the next keystroke is meant to undo.

## Wider than the review named

The ranking pass is not the only late publisher. Help, Fix and the command-accepted reset each await a provider or a pipeline and then post a view-model write to the pane's dispatcher; an owner can let go inside any of those awaits. Those go through `DispatchSurfaceWrite` now.

## Local codex review

Two findings before pushing.

**P2-1 — the post-await Enter reset. Right, and fixed.** `HandleEnterAsync` resets six view-model fields in a `finally` on the far side of a history append, and the pane starts the method fire-and-forget, so closing a pane mid-append landed that reset on a surface that was gone.

It is guarded in place rather than dispatched, and the first attempt is why. Routing it through the gate **hung the headless lane**: every other caller of that gate was already dispatching and this one was not, so posting it puts a finished test's leftover reset on the dispatcher queue the whole assembly shares, to run inside whichever test comes next. A heap dump of the hung host had `SshInteractionServiceTests.ChangedHostKey_MapsToChangedPromptViewModel` live on the heap with the dispatcher loop idle — the same test and the same shape as the #81 regression earlier in this series. Whether that write belongs on the pane's dispatcher at all is a real question, and a separate one from the disposal this PR is about.

**P2-2 — the gate is check-then-call, not atomic. Accurate, deliberately not fixed.** What survives the window is one enqueue of a delegate that does nothing: the injected dispatch holds the pane's own `Dispatcher` and only calls `CheckAccess`/`Post` on it — never `Dispatcher.UIThread`, the static whose late read made #81 possible — and the inner check drops the write when the queued action runs. Closing the window means holding a lock across a delegate that runs inline whenever the caller is already on the dispatch thread. The reasoning is in the code, not only here.

## Tests

Three, each confirmed to fail against the unfixed source:

| test | what it pins |
|---|---|
| `ATriggerAfterDisposal_StartsNoFurtherPass` | no pass is *started*, asserted at the debounce — the existing test says nothing was published, which a pass that runs and drops its own outcome would also satisfy |
| `Controller_WhenDisposedWhileHelpIsBeingAnswered_PublishesNothing` | the provider path, disposed from inside the provider |
| `DisposalWhileASubmissionIsBeingCaptured_KeepsTheResetOffTheSurface` | the Enter path, disposed from inside the append |

The last two dispose mid-await, so there is no window to time. The Enter one seeds sentinels first, because the reset's own effect — an emptied, invisible bubble — is indistinguishable from the state a fresh controller is already in, and a test that cannot tell them apart passes either way.

**Local, under CI's own filter: 3,443 executed, 0 failures, no hang.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7tAwn18it2PotNSiLkRTD
