### PR TITLE
docs: retract the disproven #81 explanations still recorded in the tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,25 +300,28 @@ jobs:
 
       # The Avalonia-headless suite (NovaTerminal.App.Tests). continue-on-error here tolerates
       # the HANG only; test failures are blocking, via the allowlist gate below.
-      # It intermittently deadlocks on a testhost teardown hang — a dump-confirmed
-      # framework deadlock in Avalonia.Headless.XUnit 12.0.4 (the latest release),
-      # reported upstream as AvaloniaUI/Avalonia#21467 and tracked here as #81. No
-      # in-repo config fixes it (collection serialization, maxParallelThreads:1, and
-      # ThreadPool.SetMinThreads were all ruled out with dump evidence). Until an
-      # upstream fix lands, run it as continue-on-error so the flake can't block PRs,
-      # while still executing it: a clean run reports real pass/fail and each hang
-      # writes a mini dump (uploaded below) for ongoing diagnosis.
+      #
+      # The hang was long recorded here as an upstream framework deadlock — AvaloniaUI/Avalonia#21467,
+      # tracked as #81 — that no in-repo change could fix. That was wrong, and it is worth being
+      # precise about why, because believing it is what kept anyone from reading a dump for months.
+      # Four hang dumps all showed the same thing: our own Command Assist pass, still in flight from
+      # a finished test, read Avalonia's mutable Dispatcher.UIThread static from a threadpool thread
+      # and became the UI thread. The next test's Compositor then threw inside
+      # EnsureIsolatedApplication(), which sits outside the try in HeadlessUnitTestSession.DispatchCore,
+      # unwinding the one dispatcher loop the assembly shares — after which every remaining test
+      # blocks forever and the trx reports nothing. PR #416 fixed the read; #417 removed the leaked
+      # panes that fed the same contamination. TerminalPane.InitializeCommandAssist has the full
+      # account.
+      #
+      # continue-on-error stays for now anyway, because the claim that replaced the old one has to
+      # earn its keep the same way: a handful of green runs is not evidence that no hang remains.
+      # Revisit by counting hang-dump uploads on main over a few dozen runs; when they stop, drop
+      # continue-on-error from both test steps and delete the hang-dump branch in
+      # check-app-tests-baseline.py.
       #
       # continue-on-error covers the HANG, not the RESULTS. The results are gated by the
       # step below, because "non-blocking" silently became "unread": this job reported
       # success for weeks while 16 tests failed on Windows and 14 on ubuntu.
-      #
-      # Why the hang still needs tolerating even though those failures are fixed: the hang is a
-      # separate, upstream defect (AvaloniaUI/Avalonia#21467) and it is frequent. Six of the last
-      # twenty Unit Tests job-runs on main uploaded a hang dump, so making this step blocking
-      # would red roughly one PR run in three for a reason unrelated to the change under review.
-      # Revisit when that upstream issue is fixed: at that point drop continue-on-error from both
-      # test steps and delete the hang-dump branch in check-app-tests-baseline.py.
       - name: Test (headless App.Tests — hang-tolerant, failures gated below; #81 / AvaloniaUI/Avalonia#21467)
         continue-on-error: true
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -418,10 +418,18 @@ All PRs are automatically checked by CI:
 - unit tests (VT, Rendering, Architecture, Platform, McpServer — blocking)
 - headless App.Tests, in two lanes (`Lane!=PlatformBoot` and `Lane=PlatformBoot`)
   — **failures are blocking**. Both test steps carry `continue-on-error`, but
-  that tolerates the *hang* only: an upstream Avalonia.Headless teardown
-  deadlock (AvaloniaUI/Avalonia#21467, tracked here as #81) hits roughly one run
-  in three, and making the step blocking would red that many PRs for reasons
-  unrelated to the change. The *results* are then gated by the following step,
+  that tolerates the *hang* only. That hang was recorded here for months as an
+  upstream Avalonia.Headless deadlock (AvaloniaUI/Avalonia#21467, tracked as
+  #81) that no in-repo change could address; four dumps say otherwise. It was
+  ours: a Command Assist pass outliving its test read Avalonia's mutable
+  `Dispatcher.UIThread` static from a threadpool thread and became the UI
+  thread, and the next test's throw inside `EnsureIsolatedApplication()` — which
+  Avalonia does not guard — unwound the single dispatcher loop the whole
+  assembly shares, so every remaining test blocked forever and the `.trx`
+  reported nothing. PR #416 fixed it; #417 removed the leaked panes feeding the
+  same contamination. The tolerance stays until run data says the hang is gone,
+  because a handful of green runs is not that evidence. The *results* are then
+  gated by the following step,
   **Check App.Tests failures against the flake allowlist**, which fails the job
   for any failing test not named in `tests/app-tests-known-flaky.txt`. A missing
   `.trx` is the hang and only warns, so the step also prints how many tests

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -17,7 +17,7 @@ namespace NovaTerminal.Pty
         private readonly CancellationTokenSource _cts = new CancellationTokenSource();
         // The read/process loops run on these dedicated threads. Exposed to tests to
         // assert they are background, non-threadpool threads — a leaked session must
-        // not consume the threadpool (#81).
+        // not consume the threadpool.
         private Thread? _readLoopThread;
         private Thread? _processLoopThread;
         internal Thread? ReadLoopThread => _readLoopThread;
@@ -766,10 +766,16 @@ namespace NovaTerminal.Pty
 
             // Start reading and processing on DEDICATED background threads, not the
             // threadpool. These loops make blocking native calls (pty_read) and an
-            // outright-blocking consuming enumerator; on the threadpool a leaked or
-            // slow-to-close session would tie up pool threads and, on low-core CI,
-            // starve the test-run completion -> testhost teardown hang (#81). Dedicated
-            // IsBackground threads never consume the pool and never block process exit.
+            // outright-blocking consuming enumerator, so on the threadpool a leaked or
+            // slow-to-close session ties up pool threads for as long as it lives.
+            // Dedicated IsBackground threads never consume the pool and never block
+            // process exit.
+            //
+            // This was also written as half the fix for the #81 testhost hang, on the
+            // theory that the tied-up pool threads starved the headless dispatcher worker.
+            // The dumps disproved that - every one of them had idle workers - and the real
+            // cause is documented at TerminalPane.InitializeCommandAssist. The threading
+            // choice here stands on its own reasoning above; only the attribution was wrong.
             _readLoopThread = new Thread(ReadLoop) { IsBackground = true, Name = $"PtyRead-{Id:N}" };
             _processLoopThread = new Thread(ProcessLoop) { IsBackground = true, Name = $"PtyProcess-{Id:N}" };
             _writeLoopThread = new Thread(WriteLoop) { IsBackground = true, Name = $"PtyWrite-{Id:N}" };

--- a/tests/NovaTerminal.App.Tests/TestHostThreadPoolConfig.cs
+++ b/tests/NovaTerminal.App.Tests/TestHostThreadPoolConfig.cs
@@ -5,21 +5,31 @@ using System.Threading;
 namespace NovaTerminal.Tests
 {
     /// <summary>
-    /// #81 (part 2): Avalonia.Headless.XUnit's <c>AvaloniaTestCase.Run</c> synchronously
-    /// blocks a worker thread per parallel test (<c>TaskAwaiter&lt;RunSummary&gt;.GetResult()</c>),
-    /// while the single shared <c>HeadlessUnitTestSession</c> dispatcher worker — which
-    /// actually runs those tests — is itself a <c>Task.Run</c> that needs a threadpool
-    /// thread. On a 2-vCPU CI runner the default min worker count (= core count) lets the
-    /// parallel blockers consume every pool thread, so the dispatcher worker can never be
-    /// scheduled, the dispatched test Tasks never complete, and the testhost hangs in
-    /// teardown until --blame-hang aborts it.
-    ///
-    /// Part 1 of the fix (RustPtySession loops moved off the threadpool onto dedicated
-    /// background threads) removed an unbounded second consumer that previously masked
-    /// AND amplified this (and is why an earlier SetMinThreads attempt didn't stick).
-    /// This gives the pool guaranteed headroom so the dispatcher worker is always
-    /// schedulable alongside the bounded set of parallel AvaloniaTestCase.Run blockers.
+    /// Threadpool headroom for a test host that blocks a worker thread per parallel test.
+    /// Avalonia.Headless.XUnit's <c>AvaloniaTestCase.Run</c> ends in
+    /// <c>TaskAwaiter&lt;RunSummary&gt;.GetResult()</c>, and the single shared
+    /// <c>HeadlessUnitTestSession</c> dispatcher worker that actually runs those tests is
+    /// itself a <c>Task.Run</c> needing a pool thread. On a 2-vCPU runner the default min
+    /// worker count is the core count, which leaves the two competing for the same few
+    /// threads.
     /// </summary>
+    /// <remarks>
+    /// <strong>This was written as the fix for #81 and is not one.</strong> The claim it
+    /// carried — that the parallel blockers starved the dispatcher worker out of the pool
+    /// and that starvation was the testhost hang — did not survive the dumps. All four
+    /// specimens showed idle workers, one of them seventeen, so the dispatcher worker was
+    /// schedulable in every hang that was ever captured. The actual cause is a throw out of
+    /// <c>EnsureIsolatedApplication()</c>, which sits outside the try in
+    /// <c>HeadlessUnitTestSession.DispatchCore</c> and so unwinds the assembly's one
+    /// dispatcher loop; <c>TerminalPane.InitializeCommandAssist</c> carries the full account
+    /// and PR #416 the fix.
+    /// <para>
+    /// Kept because giving a pool headroom is defensible for this host on its own terms —
+    /// the blocking described above is real whatever it did or did not cause — and because
+    /// removing it would be a change to the lane's scheduling made on no evidence, which is
+    /// how it came to be here in the first place. What is removed is the causal claim.
+    /// </para>
+    /// </remarks>
     internal static class TestHostThreadPoolConfig
     {
         [ModuleInitializer]


### PR DESCRIPTION
The last of the items left open after #416/#417: four places in the tree still tell a contributor a disproven story about the App.Tests teardown hang.

## What the dumps actually showed

Four times, the same thing: a Command Assist pass still in flight from a finished test read Avalonia's mutable `Dispatcher.UIThread` static from a threadpool thread and became the UI thread. The next test's `Compositor` then threw inside `EnsureIsolatedApplication()` — which sits *outside* the try in `HeadlessUnitTestSession.DispatchCore` — so the throw unwound the single dispatcher loop the whole assembly shares. Every remaining test then blocked forever on a `TaskCompletionSource` nobody could complete, and the `.trx` reported nothing. #416 fixed the read; #417 removed the leaked panes feeding the same contamination.

## What each place said

| file | claimed | status |
|---|---|---|
| `TestHostThreadPoolConfig` | "#81 (part 2)" — parallel `AvaloniaTestCase.Run` blockers starve the dispatcher worker out of the pool | every dump had **idle workers**, one had seventeen |
| `RustPtySession` | "part 1" — leaked sessions tie up pool threads and starve test-run completion | same theory, same evidence against it |
| `ci.yml` | an upstream framework deadlock, `AvaloniaUI/Avalonia#21467`, that no in-repo change could fix | it was ours |
| `CONTRIBUTING.md` | same, plus "hits roughly one run in three" | same |

The last one is the one that cost the most. Believing the hang was upstream and unfixable here is precisely why nobody read a dump for months.

## What stays

**The code.** `SetMinThreads` stays — headroom is defensible for a host that blocks a worker per parallel test whatever it did or did not cause, and removing it would be a scheduling change to the lane made on no evidence, which is how it got here in the first place. The dedicated PTY threads stay — blocking native calls do not belong on the threadpool regardless. In both cases only the causal claim is removed and the standing reasoning is left to hold on its own.

**`continue-on-error`.** On both test steps. The new explanation has to earn its keep the same way the old one failed to, and a handful of green runs is not evidence that no hang remains. Both places now name what would settle it — count hang-dump uploads on `main` over a few dozen runs — so the tolerance has an exit condition instead of an indefinite excuse. Dropping it is a maintainer call on that data, not something this PR should take.

## One thing I did not touch

`CONTRIBUTING.md` also says real-shell PTY tests must share one xUnit collection or they "reintroduce a thread-starvation hang". That is the same *shape* of claim as the two being retracted here, but I have no dump either way, so I left it rather than correct it on a hunch.

**No executable change: the diff is comments, doc comments and prose.** `ci.yml` still parses and the solution still builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U7tAwn18it2PotNSiLkRTD
