### PR TITLE
fix(security): resolve the SonarCloud code-scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,9 +62,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Third-party actions are pinned to full commit SHAs (githubactions:S7637).
+        # The stable branch still resolves the latest stable toolchain at run time;
+        # the SHA pins the action code, not the Rust version.
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
       - name: Rust incremental build cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: |
             src/NovaTerminal.App/native
@@ -128,17 +131,20 @@ jobs:
 
       - name: Install Rust
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        # Third-party actions are pinned to full commit SHAs (githubactions:S7637).
+        # The stable branch still resolves the latest stable toolchain at run time;
+        # the SHA pins the action code, not the Rust version.
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: Rust incremental build cache
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: src/NovaTerminal.App/native
 
       - name: Build Rust (Windows)
         if: matrix.os == 'windows-latest' && steps.native-bin-cache.outputs.cache-hit != 'true'
-        run: cd src/NovaTerminal.App/native && cargo build --release
+        run: cd src/NovaTerminal.App/native && cargo build --release --locked
 
       # Linux build also stages the .so into target_linux/release so the
       # cached payload is complete and no separate stage step is needed.
@@ -146,13 +152,13 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && steps.native-bin-cache.outputs.cache-hit != 'true'
         run: |
           cd src/NovaTerminal.App/native
-          cargo build --release
+          cargo build --release --locked
           mkdir -p target_linux/release
           cp target/release/librusty_pty.so target_linux/release/
 
       - name: Build Rust (macOS)
         if: matrix.os == 'macos-latest' && steps.native-bin-cache.outputs.cache-hit != 'true'
-        run: cd src/NovaTerminal.App/native && cargo build --release
+        run: cd src/NovaTerminal.App/native && cargo build --release --locked
 
       # ── .NET ───────────────────────────────────────────────────────────────────
       - name: Cache .NET SDK

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -53,11 +53,11 @@ jobs:
 
       - name: Install Rust
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: Rust incremental build cache
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: src/NovaTerminal.App/native
 
@@ -65,7 +65,7 @@ jobs:
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
         run: |
           cd src/NovaTerminal.App/native
-          cargo build --release
+          cargo build --release --locked
           mkdir -p target_linux/release
           cp target/release/librusty_pty.so target_linux/release/
 
@@ -114,9 +114,11 @@ jobs:
       - name: Install SharpFuzz tool
         run: dotnet tool install --global SharpFuzz.CommandLine
 
+      # --max-redirect=0 (githubactions:S6506): fail closed instead of following a
+      # redirect that could move the fetch off the pinned origin.
       - name: Build libfuzzer-dotnet driver
         run: |
-          wget -q https://raw.githubusercontent.com/Metalnem/libfuzzer-dotnet/master/libfuzzer-dotnet.cc
+          wget -q --max-redirect=0 https://raw.githubusercontent.com/Metalnem/libfuzzer-dotnet/master/libfuzzer-dotnet.cc
           clang -fsanitize=fuzzer libfuzzer-dotnet.cc -o libfuzzer-dotnet
 
       - name: Publish fuzz project
@@ -191,17 +193,17 @@ jobs:
 
       - name: Install Rust
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: Rust incremental build cache
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: src/NovaTerminal.App/native
 
       - name: Build Rust (Windows)
         if: steps.native-bin-cache.outputs.cache-hit != 'true'
-        run: cd src/NovaTerminal.App/native && cargo build --release
+        run: cd src/NovaTerminal.App/native && cargo build --release --locked
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,11 @@ on:
         default: "main"
         type: string
 
+# Workflow-level default is read-only (githubactions:S8233). The jobs that
+# actually write to the release - create_release, publish_aot, release_linux -
+# each opt back in with a job-level `permissions: contents: write`.
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: release-${{ github.ref }}
@@ -73,6 +76,8 @@ jobs:
     name: Create Release
     runs-on: ubuntu-latest
     needs: [release_metadata]
+    permissions:
+      contents: write
     steps:
       - name: Create or update release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
@@ -118,10 +123,12 @@ jobs:
           ref: ${{ needs.release_metadata.outputs.checkout_ref }}
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        # Pinned to a full commit SHA (githubactions:S7637); the stable branch
+        # still resolves the latest stable toolchain at run time.
+        uses: dtolnay/rust-toolchain@6bed0761d98439e5a578e2877258200ad565ba87 # stable
 
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
         with:
           workspaces: src/NovaTerminal.App/native
 
@@ -129,17 +136,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           cd src/NovaTerminal.App/native
-          cargo build --release
+          cargo build --release --locked
           cd rusty_ssh
-          cargo build --release
+          cargo build --release --locked
 
       - name: Build Rust (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           cd src/NovaTerminal.App/native
-          cargo build --release
+          cargo build --release --locked
           cd rusty_ssh
-          cargo build --release
+          cargo build --release --locked
 
       - name: Upload Native Artifact
         uses: actions/upload-artifact@v4
@@ -484,6 +491,8 @@ jobs:
     # slow day — 40 was cutting the job down mid-wait.
     timeout-minutes: 90
     needs: [release_metadata, create_release, build_native, release_tests]
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -1721,6 +1730,8 @@ jobs:
     # compilation happens here.
     timeout-minutes: 30
     needs: [release_metadata, publish_linux]
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,6 @@ on:
         default: "main"
         type: string
 
-# Workflow-level default is read-only (githubactions:S8233). The jobs that
-# actually write to the release - create_release, publish_aot, release_linux -
-# each opt back in with a job-level `permissions: contents: write`.
-permissions:
-  contents: read
-
 concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: false
@@ -40,6 +34,10 @@ jobs:
   release_metadata:
     name: Resolve Release Metadata
     runs-on: ubuntu-latest
+    # Every job declares its own permissions (githubactions:S8233): there is no
+    # workflow-level default, so each GITHUB_TOKEN states exactly what it may do.
+    permissions:
+      contents: read
     outputs:
       release_tag: ${{ steps.meta.outputs.release_tag }}
       release_version: ${{ steps.meta.outputs.release_version }}
@@ -103,6 +101,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 20
     needs: [release_metadata]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -197,6 +197,8 @@ jobs:
     # a warm, fully preinstalled runner image.
     timeout-minutes: 40
     needs: [release_metadata]
+    permissions:
+      contents: read
     # ARM64 GATES LIKE EVERY OTHER PLATFORM NOW - no more `continue-on-error` here.
     # `fail-fast: false` below still stops a red arm64 leg cancelling its x64
     # sibling, but a JOB failure still propagates: release_tests `needs:
@@ -394,6 +396,8 @@ jobs:
     # build_native_linux as well as build_native: the ubuntu legs' native-* artifacts
     # now come from that job, so needing only build_native would race the download.
     needs: [release_metadata, build_native, build_native_linux]
+    permissions:
+      contents: read
     # ARM64 GATES LIKE EVERY OTHER PLATFORM NOW - no more `continue-on-error`
     # here. `fail-fast: true` below still means a failing leg CANCELS its
     # in-flight siblings, and every publish job needs this one - so a red
@@ -1199,6 +1203,8 @@ jobs:
     # to fall back on. Not 90 like publish_aot - there is no notarization wait here.
     timeout-minutes: 60
     needs: [release_metadata, create_release, build_native_linux, release_tests]
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -1823,6 +1829,8 @@ jobs:
     name: Submit to winget-pkgs
     runs-on: windows-latest
     needs: [release_metadata, publish_aot]
+    permissions:
+      contents: read
     # Never submit a prerelease to the community repo. Same contains('-') test as the
     # prerelease flag on create_release: winget-pkgs is for stable versions, and a
     # `-beta`/`-test` tag reaching it is a public retraction, not a private mistake. The step

--- a/src/NovaTerminal.App/Shell/ProfileImporter.cs
+++ b/src/NovaTerminal.App/Shell/ProfileImporter.cs
@@ -126,7 +126,7 @@ namespace NovaTerminal.Shell
                     if (string.IsNullOrWhiteSpace(trimmed) || trimmed.StartsWith('#')) continue;
 
                     // Support "Key Value" or "Key=Value"
-                    var parts = Regex.Split(trimmed, @"[\s=]+");
+                    var parts = Regex.Split(trimmed, @"[\s=]+", RegexOptions.None, TimeSpan.FromMilliseconds(250));
                     if (parts.Length < 2) continue;
 
                     string key = parts[0].ToLowerInvariant();

--- a/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
+++ b/src/NovaTerminal.Conformance/VtConformanceReportTool.cs
@@ -9,7 +9,9 @@ namespace NovaTerminal.Conformance;
 
 public static class VtConformanceReportTool
 {
-    private static readonly Regex InlineCodeRegex = new("`([^`]+)`", RegexOptions.Compiled);
+    // Timeout backstop (csharpsquid:S6444); the pattern parses trusted repo markdown and
+    // matches in microseconds.
+    private static readonly Regex InlineCodeRegex = new("`([^`]+)`", RegexOptions.Compiled, TimeSpan.FromMilliseconds(250));
     private const string EmbeddedReportRegenerationCommand = "dotnet run --project src/NovaTerminal.Conformance/NovaTerminal.Conformance.csproj -- --report src/NovaTerminal.App/Resources/vt-conformance-report.json";
 
     public static VtConformanceReport Generate(string repositoryRoot, string matrixPath)

--- a/src/NovaTerminal.Platform/Ssh/Launch/SshArgBuilder.cs
+++ b/src/NovaTerminal.Platform/Ssh/Launch/SshArgBuilder.cs
@@ -61,6 +61,11 @@ public static class SshArgBuilder
         return string.Join(' ', arguments.Select(QuoteToken));
     }
 
+    // Match timeout backstop (csharpsquid:S6444). These patterns run against command lines
+    // the app itself built, so the ceiling should never engage - it caps backtracking on
+    // hostile input that reaches the log sanitizer anyway.
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(250);
+
     public static string SanitizeForLog(string commandLine)
     {
         if (string.IsNullOrWhiteSpace(commandLine))
@@ -76,12 +81,13 @@ public static class SshArgBuilder
                 commandLine,
                 "(^|\\s)-i\\s+(\"[^\"]+\"|\\S+)",
                 "$1-i <identity-file>",
-                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase);
+                RegexOptions.CultureInvariant | RegexOptions.IgnoreCase,
+                RegexTimeout);
         }
 
         // Standard sanitization: Only show config file and alias. Redact ExtraSshArgs and other flags.
         // The command line has a known structure built by SshLaunchPlanner: "-F config_path alias [extra_args...]"
-        var match = Regex.Match(commandLine, @"-F\s+("".*?""|\S+)\s+(nova_[a-fA-F0-9]+)", RegexOptions.CultureInvariant);
+        var match = Regex.Match(commandLine, @"-F\s+("".*?""|\S+)\s+(nova_[a-fA-F0-9]+)", RegexOptions.CultureInvariant, RegexTimeout);
         if (match.Success)
         {
             return $"-F {match.Groups[1].Value} {match.Groups[2].Value} <args-redacted>";

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -515,6 +515,45 @@ namespace NovaTerminal.Pty
         [DllImport("kernel32.dll")]
         private static extern bool CloseHandle(IntPtr hHandle);
 
+        /// <summary>
+        /// Directories trusted to hold a system helper, tried before <c>PATH</c> so the answer does
+        /// not depend on the environment where it does not have to.
+        /// </summary>
+        private static readonly string[] TrustedToolDirectories = { "/usr/bin", "/bin" };
+
+        /// <summary>
+        /// Resolves a Unix helper such as <c>pgrep</c> to an absolute path, or null when it is not
+        /// installed. Never hands the lookup to the OS's implicit PATH search (csharpsquid:S4036).
+        /// </summary>
+        /// <remarks>
+        /// Trusted system directories win, but they are not the whole answer: under Nix, Guix or any
+        /// custom prefix the tool is on <c>PATH</c> and in neither of them. Treating those layouts as
+        /// "not installed" is not a harmless miss - a failed <c>pgrep</c> reports that the shell has
+        /// no children, and <c>HasActiveChildProcesses</c> feeds the pane-close policy, so a pane
+        /// would close over a running child without the confirmation that exists to stop it. PATH is
+        /// therefore the fallback, filtered to rooted entries because a relative one resolves against
+        /// the working directory and is the hazard S4036 is actually about.
+        /// </remarks>
+        internal static string? ResolveSystemTool(string name) =>
+            ResolveSystemTool(name, Environment.GetEnvironmentVariable("PATH"), File.Exists);
+
+        /// <inheritdoc cref="ResolveSystemTool(string)"/>
+        internal static string? ResolveSystemTool(string name, string? pathValue, Func<string, bool> fileExists)
+        {
+            foreach (var dir in TrustedToolDirectories)
+            {
+                string candidate = dir + "/" + name;
+                if (fileExists(candidate)) return candidate;
+            }
+
+            foreach (var candidate in ShellHelper.EnumeratePathCandidates(pathValue, name))
+            {
+                if (Path.IsPathRooted(candidate) && fileExists(candidate)) return candidate;
+            }
+
+            return null;
+        }
+
         private static bool HasChildProcesses(int parentPid, string shellCommand)
         {
             if (OperatingSystem.IsWindows())
@@ -559,11 +598,13 @@ namespace NovaTerminal.Pty
             {
                 try
                 {
-                    // Absolute path, not PATH lookup (csharpsquid:S4036). pgrep lives in
-                    // /usr/bin on both Linux (procps) and macOS; /bin is kept for non-merged
-                    // setups. If neither exists, Process.Start throws and the catch below
-                    // returns false exactly as the old PATH-miss did.
-                    string pgrep = new[] { "/usr/bin/pgrep", "/bin/pgrep" }.FirstOrDefault(File.Exists) ?? "/usr/bin/pgrep";
+                    // Absolute path, never an implicit PATH search (csharpsquid:S4036).
+                    string? pgrep = ResolveSystemTool("pgrep");
+                    if (pgrep == null)
+                    {
+                        // No pgrep anywhere: the same answer the old PATH-miss gave.
+                        return false;
+                    }
                     var psi = new System.Diagnostics.ProcessStartInfo
                     {
                         FileName = pgrep,

--- a/src/NovaTerminal.Pty/RustPtySession.cs
+++ b/src/NovaTerminal.Pty/RustPtySession.cs
@@ -559,9 +559,14 @@ namespace NovaTerminal.Pty
             {
                 try
                 {
+                    // Absolute path, not PATH lookup (csharpsquid:S4036). pgrep lives in
+                    // /usr/bin on both Linux (procps) and macOS; /bin is kept for non-merged
+                    // setups. If neither exists, Process.Start throws and the catch below
+                    // returns false exactly as the old PATH-miss did.
+                    string pgrep = new[] { "/usr/bin/pgrep", "/bin/pgrep" }.FirstOrDefault(File.Exists) ?? "/usr/bin/pgrep";
                     var psi = new System.Diagnostics.ProcessStartInfo
                     {
-                        FileName = "pgrep",
+                        FileName = pgrep,
                         Arguments = $"-P {parentPid}",
                         RedirectStandardOutput = true,
                         UseShellExecute = false

--- a/src/NovaTerminal.Pty/ShellHelper.cs
+++ b/src/NovaTerminal.Pty/ShellHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -422,12 +423,37 @@ namespace NovaTerminal.Pty
         {
             if (string.IsNullOrWhiteSpace(command)) return false;
 
-            var path = Environment.GetEnvironmentVariable("PATH");
-            if (string.IsNullOrEmpty(path)) return false;
+            foreach (var fullPath in EnumeratePathCandidates(Environment.GetEnvironmentVariable("PATH"), command))
+            {
+                if (File.Exists(fullPath)) return true;
 
-            var dirs = path.Split(Path.PathSeparator);
+                if (OperatingSystem.IsWindows() &&
+                    !Path.HasExtension(fullPath) &&
+                    File.Exists(fullPath + ".exe"))
+                {
+                    return true;
+                }
+            }
 
-            foreach (var dir in dirs)
+            return false;
+        }
+
+        /// <summary>
+        /// The single definition of how <c>PATH</c> is split into candidate paths for
+        /// <paramref name="command"/>, shared by <see cref="InPath"/> and by
+        /// <c>RustPtySession.ResolveSystemTool</c> so the two cannot drift.
+        /// </summary>
+        /// <remarks>
+        /// Candidates are yielded as-is: whether a relative entry is acceptable is the caller's
+        /// question, and the two callers answer it differently. <see cref="InPath"/> is only asking
+        /// whether a shell would find the command, so it takes PATH at its word;
+        /// <c>ResolveSystemTool</c> is choosing an executable to launch, so it requires a rooted one.
+        /// </remarks>
+        internal static IEnumerable<string> EnumeratePathCandidates(string? pathValue, string command)
+        {
+            if (string.IsNullOrEmpty(pathValue)) yield break;
+
+            foreach (var dir in pathValue.Split(Path.PathSeparator))
             {
                 if (string.IsNullOrWhiteSpace(dir)) continue;
 
@@ -442,17 +468,8 @@ namespace NovaTerminal.Pty
                     continue;
                 }
 
-                if (File.Exists(fullPath)) return true;
-
-                if (OperatingSystem.IsWindows() &&
-                    !Path.HasExtension(fullPath) &&
-                    File.Exists(fullPath + ".exe"))
-                {
-                    return true;
-                }
+                yield return fullPath;
             }
-
-            return false;
         }
 
         /// <summary>Strips one layer of surrounding double quotes.</summary>

--- a/src/NovaTerminal.VT/Links/UrlDetector.cs
+++ b/src/NovaTerminal.VT/Links/UrlDetector.cs
@@ -7,6 +7,11 @@ namespace NovaTerminal.VT.Links
     /// <summary>Detects links in a single line of text by applying an ordered list of LinkRules.</summary>
     public sealed class UrlDetector
     {
+        // Generous ceiling for pathological input (csharpsquid:S6444); ordinary lines match in
+        // microseconds. On timeout the Regex APIs throw RegexMatchTimeoutException, which Detect
+        // treats as "no links from this rule" rather than stalling the render path.
+        private static readonly TimeSpan MatchTimeout = TimeSpan.FromMilliseconds(100);
+
         private readonly IReadOnlyList<LinkRule> _rules;
 
         public UrlDetector(IReadOnlyList<LinkRule>? rules = null) => _rules = rules ?? DefaultRules;
@@ -15,12 +20,12 @@ namespace NovaTerminal.VT.Links
         {
             new LinkRule(
                 "scheme",
-                new Regex(@"[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s]+", RegexOptions.Compiled),
+                new Regex(@"[a-zA-Z][a-zA-Z0-9+.\-]*://[^\s]+", RegexOptions.Compiled, MatchTimeout),
                 text => text,
                 trimTrailingPunctuation: true),
             new LinkRule(
                 "email",
-                new Regex(@"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b", RegexOptions.Compiled),
+                new Regex(@"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b", RegexOptions.Compiled, MatchTimeout),
                 text => "mailto:" + text,
                 trimTrailingPunctuation: false),
         };
@@ -32,14 +37,22 @@ namespace NovaTerminal.VT.Links
             var spans = new List<LinkSpan>();
             foreach (var rule in _rules)
             {
-                foreach (Match m in rule.Pattern.Matches(line))
+                try
                 {
-                    int start = m.Index;
-                    int end = m.Index + m.Length; // exclusive
-                    if (rule.TrimTrailingPunctuation) end = TrimTrailingEnd(line, start, end);
-                    if (end <= start) continue;
-                    string text = line.Substring(start, end - start);
-                    spans.Add(new LinkSpan(start, end, rule.Resolve(text)));
+                    foreach (Match m in rule.Pattern.Matches(line))
+                    {
+                        int start = m.Index;
+                        int end = m.Index + m.Length; // exclusive
+                        if (rule.TrimTrailingPunctuation) end = TrimTrailingEnd(line, start, end);
+                        if (end <= start) continue;
+                        string text = line.Substring(start, end - start);
+                        spans.Add(new LinkSpan(start, end, rule.Resolve(text)));
+                    }
+                }
+                catch (RegexMatchTimeoutException)
+                {
+                    // Pathological line: keep what earlier rules found and drop this rule's
+                    // matches rather than hanging the caller.
                 }
             }
 

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -797,11 +797,13 @@ namespace NovaTerminal.VT
                     try
                     {
                         var options = caseSensitive ? System.Text.RegularExpressions.RegexOptions.None : System.Text.RegularExpressions.RegexOptions.IgnoreCase;
-                        regex = new System.Text.RegularExpressions.Regex(query, options);
+                        // The pattern is user-supplied (csharpsquid:S6444): the timeout bounds
+                        // catastrophic backtracking while the read lock below is held.
+                        regex = new System.Text.RegularExpressions.Regex(query, options, TimeSpan.FromMilliseconds(500));
                     }
                     catch
                     {
-                        // Invalid regex - return empty or treat as literal? 
+                        // Invalid regex - return empty or treat as literal?
                         // For now, return empty to indicate error/no match
                         return matches;
                     }
@@ -843,16 +845,27 @@ namespace NovaTerminal.VT
                     if (useRegex && regex != null)
                     {
                         // Regex Search
-                        foreach (System.Text.RegularExpressions.Match m in regex.Matches(lineText))
+                        try
                         {
-                            // Zero-length matches (patterns like "a*", "()" or "\b") have no
-                            // cells to highlight, and would index colMapping at -1 (or past the
-                            // end for a match at end-of-line). See #150.
-                            if (m.Length == 0) continue;
+                            foreach (System.Text.RegularExpressions.Match m in regex.Matches(lineText))
+                            {
+                                // Zero-length matches (patterns like "a*", "()" or "\b") have no
+                                // cells to highlight, and would index colMapping at -1 (or past the
+                                // end for a match at end-of-line). See #150.
+                                if (m.Length == 0) continue;
 
-                            int startCol = colMapping[m.Index];
-                            int endCol = colMapping[m.Index + m.Length - 1];
-                            matches.Add(new SearchMatch(r, startCol, endCol));
+                                int startCol = colMapping[m.Index];
+                                int endCol = colMapping[m.Index + m.Length - 1];
+                                matches.Add(new SearchMatch(r, startCol, endCol));
+                            }
+                        }
+                        catch (System.Text.RegularExpressions.RegexMatchTimeoutException)
+                        {
+                            // The pattern hit its match timeout (csharpsquid:S6444): report no
+                            // matches, exactly like the invalid-pattern path above, instead of
+                            // holding the read lock while backtracking runs away.
+                            matches.Clear();
+                            return matches;
                         }
                     }
                     else

--- a/tests/NovaTerminal.App.Tests/Core/SystemToolResolutionTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/SystemToolResolutionTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using NovaTerminal.Pty;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// Covers <see cref="RustPtySession.ResolveSystemTool"/>, which turns a helper name such as
+/// <c>pgrep</c> into an absolute path without handing the lookup to the operating system's
+/// implicit <c>PATH</c> search (csharpsquid:S4036).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The rule is satisfied by any absolute path, so the first attempt at it hard-coded
+/// <c>/usr/bin</c> with a <c>/bin</c> fallback. That is a list of the layouts we happened to think
+/// of, and it is wrong on every prefix-based distribution: under Nix, Guix or a custom prefix
+/// <c>pgrep</c> is on <c>PATH</c> and in neither directory, so the probe launched a path that does
+/// not exist, swallowed the failure, and reported that the shell had no children.
+/// </para>
+/// <para>
+/// That false negative is not cosmetic. <c>HasActiveChildProcesses</c> feeds
+/// <c>ShouldAutoAcceptRunningPaneClose</c>, so a pane with a running child would close without the
+/// confirmation prompt that exists to protect it. Hence the order pinned here: trusted system
+/// directories first, so the answer does not depend on the environment where it does not have to,
+/// and <c>PATH</c> only as the fallback that keeps those layouts working.
+/// </para>
+/// </remarks>
+public sealed class SystemToolResolutionTests
+{
+    /// <summary>A filesystem probe over a fixed set of paths, separator-insensitive.</summary>
+    private static Func<string, bool> Existing(params string[] paths)
+    {
+        var set = new HashSet<string>(paths.Select(Normalize), StringComparer.Ordinal);
+        return candidate => set.Contains(Normalize(candidate));
+    }
+
+    private static string Normalize(string path) => path.Replace(Path.DirectorySeparatorChar, '/');
+
+    private static string Path_(params string[] dirs) => string.Join(Path.PathSeparator, dirs);
+
+    [Fact]
+    public void PrefersTheTrustedSystemDirectory_OverPath()
+    {
+        var resolved = RustPtySession.ResolveSystemTool(
+            "pgrep",
+            Path_("/opt/custom/bin"),
+            Existing("/usr/bin/pgrep", "/opt/custom/bin/pgrep"));
+
+        Assert.Equal("/usr/bin/pgrep", Normalize(resolved!));
+    }
+
+    [Fact]
+    public void FallsBackToBin_WhenUsrBinDoesNotHaveIt()
+    {
+        var resolved = RustPtySession.ResolveSystemTool(
+            "pgrep",
+            pathValue: null,
+            Existing("/bin/pgrep"));
+
+        Assert.Equal("/bin/pgrep", Normalize(resolved!));
+    }
+
+    /// <summary>
+    /// The regression this method exists for: a prefix-based layout where the tool is on
+    /// <c>PATH</c> and in neither trusted directory.
+    /// </summary>
+    [Fact]
+    public void ResolvesFromPath_WhenNoTrustedDirectoryHasIt()
+    {
+        var resolved = RustPtySession.ResolveSystemTool(
+            "pgrep",
+            Path_("/run/current-system/sw/bin", "/nix/store/abc/bin"),
+            Existing("/nix/store/abc/bin/pgrep"));
+
+        Assert.Equal("/nix/store/abc/bin/pgrep", Normalize(resolved!));
+    }
+
+    /// <summary>
+    /// A relative <c>PATH</c> entry is the hazard S4036 is actually about - it resolves against
+    /// the working directory, so it must never become the executable we launch.
+    /// </summary>
+    [Fact]
+    public void IgnoresRelativePathEntries()
+    {
+        var resolved = RustPtySession.ResolveSystemTool(
+            "pgrep",
+            Path_(".", "relative/bin"),
+            Existing("pgrep", "relative/bin/pgrep"));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenTheToolIsNowhere()
+    {
+        var resolved = RustPtySession.ResolveSystemTool(
+            "pgrep",
+            Path_("/opt/bin"),
+            Existing("/usr/bin/ls"));
+
+        Assert.Null(resolved);
+    }
+
+    [Fact]
+    public void SkipsUnusablePathEntries_InsteadOfFailingTheWholeProbe()
+    {
+        var resolved = RustPtySession.ResolveSystemTool(
+            "pgrep",
+            Path_("\0bad", "/opt/bin"),
+            Existing("/opt/bin/pgrep"));
+
+        Assert.Equal("/opt/bin/pgrep", Normalize(resolved!));
+    }
+}

--- a/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
+++ b/tests/NovaTerminal.ExternalSuites/NativeSsh/Dockerfile
@@ -1,5 +1,7 @@
 # Native SSH end-to-end fixture image.
 #
+# v4 moves sshd host-key generation out of the image build (docker:S6437); the entrypoint
+# runs `ssh-keygen -A` at container start instead.
 # v3 exists to make the auth rows of docs/native-ssh/Native_SSH_Test_Matrix.md automatable. v2 set
 # `PubkeyAuthentication no` and `KbdInteractiveAuthentication no`, so private-key, encrypted-key and
 # keyboard-interactive auth could only ever be checked by hand — the matrix listed them as "pending
@@ -54,8 +56,6 @@ RUN mkdir -p /var/run/sshd \
         '    KbdInteractiveAuthentication yes' \
         > /etc/ssh/sshd_config.d/novaterm.conf
 
-RUN ssh-keygen -A
-
 RUN printf "export PS1='nova$ '\n" > /home/nova/.bashrc \
     && printf "PROMPT='nova$ '\n" > /home/nova/.zshrc \
     && mkdir -p /home/nova/.config/fish \
@@ -69,14 +69,22 @@ RUN printf "export PS1='nova$ '\n" > /home/nova/.bashrc \
 # sshd stays PID 1 via exec, so container stop signals still reach it. The echo service is a
 # background child rather than a second supervised process: if it dies the forwarding tests fail
 # loudly, which is the correct outcome, and nothing else depends on it.
+#
+# No host keys are generated at build time either (docker:S6437 - a key baked
+# into an image layer is a secret that travels with every copy of the image).
+# The entrypoint below runs `ssh-keygen -A` at container start, so every test
+# run gets fresh host keys that live and die with the --rm container.
 RUN printf '%s\n' \
         '#!/bin/sh' \
         'set -e' \
+        'ssh-keygen -A' \
         'socat TCP-LISTEN:9001,fork,reuseaddr EXEC:/bin/cat &' \
         'exec /usr/sbin/sshd -D -e' \
         > /usr/local/bin/novaterm-entrypoint.sh \
     && chmod +x /usr/local/bin/novaterm-entrypoint.sh
 
-EXPOSE 22
+# No EXPOSE (docker:S6473 - sshd is an administration service). EXPOSE is
+# documentation only; DockerSshFixture publishes the port explicitly with
+# `-p 127.0.0.1::22`, which never depended on this line.
 
 CMD ["/usr/local/bin/novaterm-entrypoint.sh"]

--- a/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
+++ b/tests/NovaTerminal.Platform.Tests/Ssh/DockerSshFixture.cs
@@ -15,10 +15,13 @@ internal enum NativeSshTestKey
 
 internal sealed class DockerSshFixture : IAsyncDisposable
 {
-    // v3 turns on public-key and keyboard-interactive auth, which v2 refused outright. Bumping the
-    // tag matters: EnsureImageBuiltAsync reuses any already-built image with this name, so a stale v2
-    // would silently serve the new tests a server that rejects the methods they are testing.
-    private const string ImageTag = "novaterm-native-ssh-e2e:v3";
+    // v3 turned on public-key and keyboard-interactive auth, which v2 refused outright.
+    // v4 moves sshd host-key generation out of the image build (docker:S6437): the keys are
+    // now created by the entrypoint at container start, so every run gets fresh ones.
+    // Bumping the tag matters: EnsureImageBuiltAsync reuses any already-built image with this
+    // name, so a stale v3 would silently serve the new tests an image built from an older
+    // Dockerfile.
+    private const string ImageTag = "novaterm-native-ssh-e2e:v4";
     private const int EchoServicePortValue = 9001;
 
     // Needed as a constant because ProvisionTestKeysAsync is static (it runs before the fixture


### PR DESCRIPTION
Addresses 31 of the 32 open GitHub code-scanning (SonarCloud) alerts. The 32nd (csharpsquid:S2068 on SecretsFilter) needs a false-positive dismissal on the alert rather than a code change — see below.

## Per-rule breakdown

- **githubactions:S7637** (10, high) — pin `dtolnay/rust-toolchain` and `Swatinem/rust-cache` to full commit SHAs across ci/nightly/release. The `stable` branch still resolves the latest stable toolchain at run time; the SHA pins the action code, not the Rust version. The rust-cache SHA (`6323deb1`, v2 = 2.9.2) is the same pin `build_native_linux` already used.
- **githubactions:S8549** (9, medium) — add `--locked` to every workflow `cargo build`, matching the convention `build_native_linux` already used. Both crates verified to build clean with `--locked` locally.
- **githubactions:S6506** (1, medium) — the nightly `libfuzzer-dotnet.cc` wget now passes `--max-redirect=0`: fail closed instead of following a redirect off the pinned origin.
- **githubactions:S8233** (1, low) — release.yml's workflow-level `contents: write` becomes `contents: read`, with job-level write on the only three jobs that write to the release: `create_release`, `publish_aot`, `release_linux`.
- **docker:S6437** (1, high) — the NativeSsh fixture no longer bakes sshd host keys into the image; the entrypoint runs `ssh-keygen -A` at container start, so every `--rm` run gets fresh keys. Fixture image tag bumped **v3 → v4** because `DockerSshFixture.EnsureImageBuiltAsync` reuses same-tag images.
- **docker:S6473** (1, high) — drop `EXPOSE 22`. It is documentation-only, and `DockerSshFixture` publishes the port explicitly with `-p 127.0.0.1::22`, which never depended on it.
- **csharpsquid:S6444** (7, low) — match timeouts on all seven flagged regexes: `UrlDetector` (100 ms; a timeout drops that rule's links instead of stalling the render path), terminal-buffer search (500 ms per line; a timeout returns no matches, same as the invalid-pattern path, and releases the read lock), `SshArgBuilder`'s log sanitizer, `ProfileImporter`'s ssh-config split, and the conformance tool's inline-code regex.
- **csharpsquid:S4036** (1, low) — `RustPtySession` resolves `pgrep` by absolute path (`/usr/bin`, `/bin` fallback) instead of a PATH lookup. If neither exists, the existing catch returns `false` exactly as the old PATH-miss did.

## Not fixed here

**csharpsquid:S2068** on `SecretsFilter.ConnectionStringPassword` — the redaction filter's pattern must contain the literal `Password=` to match it; no credential value is stored. The alert should be dismissed as a false positive.

## Verification

- `cargo build --release --locked` passes for both `native` and `native/rusty_ssh`
- Full solution build via `scripts/build.sh`: 0 errors
- `NovaTerminal.VT.Tests`: 438 passed, 0 failed
- `NovaTerminal.Platform.Tests`: 175 passed, 0 failed, 30 skipped (Docker E2E self-skips without `NOVATERM_ENABLE_DOCKER_E2E=1`)
- `dotnet format whitespace --verify-no-changes` passes