### PR TITLE
fix(app): make process-wide cached brushes immutable

### DIFF
--- a/src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs
+++ b/src/NovaTerminal.App/AgentOutput/MarkdownTheme.cs
@@ -1,6 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 
 namespace NovaTerminal.AgentOutput;
 
@@ -12,15 +13,15 @@ namespace NovaTerminal.AgentOutput;
 /// </remarks>
 internal sealed class MarkdownTheme
 {
-    private static readonly IBrush FallbackForeground = new SolidColorBrush(Color.FromRgb(0xF3, 0xF6, 0xFA));
-    private static readonly IBrush FallbackSecondary = new SolidColorBrush(Color.FromRgb(0x96, 0xA0, 0xAE));
-    private static readonly IBrush FallbackCodeBackground = new SolidColorBrush(Color.FromRgb(0x16, 0x18, 0x1C));
-    private static readonly IBrush FallbackPanel = new SolidColorBrush(Color.FromRgb(0x1B, 0x1D, 0x21));
-    private static readonly IBrush FallbackHairline = new SolidColorBrush(Color.FromRgb(0x2A, 0x2F, 0x35));
-    private static readonly IBrush FallbackAccent = new SolidColorBrush(Color.FromRgb(0x4C, 0x8B, 0xD8));
-    private static readonly IBrush FallbackAdded = new SolidColorBrush(Color.FromRgb(0x6F, 0xBF, 0x73));
-    private static readonly IBrush FallbackRemoved = new SolidColorBrush(Color.FromRgb(0xD9, 0x6C, 0x6C));
-    private static readonly IBrush FallbackHunk = new SolidColorBrush(Color.FromRgb(0xD6, 0xB0, 0x5C));
+    private static readonly IBrush FallbackForeground = new ImmutableSolidColorBrush(Color.FromRgb(0xF3, 0xF6, 0xFA));
+    private static readonly IBrush FallbackSecondary = new ImmutableSolidColorBrush(Color.FromRgb(0x96, 0xA0, 0xAE));
+    private static readonly IBrush FallbackCodeBackground = new ImmutableSolidColorBrush(Color.FromRgb(0x16, 0x18, 0x1C));
+    private static readonly IBrush FallbackPanel = new ImmutableSolidColorBrush(Color.FromRgb(0x1B, 0x1D, 0x21));
+    private static readonly IBrush FallbackHairline = new ImmutableSolidColorBrush(Color.FromRgb(0x2A, 0x2F, 0x35));
+    private static readonly IBrush FallbackAccent = new ImmutableSolidColorBrush(Color.FromRgb(0x4C, 0x8B, 0xD8));
+    private static readonly IBrush FallbackAdded = new ImmutableSolidColorBrush(Color.FromRgb(0x6F, 0xBF, 0x73));
+    private static readonly IBrush FallbackRemoved = new ImmutableSolidColorBrush(Color.FromRgb(0xD9, 0x6C, 0x6C));
+    private static readonly IBrush FallbackHunk = new ImmutableSolidColorBrush(Color.FromRgb(0xD6, 0xB0, 0x5C));
 
     internal required IBrush Foreground { get; init; }
 

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Layout;
 using Avalonia.Platform;
 using Avalonia.Platform.Storage;
@@ -131,18 +132,18 @@ namespace NovaTerminal
         internal const double TabHeaderViewportPadding = 16;
         // Hoisted out of UpdateVerticalTabExtras: that method runs per tab per visual-refresh
         // pass, and allocating a new SolidColorBrush per tab per pass adds up.
-        private static readonly IBrush TabAttentionBrush = new SolidColorBrush(Color.Parse("#FFD25A"));
+        private static readonly IBrush TabAttentionBrush = new ImmutableSolidColorBrush(Color.Parse("#FFD25A"));
 
         // Agent-aware tab status colors (dot + marker chips). They intentionally match the
         // in-pane agent segment (TerminalPane.ApplyAgentAttention: dot #E8A33D/#4FB0D4, text
         // #F0C07A/#7FC3DC) and the existing tab attention constant above, so the same tier
         // reads as one color everywhere it appears.
-        private static readonly IBrush TabAgentWroteDotBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0xE8, 0xA3, 0x3D));
-        private static readonly IBrush TabAgentWatchedDotBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0x4F, 0xB0, 0xD4));
+        private static readonly IBrush TabAgentWroteDotBrush = new ImmutableSolidColorBrush(Color.FromArgb(0xFF, 0xE8, 0xA3, 0x3D));
+        private static readonly IBrush TabAgentWatchedDotBrush = new ImmutableSolidColorBrush(Color.FromArgb(0xFF, 0x4F, 0xB0, 0xD4));
         private static readonly IBrush TabBellChipBrush = TabAttentionBrush; // #FFD25A
-        private static readonly IBrush TabActivityChipBrush = new SolidColorBrush(Color.FromArgb(0x99, 0xFF, 0xFF, 0xFF));
-        private static readonly IBrush TabAgentWroteChipBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0xF0, 0xC0, 0x7A));
-        private static readonly IBrush TabAgentWatchedChipBrush = new SolidColorBrush(Color.FromArgb(0xFF, 0x7F, 0xC3, 0xDC));
+        private static readonly IBrush TabActivityChipBrush = new ImmutableSolidColorBrush(Color.FromArgb(0x99, 0xFF, 0xFF, 0xFF));
+        private static readonly IBrush TabAgentWroteChipBrush = new ImmutableSolidColorBrush(Color.FromArgb(0xFF, 0xF0, 0xC0, 0x7A));
+        private static readonly IBrush TabAgentWatchedChipBrush = new ImmutableSolidColorBrush(Color.FromArgb(0xFF, 0x7F, 0xC3, 0xDC));
         private bool _isVerticalTabStrip;
         internal bool IsVerticalTabStripActive => _isVerticalTabStrip;
 

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -4,6 +4,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 using Avalonia.Media.TextFormatting;
 using Avalonia.Threading;
 using Avalonia.Platform.Storage;
@@ -1098,7 +1099,7 @@ namespace NovaTerminal.Shell
             System.Array.Empty<NovaTerminal.VT.Links.LinkSpan>();
         private int[] _hoverScanMap = System.Array.Empty<int>();
         private bool _isSelecting = false;
-        private static readonly IBrush SelectionBrush = new SolidColorBrush(Color.FromArgb(100, 51, 153, 255));
+        private static readonly IBrush SelectionBrush = new ImmutableSolidColorBrush(Color.FromArgb(100, 51, 153, 255));
 
         // Session for sending mouse events
         private ITerminalSession? _session;

--- a/tests/NovaTerminal.Architecture.Tests/AvaloniaTestSchedulingTests.cs
+++ b/tests/NovaTerminal.Architecture.Tests/AvaloniaTestSchedulingTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace NovaTerminal.Architecture.Tests;
 
@@ -121,6 +123,248 @@ public class AvaloniaTestSchedulingTests
         ".SetupWithLifetime(",
         ".StartWithClassicDesktopLifetime(",
     ];
+
+    /// <summary>
+    /// No <c>static</c> field or property initializer in <c>src/</c> may construct a thread-affine
+    /// Avalonia drawing object. They are <c>AvaloniaObject</c>s, so every property read goes
+    /// through <c>VerifyAccess</c>: one cached in a static is created once per process, owned by
+    /// whichever thread first touched the type, and every later read from another thread throws.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The headless lane makes that certain rather than unlikely. Under <c>PerTest</c> isolation
+    /// Avalonia nulls <c>Dispatcher.s_uiThread</c> at every test boundary and the next test rebinds
+    /// it to whichever threadpool worker serves it - measured at twenty-one migrations across eight
+    /// workers in one run, by reading the private field directly, since the
+    /// <c>Dispatcher.UIThread</c> property heals the very state a probe is trying to observe. An
+    /// object created under one binding and rendered under another throws
+    /// <c>"The calling thread cannot access this object because a different thread owns it"</c>
+    /// inside <c>MediaContext.Render</c>, and whichever test happens to be pumping the dispatcher
+    /// wears a failure it did not cause.
+    /// </para>
+    /// <para>
+    /// Not hypothetical: six such brushes on <c>MainWindow</c> - the tab dots and marker chips -
+    /// took out eighteen <c>VerticalTabStripTests</c> and <c>TabRunningCommandTests</c> in two of
+    /// five runs on main, in a cascade read as flakiness for months.
+    /// <c>VerticalTabStripTests.DotColorOf</c> reads <c>SolidColorBrush.get_Color</c>, which is the
+    /// throwing frame. It is a production hazard too, not only a test one: any static
+    /// <c>AvaloniaObject</c> touched off the UI thread has the same defect.
+    /// </para>
+    /// <para>
+    /// <strong>Source, not reflection, and deliberately so.</strong> Reading the fields answers the
+    /// question exactly - it sees through arrays, ternaries and auto-property backing fields
+    /// without caring how the initializer was written - and a draft of this guard did that. It also
+    /// runs every declaring type's static initializer, and one of those, <c>AppLogger</c>, truncates
+    /// the real <c>debug.log</c> under <c>%LOCALAPPDATA%</c>. A guard that damages the developer's
+    /// machine to check a rule is not worth the precision, so this reads the text instead.
+    /// </para>
+    /// <para>
+    /// Two gaps are deliberate, both narrow and both preferred to their alternative. A brush that
+    /// a <c>Lazy&lt;IBrush&gt;</c> caches behind a lambda is not reported, because the rule that
+    /// spares a <c>Func&lt;IBrush&gt;</c> factory - nothing past a lambda arrow runs at type-init -
+    /// cannot tell the two apart from the text, and wrongly failing correct code is the worse of
+    /// the two errors. Nor is a target-typed <c>new()</c> buried inside a ternary, where neither
+    /// the initializer's first token nor the constructor names a type. Each further spelling costs
+    /// more false-positive risk than it removes hazard; the common shape - and all sixteen real
+    /// ones - is a plain static field assigned a constructor, and that is caught every way it can
+    /// be written.
+    /// </para>
+    /// <para>
+    /// What it does catch, all verified against a probe: wrapped initializers, fully qualified and
+    /// <c>global::</c> constructors, target-typed <c>new()</c>, auto-properties, and affine objects
+    /// nested anywhere inside the initializer - inside an array, a ternary, a collection
+    /// initializer or a lambda. What it cannot see is a brush built behind a factory method, since
+    /// the initializer no longer names the type. Reviews found the first two drafts of this guard
+    /// short exactly one spelling each, which is the failure the lane rule below already warns
+    /// about, so the limit is stated rather than left to be discovered.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void NoStaticInitializerConstructsAThreadAffineDrawingObject()
+    {
+        var offenders = new List<string>();
+        string root = RepoRoot();
+
+        foreach (string file in Directory.EnumerateFiles(Path.Combine(root, "src"), "*.cs", SearchOption.AllDirectories))
+        {
+            if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                || file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            string text = WithoutCommentsAndLiterals(File.ReadAllText(file));
+            foreach ((int index, string declaration, string initializer) in StaticInitializers(text))
+            {
+                int line = text.Take(index).Count(c => c == (char)10) + 1;
+                string where = $"{Path.GetRelativePath(root, file)}:{line}";
+
+                foreach (Match construction in AffineConstruction.Matches(initializer))
+                {
+                    // Anything past a lambda arrow runs per call, not once at type-init, so a
+                    // cached factory - static Func<IBrush> Make = () => new SolidColorBrush(...) -
+                    // is exactly the "build a fresh instance per use" the message recommends and
+                    // must not be reported for following the advice (local codex review).
+                    if (initializer[..construction.Index].Contains("=>", StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+
+                    offenders.Add($"{where}  {construction.Value}");
+                }
+
+                // The target-typed form names no type on the right, so the type on the left is the
+                // only place the hazard is written down.
+                if (AffineTypeName.IsMatch(declaration) && TargetTypedNew.IsMatch(initializer))
+                {
+                    offenders.Add($"{where}  {declaration.Trim()} new(...)");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "These static initializers construct thread-affine Avalonia drawing objects. A static is "
+            + "created once per process, owned by the thread that first touched the type, and every "
+            + "read from another thread throws \"a different thread owns it\" - in the headless "
+            + "lane, as a render failure inside an unrelated test. Use an immutable equivalent "
+            + "(ImmutableSolidColorBrush, ImmutablePen, ...), which has no property system and no "
+            + "thread affinity, or build a fresh instance per use: "
+            + string.Join("; ", offenders));
+    }
+
+    /// <summary>
+    /// The initializer text of every <c>static</c> field or property, with its offset. Both shapes
+    /// are matched up to the <c>=</c>; the value that follows is taken by balancing brackets to the
+    /// declaration's semicolon, so an array, a ternary, a collection initializer or a lambda is
+    /// inside the span rather than truncating it.
+    /// </summary>
+    /// <remarks>
+    /// A static <em>method</em> cannot match: the field pattern forbids braces before the <c>=</c>,
+    /// so it cannot reach past a method's parameter list into its body, and the property pattern
+    /// requires an <c>=</c> immediately after the accessor block. Either way a local built fresh on
+    /// every call - which is not the hazard - stays out.
+    /// </remarks>
+    private static IEnumerable<(int Index, string Declaration, string Initializer)> StaticInitializers(string text)
+    {
+        foreach (Match declaration in StaticFieldOrProperty.Matches(text))
+        {
+            int i = declaration.Index + declaration.Length;
+            int depth = 0;
+            int start = i;
+
+            while (i < text.Length)
+            {
+                char c = text[i];
+                if (c is '(' or '[' or '{')
+                {
+                    depth++;
+                }
+                else if (c is ')' or ']' or '}')
+                {
+                    depth--;
+                }
+                else if (c == ';' && depth == 0)
+                {
+                    break;
+                }
+
+                i++;
+            }
+
+            yield return (declaration.Index, declaration.Value, text[start..Math.Min(i, text.Length)]);
+        }
+    }
+
+    /// <summary>
+    /// Comments and literals blanked, so a type named in prose or in a string is not a finding.
+    /// Length and offsets are preserved, which is what keeps the reported line numbers honest.
+    /// </summary>
+    private static string WithoutCommentsAndLiterals(string text)
+    {
+        var buffer = new System.Text.StringBuilder(text.Length);
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+
+            if (c == '/' && i + 1 < text.Length && text[i + 1] == '/')
+            {
+                while (i < text.Length && text[i] != (char)10) { buffer.Append(text[i] == (char)10 ? text[i] : ' '); i++; }
+                if (i < text.Length) { buffer.Append(text[i]); }
+                continue;
+            }
+
+            if (c == '/' && i + 1 < text.Length && text[i + 1] == '*')
+            {
+                while (i < text.Length && !(text[i] == '*' && i + 1 < text.Length && text[i + 1] == '/'))
+                {
+                    buffer.Append(text[i] == (char)10 ? text[i] : ' ');
+                    i++;
+                }
+
+                buffer.Append("  ");
+                i++;
+                continue;
+            }
+
+            if (c is '"' or '\'')
+            {
+                char quote = c;
+                bool verbatim = quote == '"' && i > 0 && text[i - 1] == '@';
+                buffer.Append(' ');
+                i++;
+                while (i < text.Length)
+                {
+                    if (!verbatim && text[i] == '\\') { buffer.Append("  "); i += 2; continue; }
+                    if (text[i] == quote)
+                    {
+                        if (verbatim && i + 1 < text.Length && text[i + 1] == quote) { buffer.Append("  "); i += 2; continue; }
+                        break;
+                    }
+
+                    buffer.Append(text[i] == (char)10 ? text[i] : ' ');
+                    i++;
+                }
+
+                buffer.Append(' ');
+                continue;
+            }
+
+            buffer.Append(c);
+        }
+
+        return buffer.ToString();
+    }
+
+    /// <summary>
+    /// The mutable, <c>AvaloniaObject</c>-derived drawing types. The <c>Immutable</c> prefixed
+    /// counterparts are deliberately absent - they are the fix, not the hazard - and the leading
+    /// word boundary is what keeps <c>ImmutableSolidColorBrush</c> from matching
+    /// <c>SolidColorBrush</c>.
+    /// </summary>
+    private const string ThreadAffineDrawingTypes =
+        "SolidColorBrush|LinearGradientBrush|RadialGradientBrush|ConicGradientBrush"
+        + "|ImageBrush|VisualBrush|DrawingBrush|Pen";
+
+    /// <summary>A static field, or a static property whose accessor block is followed by <c>=</c>.</summary>
+    private static readonly Regex StaticFieldOrProperty = new(
+        @"\bstatic\b[^;{}=]*?=" + @"|\bstatic\b[^;{}=]*?\{[^{}]*\}\s*=",
+        RegexOptions.Compiled);
+
+    /// <summary>The declared type naming one of those types, for the target-typed case.</summary>
+    private static readonly Regex AffineTypeName = new(
+        @"\b(?:" + ThreadAffineDrawingTypes + @")\b",
+        RegexOptions.Compiled);
+
+    /// <summary>A bare <c>new()</c> or <c>new { }</c>, which takes its type from the declaration.</summary>
+    private static readonly Regex TargetTypedNew = new(
+        @"^\s*new\s*[({]",
+        RegexOptions.Compiled);
+
+    /// <summary>A construction of one of those types, qualified however the author spelled it.</summary>
+    private static readonly Regex AffineConstruction = new(
+        @"\bnew\s+(?:global::)?(?:[\w.]+\.)?\b(?:" + ThreadAffineDrawingTypes + @")\s*[({]",
+        RegexOptions.Compiled);
 
     private static string RepoRoot()
     {


### PR DESCRIPTION
Fixes the cross-thread cascade that has been reading as flakiness in the headless lane for months, and that turned #419 red twice for reasons that had nothing to do with #419.

## What was wrong

Sixteen `static readonly IBrush` fields held **mutable** `SolidColorBrush` instances — six on `MainWindow` (the tab dots and marker chips), nine in `MarkdownTheme`, one in `TerminalView`. A brush is an `AvaloniaObject`, so every property read goes through `VerifyAccess`. Cache one in a static and it is created **once per process**, owned by whichever thread first touched the type, and every later read from another thread throws.

That is a production hazard wherever a non-UI thread touches one. The headless lane makes it a certainty.

## How it was found

Under `PerTest` isolation Avalonia nulls `Dispatcher.s_uiThread` at every test boundary, and the next test rebinds it to whichever threadpool worker serves it. Instrumenting that field **directly** — the `Dispatcher.UIThread` property's getter binds the field when it is null, so a probe that goes through the property heals the state it is trying to observe, which is why an earlier attempt saw nothing — measured **21 migrations across 8 workers in a single run**.

A brush created under one binding and rendered under another throws `The calling thread cannot access this object because a different thread owns it` inside `MediaContext.Render`, and whichever test happens to be pumping the dispatcher wears a failure it did not cause. `VerticalTabStripTests.DotColorOf` reads `SolidColorBrush.get_Color` — the exact throwing frame.

## Measurement

| | cascade fired |
|---|---|
| clean `main` | **2 of 5** full runs (18 and 19 failures) |
| with this change | **0 of 8** full runs |

The other main runs were clean or carried only the one allowlisted flake, which is why CI has looked green: the gate allowlists exactly one of these tests and the cascade simply had not fired on those runs.

## The guard

A regression test for the cascade would just be the flaky suite again. The invariant — no static initializer constructs a thread-affine drawing object — is checkable, so `AvaloniaTestSchedulingTests` gets it, alongside its existing rules about process-global Avalonia state.

Three rounds of local `codex` review shaped it and **both wrong turns are recorded in the file**:

- *Matching lines* missed spellings — wrapped initializers, target-typed `new()`, qualified and `global::` constructors, auto-properties, collection initializers, ternaries.
- *Reading the fields by reflection* fixed all of that at a stroke, and also ran every declaring type's static initializer. One of those, `AppLogger`, truncates the real `debug.log` under `%LOCALAPPDATA%`. **It did that on my machine before the review caught it.** A guard that damages a developer's machine to check a rule is not worth the precision.

What shipped reads the text but takes the whole initializer by balancing brackets to the declaration's semicolon, so it sees a brush nested in an array, a ternary, a dictionary initializer or a lambda. Comments and string literals are blanked first. Verified against eight offending spellings and five that must not fire, including a `Func<IBrush>` factory — a fourth review round found the guard failing that, which is correct code following the advice in its own error message.

Three gaps are deliberate and stated in the file: a brush behind a factory method, one a `Lazy` caches behind a lambda, and a target-typed `new()` inside a ternary. The `Lazy` case is the price of sparing the `Func` factory — nothing past a lambda arrow runs at type-init and the text cannot tell the two apart, and wrongly failing correct code is the worse error. That is also why I acted on the review round that found a false positive and stopped at the one after it, which offered a narrower false negative in exchange for more false-positive risk.

## Not included

Hiding shown test windows at teardown was tried alongside this and carried none of the improvement — the cascade stayed gone without it — so it is dropped rather than shipped as a second guess.

A residual single failure per run remains, rotating between two `TerminalPane` CommandAssist tests that wait on short `Task.Delay` calls. It predates this change and was masked by the cascade. Separate problem, not fixed here.

Local: architecture suite 68/68; App.Tests under CI's own filter across the 8 runs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
