### PR TITLE
build: fail a test run that aborted, whatever its summary says (#425)

### DIFF
--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -73,5 +73,59 @@ if ($verbs -contains $dotnetArgs[0]) {
     }
 }
 
+# A `test` run that aborts partway still prints a summary, and that summary counts only what
+# ran: a crashed or hung host has been seen printing "Passed! - Failed: 0, Passed: 1582,
+# Total: 1584" over a 3,443-test suite, followed by "Test Run Aborted." on the next line. Read
+# the summary and stop, as a human or an agent skimming output naturally does, and 46% of the
+# suite reports green.
+#
+# CI already refuses to be fooled - check-app-tests-baseline.py compares executed counts against
+# a per-lane floor and treats a missing trx as the hang - but every number gathered by hand comes
+# through this wrapper instead, and it was believing one of those numbers that cost a day. So the
+# wrapper says so itself, loudly, and fails even when dotnet's own exit code does not.
+if ($dotnetArgs[0] -eq 'test') {
+    $aborted = $false
+
+    # 2>&1, because both abort markers are written to stderr - a scan of stdout alone leaves
+    # $aborted false in exactly the case this guard exists for (local codex review). The
+    # preference is relaxed around the call for the same reason: with it set to Stop, native
+    # stderr arriving through the pipeline is itself treated as a terminating error, so the
+    # redirect that makes the markers visible would abort the wrapper before it could read them.
+    # Pinned to English for the duration of the run: VSTest localizes both markers, so on a
+    # non-English host the scan below would look for "Test Run Aborted." while the tool printed
+    # its translation, and the wrapper would report success on a truncated run - the exact failure
+    # it exists to prevent (local codex review). CI's gate scripts already parse the English
+    # strings, so this makes local runs agree with them rather than diverging by locale.
+    $previousLanguage = $env:DOTNET_CLI_UI_LANGUAGE
+    $env:DOTNET_CLI_UI_LANGUAGE = 'en'
+
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & dotnet @dotnetArgs 2>&1 | ForEach-Object {
+            $line = [string]$_
+            if ($line -match '^Test Run Aborted\.' -or $line -match 'The active test run was aborted') {
+                $aborted = $true
+            }
+            $line
+        }
+        $status = $LASTEXITCODE
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+        $env:DOTNET_CLI_UI_LANGUAGE = $previousLanguage
+    }
+
+    if ($aborted) {
+        Write-Output ''
+        Write-Output 'build.ps1: THE TEST RUN WAS ABORTED. The summary above counts only the tests that'
+        Write-Output 'build.ps1: ran before the abort - it is not a result for the suite. Treat it as no'
+        Write-Output 'build.ps1: answer at all, not as a pass.'
+        exit 1
+    }
+
+    exit $status
+}
+
 & dotnet @dotnetArgs
 exit $LASTEXITCODE

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -70,8 +70,65 @@ sweep_stale_hosts() {
     ' 2>/dev/null || true
 }
 
+# A `test` run that aborts partway still prints a summary, and that summary counts only what
+# ran: a crashed or hung host has been seen printing "Passed! - Failed: 0, Passed: 1582,
+# Total: 1584" over a 3,443-test suite, followed by "Test Run Aborted." on the next line. Read
+# the summary and stop, as a human or an agent skimming output naturally does, and 46% of the
+# suite reports green.
+#
+# CI already refuses to be fooled - check-app-tests-baseline.py compares executed counts against
+# a per-lane floor and treats a missing trx as the hang - but every number gathered by hand comes
+# through this wrapper instead, and it was believing one of those numbers that cost a day. So the
+# wrapper says so itself, loudly, and fails even when dotnet's own exit code does not.
+run_test_verb() {
+    local log status pgid
+    log="$(mktemp -t nova-test-XXXXXX.log)"
+
+    # Job control, so the pipeline gets its own process group. Replacing the previous `exec` cost
+    # the wrapper its signal semantics: exec made this process *become* dotnet, so a SIGTERM from
+    # an automation timeout reached it: a plain pipeline leaves bash in front, and dotnet, testhost
+    # and tee survive holding the captured output handles - which is the orphan-holds-the-pipe hang
+    # this whole script exists to prevent (local codex review). The trap forwards to the group.
+    #
+    # `pipefail` is already set at the top of the script, so the pipeline's status is non-zero if
+    # *either* dotnet or tee failed. That matters beyond tidiness: a tee that cannot write leaves
+    # the scan log short, and a short log cannot be trusted to lack an abort marker, so the guard
+    # has to fail closed rather than read a truncated file and call it clean.
+    set -m
+    (
+        DOTNET_CLI_UI_LANGUAGE=en dotnet test -nodeReuse:false "$@" 2>&1 | tee "$log"
+    ) &
+    pgid=$!
+    trap 'kill -TERM -"$pgid" 2>/dev/null || kill -TERM "$pgid" 2>/dev/null' INT TERM
+
+    set +e
+    wait "$pgid"
+    status=$?
+    set -e
+
+    trap - INT TERM
+    set +m
+
+    if grep -qE '^(Test Run Aborted\.|.*The active test run was aborted)' "$log"; then
+        echo ""
+        echo "build.sh: THE TEST RUN WAS ABORTED. The summary above counts only the tests that"
+        echo "build.sh: ran before the abort - it is not a result for the suite. Treat it as no"
+        echo "build.sh: answer at all, not as a pass."
+        rm -f "$log"
+        return 1
+    fi
+
+    rm -f "$log"
+    return "$status"
+}
+
 case "$verb" in
-    build|test|publish|pack|msbuild|clean)
+    test)
+        sweep_stale_hosts
+        run_test_verb "$@"
+        exit $?
+        ;;
+    build|publish|pack|msbuild|clean)
         sweep_stale_hosts
         exec dotnet "$verb" -nodeReuse:false "$@"
         ;;


### PR DESCRIPTION
Closes #425.

## The problem

A `dotnet test` run that aborts partway still prints a summary, and that summary counts only what ran. Observed on this repo:

```
Passed!  - Failed: 0, Passed: 1582, Skipped: 2, Total: 1584
Test Run Aborted.
```

**1,584 of a 3,443-test suite — 46% — reported as `Passed!`.** Read the summary and stop, which is what a human skimming output does and what an agent grepping for `Passed!` does, and a crashed host looks like a clean suite.

CI is not fooled: `check-app-tests-baseline.py` compares executed counts against a per-lane floor and treats a missing trx as the hang. That gate exists because "non-blocking" had quietly become "unread". But every number gathered by hand comes through this wrapper instead, and believing one of those numbers cost real time in this series — twice, in different ways.

## The change

The `test` verb now tees its output, looks for either abort marker, and exits non-zero with a message saying the summary is not a result. It fails **even when dotnet's own exit code is zero**, which is the case that matters — an exit code nobody checked is what let the first one through. Other verbs keep their `exec`.

## Four rounds of local codex review, three of which found real defects

| finding | why it mattered |
|---|---|
| PowerShell scanned stdout only | Both markers go to **stderr**. The guard would have been inert on Windows, in precisely the case it exists for. |
| Markers are localized | On a de-DE host VSTest prints `Testlauf abgebrochen.` and the regex looks straight past it. The run is now pinned to `DOTNET_CLI_UI_LANGUAGE=en` and restored after. |
| Losing `exec` broke signal forwarding | `exec` made the wrapper *become* dotnet, so a SIGTERM from an automation timeout reached it. A plain pipeline leaves bash in front and dotnet, testhost and tee survive holding the captured output handles — the orphan-holds-the-pipe hang this script exists to prevent, reintroduced by a guard against a different one. |
| Fail closed if tee cannot write | A short log cannot be trusted to lack a marker. The script's existing `pipefail` already makes a failed tee a non-zero pipeline status; the reasoning is now written down rather than incidental. |

The signal fix puts the run in its own process group with a trap forwarding INT and TERM.

## Verification

Stubbed `dotnet`, through the real wrapper:

| scenario | wrapper exit |
|---|---|
| abort marker, dotnet exits **0** | **1**, with the message |
| ordinary failures, dotnet exits 1 | 1 |
| clean run | 0 |
| `DOTNET_CLI_UI_LANGUAGE` seen by child | `en` |
| SIGTERM to wrapper | child pipeline dies (verified by process count) |

PowerShell path verified separately against a native command writing the marker to **stderr** and exiting 0 — detected. Both markers also checked against the real console output of the aborted run from 2026-09-05. Real runs still pass through unchanged (Architecture suite 68/68, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
