### PR TITLE
test(command-assist): wait on the assist surface, not on a fixed delay (#424)

### DIFF
--- a/tests/NovaTerminal.App.Tests/CommandAssist/AssistWait.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/AssistWait.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace NovaTerminal.Tests.CommandAssist;
+
+/// <summary>
+/// Waits for the assist surface to reach a state, rather than for a fixed number of milliseconds.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A Help or Fix pass awaits its providers and then posts the surface write to the pane's
+/// dispatcher, so a test that drives one and sleeps is betting that the whole round trip fits
+/// inside the sleep. On a loaded machine it does not, and the assertion on the far side fails for
+/// a reason that has nothing to do with what it is testing (#424). Two tests were losing that bet
+/// roughly once per full run.
+/// </para>
+/// <para>
+/// The timeout is generous on purpose: it is there to turn a hang into a legible failure, not to
+/// bound the wait tightly. A test that needs the whole two seconds is telling you something real,
+/// and the failure reports what actually elapsed so that message is worth reading.
+/// </para>
+/// </remarks>
+internal static class AssistWait
+{
+    private const int DefaultTimeoutMs = 2000;
+    private const int PollMs = 10;
+
+    public static async Task UntilAsync(Func<bool> condition, string because, int timeoutMs = DefaultTimeoutMs)
+    {
+        // A stopwatch rather than a count of polls. Multiplying iterations by the poll interval
+        // assumes each Task.Delay(10) takes 10 ms, and under the loaded machine this helper exists
+        // for it does not - so the ceiling would stretch exactly when it is needed, and the message
+        // would name a duration that never elapsed (local codex review).
+        var clock = Stopwatch.StartNew();
+        while (!condition())
+        {
+            if (clock.ElapsedMilliseconds >= timeoutMs)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {clock.ElapsedMilliseconds} ms (ceiling {timeoutMs} ms) waiting until {because}.");
+            }
+
+            await Task.Delay(PollMs);
+        }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistLayoutTests.cs
@@ -278,7 +278,14 @@ public sealed class CommandAssistLayoutTests
         ConfigureCommandAssist(pane);
         await AtAnIntegratedPromptAsync(pane, "frobnicate");
         pane.OpenCommandAssistHelp();
-        await Task.Delay(50);
+
+        // Waited on the surface rather than on the clock, for the reason in AssistWait: Help awaits
+        // its providers before posting, and a fixed delay is a bet on that round trip fitting inside
+        // it. This test was losing that bet about once per full run (#424).
+        await AssistWait.UntilAsync(
+            () => (pane.FindControl<CommandAssistPopupView>("CommandAssistPopup")?.DataContext
+                       as CommandAssistPopupViewModel)?.IsVisible == true,
+            "the empty-state Help result reached the popup");
 
         CommandAssistPopupView popupView = Assert.IsType<CommandAssistPopupView>(pane.FindControl<CommandAssistPopupView>("CommandAssistPopup"));
         CommandAssistPopupViewModel vm = Assert.IsType<CommandAssistPopupViewModel>(popupView.DataContext);

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalPaneCommandAssistShortcutTests.cs
@@ -131,7 +131,13 @@ public sealed class TerminalPaneCommandAssistShortcutTests
         await TypeAtAnIntegratedPromptAsync(pane, "Get-ChildItem");
 
         bool handled = pane.OpenCommandAssistHelp();
-        await Task.Delay(50);
+
+        // Waited on the surface rather than on the clock. Help awaits its providers and then posts
+        // the write to the pane's dispatcher, so a fixed delay is a bet on that round trip fitting
+        // inside it - a bet this test was losing about once per full run (#424).
+        await AssistWait.UntilAsync(
+            () => pane.CommandAssistViewModel?.IsVisible == true,
+            "the Help pass published to the assist surface");
 
         CommandAssistBarViewModel vm = AssertViewModel(pane);
         Assert.True(handled);


### PR DESCRIPTION
Closes #424.

Two `TerminalPane` tests drove a Help pass and then slept 50 ms before asserting what it produced:

```csharp
bool handled = pane.OpenCommandAssistHelp();
await Task.Delay(50);
...
Assert.True(vm.IsVisible);
```

Help awaits its providers and then posts the surface write to the pane's dispatcher, so the sleep is a bet that the whole round trip fits inside it. On a loaded machine it does not, and the assertion on the far side fails for a reason unrelated to what the test is about. Between them they lost that bet roughly **once per full run** — the residual failure left over once #422 removed the cascade that had been hiding it.

Both now wait on the state they are about to assert, through a small `AssistWait` helper.

## Scope, deliberately narrow

There are **21** fixed delays across these two files. Only the two that actually flaked are converted.

Each conversion has to name the condition the test is waiting for, and a condition chosen carelessly makes a test pass without observing anything — a mistake already made once in this series, in a test whose counter could not distinguish the two outcomes it was meant to tell apart. Converting nineteen more blind would risk nineteen quietly weakened tests to fix a flake that has not been seen in them. The helper is there for the next one that does.

## Local review

Codex caught the helper measuring its timeout by counting polls — `iterations × 10 ms` assumes every `Task.Delay(10)` takes 10 ms, which is exactly what a loaded machine does not do. The ceiling would have stretched precisely when it was needed, and the message would have named a duration that never elapsed. It now uses a stopwatch and reports what actually passed.

## Verification

Full suite under CI's own filter, twice: **3,445 executed, no failures either time.** The flake is roughly one per run, so two clean runs are consistent with the fix rather than proof of it — but the mechanism is not in doubt, and the tests now fail only when the thing they name does not happen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
