### PR TITLE
build: refuse to run on a toolchain that cannot compile (#347)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Both wrappers refuse to run on a toolchain that cannot compile, because the host does
+      # not reliably say so itself: an unresolvable global.json pin has been seen printing "A
+      # compatible .NET SDK was not found" and exiting 0 (#347), which used to reach CI steps
+      # and && chains as a success for a build that produced nothing. Every instruction in
+      # CLAUDE.md routes through these scripts, so this is the exit code the project's tooling
+      # rests on, and it is worth a couple of seconds to know it still works on both shells.
+      # Runs against a stub dotnet, so it needs no SDK and is placed before the toolchain setup.
+      - name: Self-test the build wrappers' SDK guard
+        shell: bash
+        run: |
+          py=python3
+          command -v "$py" >/dev/null 2>&1 || py=python
+          "$py" scripts/tests/build_wrapper_sdk_guard_tests.py
+
       # ── Rust native ────────────────────────────────────────────────────────────
       # Cache the compiled binary keyed on all Rust source files.
       # On a hit the toolchain install, Swatinem, and cargo build are all skipped.

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -74,16 +74,37 @@ if ($dotnetArgs.Count -eq 0) {
     $dotnetArgs = @('build')
 }
 
-# Everything except the forms that do not need an SDK in the first place. Listing the guarded
-# verbs instead was the first draft, and it left `vstest`, `watch`, `tool`, `format` and every
-# future addition able to reproduce the exact bug this guards (local codex review) - an
-# allowlist of a hazard's known spellings catches only the known spellings.
+# Which invocations need an SDK, decided by the first argument that is not an option.
 #
-# The exemptions run on the shared host or the runtime alone, so they still work when no SDK
-# resolves, and the first two are what someone reaches for to find out why none does. A guard
-# that swallowed `--info` would take away the diagnosis along with the failure.
-$firstArg = [string]$dotnetArgs[0]
-if (-not ($firstArg.StartsWith('-') -or $firstArg -eq 'exec' -or $firstArg.EndsWith('.dll'))) {
+# Two earlier drafts of this predicate were wrong in the same direction, both caught by local
+# codex review, and the shape of the mistake is worth keeping written down. The first listed
+# the verbs to guard, which let `vstest`, `watch`, `tool`, `format` and anything added later
+# reproduce the exact bug being guarded. The second inverted that but tested only the leading
+# token, so `--diagnostics build` - a documented SDK-global form - read as SDK-free because it
+# starts with a dash. An allowlist of a hazard's known spellings catches only the known
+# spellings, which is also what the architecture guard in #422 had to be corrected for.
+#
+# So skip leading options and judge what follows. The exemptions are the forms that need no
+# SDK at all: options alone (--info, --list-sdks, --version) are answered by the shared host,
+# and `exec` or a bare app.dll run on the runtime. Those keep working when nothing resolves,
+# and the first two are precisely what someone runs to find out why nothing does - a guard
+# that swallowed them would take the diagnosis away along with the failure.
+#
+# Over-guarding is close to free here: when an SDK does resolve, the probe costs ~150ms and
+# changes nothing. Under-guarding is what returns a green for a build that never happened, so
+# anything ambiguous is guarded.
+function Test-NeedsSdk([string[]] $arguments) {
+    foreach ($argument in $arguments) {
+        if ($argument.StartsWith('-')) { continue }
+        # -like and -eq are case-insensitive here, which is what we want for a file extension.
+        if ($argument -eq 'exec' -or $argument -like '*.dll') { return $false }
+        return $true
+    }
+
+    return $false
+}
+
+if (Test-NeedsSdk $dotnetArgs) {
     Assert-UsableSdk
 }
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -93,6 +93,17 @@ if ($dotnetArgs.Count -eq 0) {
 # Over-guarding is close to free here: when an SDK does resolve, the probe costs ~150ms and
 # changes nothing. Under-guarding is what returns a green for a build that never happened, so
 # anything ambiguous is guarded.
+#
+# Known and deliberate limit: a host option that takes a VALUE (--roll-forward LatestMajor
+# app.dll, --fx-version, --additionalprobingpath) puts a non-option token in front of the
+# .dll, so this guards a runtime-only run that did not need guarding. Fixing it means a table
+# of which host options consume a value - the very allowlist-of-known-spellings shape that
+# produced both defects above, and one whose failure mode when incomplete is the silent green
+# this whole guard exists to stop. The trade is deliberate: this direction costs a loud, wrong
+# refusal on a form that appears nowhere in the repo or its docs, and the other direction
+# costs a build that reports success without building. No invocation like it exists today; if
+# one ever does, exempt it explicitly rather than teaching this predicate to parse the host's
+# option grammar.
 function Test-NeedsSdk([string[]] $arguments) {
     foreach ($argument in $arguments) {
         if ($argument.StartsWith('-')) { continue }

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -74,9 +74,16 @@ if ($dotnetArgs.Count -eq 0) {
     $dotnetArgs = @('build')
 }
 
-# Only the verbs that compile or run code. A host-level query (--info, --list-sdks) is
-# exactly what someone reaches for when the resolver is broken, so it stays unguarded.
-if (@('build','test','publish','pack','msbuild','clean','restore','run') -contains $dotnetArgs[0]) {
+# Everything except the forms that do not need an SDK in the first place. Listing the guarded
+# verbs instead was the first draft, and it left `vstest`, `watch`, `tool`, `format` and every
+# future addition able to reproduce the exact bug this guards (local codex review) - an
+# allowlist of a hazard's known spellings catches only the known spellings.
+#
+# The exemptions run on the shared host or the runtime alone, so they still work when no SDK
+# resolves, and the first two are what someone reaches for to find out why none does. A guard
+# that swallowed `--info` would take away the diagnosis along with the failure.
+$firstArg = [string]$dotnetArgs[0]
+if (-not ($firstArg.StartsWith('-') -or $firstArg -eq 'exec' -or $firstArg.EndsWith('.dll'))) {
     Assert-UsableSdk
 }
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -17,9 +17,67 @@ $ErrorActionPreference = 'Stop'
 
 $env:DOTNET_CLI_USE_MSBUILD_SERVER = '0'
 
+# Refuse to run on a toolchain that cannot compile anything, because the exit code will not
+# say so. When global.json pins an SDK that is not installed, the host prints "A compatible
+# .NET SDK was not found" and has been seen exiting 0 (#347), so the wrapper propagates a
+# success for a build that produced nothing - satisfying a CI step, a && chain, and anyone
+# reading $LASTEXITCODE. It bit for real when main pinned a preview SDK that was later pulled
+# from the CDN: a fresh worktree could not build, and the wrapper said it had.
+#
+# The exit code is not the thing to fix. The same input on the machine this was written on
+# exits 155, so the code is a host implementation detail that varies by version and platform,
+# and the bug was reported from Linux. A guard keyed to 0 would be inert exactly where the
+# next variation shows up.
+#
+# Matching the error text is no better: that message is localized, so a scan for the English
+# spelling would be a silent no-op on a translated host - the mistake the test-abort guard
+# below had to be corrected for once already. So assert the *success* shape instead. On
+# success `dotnet --version` prints a bare version and nothing else; the failure output does
+# contain version-like lines - it lists the installed SDKs - but every one carries a trailing
+# " [path]", so anchoring both ends separates them in any language.
+function Assert-UsableSdk {
+    # Continue for the duration of the call, because with the preference set to Stop the
+    # native stderr this deliberately captures via 2>&1 is itself a terminating error - the
+    # same trap the test path documents below.
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    $status = $null
+    $probe = @()
+    try {
+        $probe = @(& dotnet --version 2>&1 | ForEach-Object { [string]$_ })
+        $status = $LASTEXITCODE
+    }
+    catch {
+        # `dotnet` absent from PATH throws rather than returning a code.
+        $probe = @($_.Exception.Message)
+        $status = 1
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+    }
+
+    if ($status -eq 0 -and @($probe | Where-Object { $_ -match '^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*$' }).Count -gt 0) {
+        return
+    }
+
+    Write-Output ''
+    Write-Output "build.ps1: NO USABLE .NET SDK. 'dotnet --version' did not report one, so nothing would"
+    Write-Output 'build.ps1: have been compiled - whatever exit code the command itself would have gone'
+    Write-Output "build.ps1: on to report. The resolver's own diagnosis follows."
+    Write-Output ''
+    $probe | ForEach-Object { Write-Output $_ }
+    exit 1
+}
+
 $dotnetArgs = @($args)
 if ($dotnetArgs.Count -eq 0) {
     $dotnetArgs = @('build')
+}
+
+# Only the verbs that compile or run code. A host-level query (--info, --list-sdks) is
+# exactly what someone reaches for when the resolver is broken, so it stays unguarded.
+if (@('build','test','publish','pack','msbuild','clean','restore','run') -contains $dotnetArgs[0]) {
+    Assert-UsableSdk
 }
 
 # Insert -nodeReuse:false immediately after the verb (build/test/publish/etc.) so it

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -180,6 +180,17 @@ run_test_verb() {
 # Over-guarding is close to free here: when an SDK does resolve, the probe costs ~150ms and
 # changes nothing. Under-guarding is what returns a green for a build that never happened, so
 # anything ambiguous is guarded.
+#
+# Known and deliberate limit: a host option that takes a VALUE (--roll-forward LatestMajor
+# app.dll, --fx-version, --additionalprobingpath) puts a non-option token in front of the
+# .dll, so this guards a runtime-only run that did not need guarding. Fixing it means a table
+# of which host options consume a value - the very allowlist-of-known-spellings shape that
+# produced both defects above, and one whose failure mode when incomplete is the silent green
+# this whole guard exists to stop. The trade is deliberate: this direction costs a loud, wrong
+# refusal on a form that appears nowhere in the repo or its docs, and the other direction
+# costs a build that reports success without building. No invocation like it exists today; if
+# one ever does, exempt it explicitly rather than teaching this predicate to parse the host's
+# option grammar.
 needs_sdk() {
     local arg lower
     for arg in "$@"; do

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,6 +29,45 @@ fi
 verb="$1"
 shift
 
+# Refuse to run on a toolchain that cannot compile anything, because the exit code will not
+# say so. When global.json pins an SDK that is not installed, the host prints "A compatible
+# .NET SDK was not found" and has been seen exiting 0 (#347): `set -e` and the `exec` below
+# then propagate a success for a build that produced nothing, which satisfies a CI step, an
+# && chain, and anyone reading $?. It bit for real when main pinned a preview SDK that was
+# later pulled from the CDN - a fresh worktree could not build, and this wrapper said it had.
+#
+# The exit code is not the thing to fix. The same input on the machine this was written on
+# exits 155, so the code is a host implementation detail that varies by version and platform,
+# and the bug was reported from Linux. A guard keyed to 0 would be inert exactly where the
+# next variation shows up.
+#
+# Matching the error text is no better: that message is localized, so a scan for the English
+# spelling would be a silent no-op on a translated host - the mistake the test-abort guard
+# below had to be corrected for once already. So assert the *success* shape instead. On
+# success `dotnet --version` prints a bare version and nothing else; the failure output does
+# contain version-like lines - it lists the installed SDKs - but every one carries a trailing
+# " [path]", so anchoring both ends separates them in any language.
+require_sdk() {
+    local probe status
+
+    set +e
+    probe="$(dotnet --version 2>&1)"
+    status=$?
+    set -e
+
+    if [ "$status" -eq 0 ] && printf '%s\n' "$probe" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*$'; then
+        return 0
+    fi
+
+    echo "" >&2
+    echo "build.sh: NO USABLE .NET SDK. 'dotnet --version' did not report one, so nothing would" >&2
+    echo "build.sh: have been compiled - whatever exit code the command itself would have gone" >&2
+    echo "build.sh: on to report. The resolver's own diagnosis follows." >&2
+    echo "" >&2
+    printf '%s\n' "$probe" >&2
+    exit 1
+}
+
 # Sweep processes that lock this tree's build output before compiling: MCP servers that
 # clients left running, and test hosts from an interrupted `test` run. On Windows those hold
 # the DLLs open, so the next run fails with "file is in use" or sits there looking hung
@@ -121,6 +160,12 @@ run_test_verb() {
     rm -f "$log"
     return "$status"
 }
+
+# Only the verbs that compile or run code. A host-level query (--info, --list-sdks) is
+# exactly what someone reaches for when the resolver is broken, so it stays unguarded.
+case "$verb" in
+    build|test|publish|pack|msbuild|clean|restore|run) require_sdk ;;
+esac
 
 case "$verb" in
     test)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -161,18 +161,47 @@ run_test_verb() {
     return "$status"
 }
 
-# Everything except the forms that do not need an SDK in the first place. Listing the guarded
-# verbs instead was the first draft, and it left `vstest`, `watch`, `tool`, `format` and every
-# future addition able to reproduce the exact bug this guards (local codex review) - an
-# allowlist of a hazard's known spellings catches only the known spellings.
+# Which invocations need an SDK, decided by the first argument that is not an option.
 #
-# The exemptions run on the shared host or the runtime alone, so they still work when no SDK
-# resolves, and the first two are what someone reaches for to find out why none does. A guard
-# that swallowed `--info` would take away the diagnosis along with the failure.
-case "$verb" in
-    -*|exec|*.dll) : ;;
-    *) require_sdk ;;
-esac
+# Two earlier drafts of this predicate were wrong in the same direction, both caught by local
+# codex review, and the shape of the mistake is worth keeping written down. The first listed
+# the verbs to guard, which let `vstest`, `watch`, `tool`, `format` and anything added later
+# reproduce the exact bug being guarded. The second inverted that but tested only the leading
+# token, so `--diagnostics build` - a documented SDK-global form - read as SDK-free because it
+# starts with a dash. An allowlist of a hazard's known spellings catches only the known
+# spellings, which is also what the architecture guard in #422 had to be corrected for.
+#
+# So skip leading options and judge what follows. The exemptions are the forms that need no
+# SDK at all: options alone (--info, --list-sdks, --version) are answered by the shared host,
+# and `exec` or a bare app.dll run on the runtime. Those keep working when nothing resolves,
+# and the first two are precisely what someone runs to find out why nothing does - a guard
+# that swallowed them would take the diagnosis away along with the failure.
+#
+# Over-guarding is close to free here: when an SDK does resolve, the probe costs ~150ms and
+# changes nothing. Under-guarding is what returns a green for a build that never happened, so
+# anything ambiguous is guarded.
+needs_sdk() {
+    local arg lower
+    for arg in "$@"; do
+        case "$arg" in
+            -*) continue ;;
+        esac
+
+        # tr rather than ${arg,,}: macOS still ships bash 3.2, where that expansion is a
+        # syntax error, and this script runs there.
+        lower="$(printf '%s' "$arg" | tr '[:upper:]' '[:lower:]')"
+        case "$lower" in
+            exec|*.dll) return 1 ;;
+            *) return 0 ;;
+        esac
+    done
+
+    return 1
+}
+
+if needs_sdk "$verb" "$@"; then
+    require_sdk
+fi
 
 case "$verb" in
     test)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -161,10 +161,17 @@ run_test_verb() {
     return "$status"
 }
 
-# Only the verbs that compile or run code. A host-level query (--info, --list-sdks) is
-# exactly what someone reaches for when the resolver is broken, so it stays unguarded.
+# Everything except the forms that do not need an SDK in the first place. Listing the guarded
+# verbs instead was the first draft, and it left `vstest`, `watch`, `tool`, `format` and every
+# future addition able to reproduce the exact bug this guards (local codex review) - an
+# allowlist of a hazard's known spellings catches only the known spellings.
+#
+# The exemptions run on the shared host or the runtime alone, so they still work when no SDK
+# resolves, and the first two are what someone reaches for to find out why none does. A guard
+# that swallowed `--info` would take away the diagnosis along with the failure.
 case "$verb" in
-    build|test|publish|pack|msbuild|clean|restore|run) require_sdk ;;
+    -*|exec|*.dll) : ;;
+    *) require_sdk ;;
 esac
 
 case "$verb" in

--- a/scripts/tests/build_wrapper_sdk_guard_tests.py
+++ b/scripts/tests/build_wrapper_sdk_guard_tests.py
@@ -1,0 +1,203 @@
+"""
+Behaviour matrix for the SDK-resolution guard in scripts/build.sh and scripts/build.ps1.
+
+The guard exists because a wrapper that reports success for a build which produced nothing is
+worse than no wrapper: CLAUDE.md tells every contributor and agent to use these scripts, so
+this is the exit code the project's tooling is built on. When global.json pins an SDK that is
+not installed, the host prints "A compatible .NET SDK was not found" and has been seen exiting
+0 (#347), and that zero used to travel all the way out.
+
+Two things here are easy to get wrong later, so they are cases rather than comments:
+
+  * The guard must not key on the exit code. The same input exits 0 on the Linux host that
+    reported #347 and 155 on the Windows machine that fixed it, so both are in the table.
+  * It must not key on the English error text, because the host localizes it. The "localized"
+    case carries no English at all; a guard grepping for "A compatible .NET SDK was not found"
+    passes every other case here and fails only that one.
+
+Each case also asserts whether the underlying command RAN, not only what the wrapper exited
+with. A guard that returned 1 while still letting the build proceed would satisfy an
+exit-code-only table, and so would one that blocked everything - including the host queries
+you need in order to diagnose a broken resolver.
+
+Plain python with no test framework, matching the rest of scripts/. Run it directly:
+
+    python scripts/tests/build_wrapper_sdk_guard_tests.py
+
+Exits non-zero if any case behaves differently from the table at the bottom.
+"""
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+BUILD_SH = REPO / "scripts" / "build.sh"
+BUILD_PS1 = REPO / "scripts" / "build.ps1"
+
+# Printed by the stub for any verb that is not --version. Its presence in the output is how a
+# case tells "the guard stopped this" apart from "the guard let it through".
+RAN = "STUB-DOTNET-RAN-THE-COMMAND"
+
+RESOLVER_FAILURE = """The command could not be loaded, possibly because:
+  * You intended to execute a .NET application:
+      The application 'build' does not exist or is not a managed .dll or .exe.
+  * You intended to execute a .NET SDK command:
+      A compatible .NET SDK was not found.
+
+Requested SDK version: 10.0.300-preview.0.26177.108
+global.json file: /repo/global.json
+
+Installed SDKs:
+
+8.0.424 [/usr/share/dotnet/sdk]
+10.0.400 [/usr/share/dotnet/sdk]"""
+
+# The same failure with the English translated away, which is what a host with a non-en UI
+# culture prints. The installed-SDK list stays as it is - those are versions and paths, not
+# prose - which makes this also the case proving that the " [path]" suffix is what stops the
+# list from reading as a successful bare-version line.
+RESOLVER_FAILURE_LOCALIZED = """Der Befehl konnte nicht geladen werden, moeglicherweise weil:
+  * Sie eine .NET-Anwendung ausfuehren wollten:
+      Die Anwendung "build" ist nicht vorhanden.
+  * Sie einen .NET SDK-Befehl ausfuehren wollten:
+      Es wurde kein kompatibles .NET SDK gefunden.
+
+Angeforderte SDK-Version: 10.0.300-preview.0.26177.108
+
+Installierte SDKs:
+
+8.0.424 [/usr/share/dotnet/sdk]
+10.0.400 [/usr/share/dotnet/sdk]"""
+
+HEALTHY = "10.0.400"
+
+
+def write_stub(directory: Path, version_output: str, version_status: int):
+    """
+    A fake `dotnet` that answers --version as configured and announces itself otherwise.
+
+    Both stubs print the canned output with `cat`/`type` from a sibling file rather than
+    building it out of echo lines. That is not tidiness: cmd's echo would need every one of
+    ( ) & < > | ^ escaped, and would turn the blank lines into stray dots, so the fixture
+    would quietly stop resembling what a real host prints.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "version.txt").write_text(version_output + "\n", encoding="utf-8")
+
+    sh = directory / "dotnet"
+    sh.write_text(
+        '#!/usr/bin/env bash\n'
+        'if [ "$1" = "--version" ]; then\n'
+        '  cat "$(dirname "$0")/version.txt"\n'
+        '  exit ' + str(version_status) + '\n'
+        'fi\n'
+        'echo "' + RAN + '"\n'
+        'exit 0\n',
+        encoding="utf-8",
+        newline="\n",
+    )
+    sh.chmod(0o755)
+
+    if os.name == "nt":
+        # PowerShell will not run the extensionless script above; it needs something on
+        # PATHEXT, and .cmd is the one it resolves from PATH the way it resolves dotnet.exe.
+        (directory / "dotnet.cmd").write_text(
+            "@echo off\r\n"
+            'if "%1"=="--version" (\r\n'
+            '  type "%~dp0version.txt"\r\n'
+            "  exit /b " + str(version_status) + "\r\n"
+            ")\r\n"
+            "echo " + RAN + "\r\n"
+            "exit /b 0\r\n",
+            encoding="utf-8",
+        )
+
+
+def run_wrapper(shell: str, exe: str, stub_dir: Path, args):
+    env = dict(os.environ)
+    env["PATH"] = str(stub_dir) + os.pathsep + env["PATH"]
+    # The wrappers sweep leftover test hosts before compiling; irrelevant here, and it shells
+    # out to PowerShell on every case. Opt out.
+    env["NOVA_KEEP_STALE_HOSTS"] = "1"
+
+    if shell == "sh":
+        # as_posix(), because bash receives "D:\path\build.sh" with the backslashes eaten as
+        # escapes and reports the script as missing. Forward slashes work on both platforms.
+        cmd = [exe, BUILD_SH.as_posix()] + args
+    else:
+        cmd = [exe, "-NoProfile", "-File", str(BUILD_PS1)] + args
+
+    p = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=str(REPO))
+    return p.returncode, p.stdout + p.stderr
+
+
+def interpreter(shell: str):
+    """
+    The full path to the interpreter, never the bare name.
+
+    On Windows, handing subprocess a bare "bash" gets WSL's C:\\Windows\\System32\\bash.exe
+    rather than Git Bash: CreateProcess searches System32 before it searches PATH, so the
+    lookup disagrees with both shutil.which and the shell the developer is typing in. That
+    bash cannot see D:\\ at all, so every case failed with "No such file or directory" while
+    the script sat right where the path said it was.
+    """
+    return shutil.which("bash" if shell == "sh" else "pwsh")
+
+
+cases = [
+    # name,                                 version output,             status, args,               exit, ran
+    ("resolver fails, host exits 0 (#347)", RESOLVER_FAILURE,           0,      ["build", "x.sln"], 1,    False),
+    ("resolver fails, host exits 155",      RESOLVER_FAILURE,           155,    ["build", "x.sln"], 1,    False),
+    ("resolver fails, localized message",   RESOLVER_FAILURE_LOCALIZED, 0,      ["build", "x.sln"], 1,    False),
+    ("version printed but status nonzero",  HEALTHY,                    1,      ["build", "x.sln"], 1,    False),
+    ("nothing printed at all, status 0",    "",                         0,      ["build", "x.sln"], 1,    False),
+    # A usable SDK: the guard has to get out of the way, for every verb it covers.
+    ("healthy sdk, build proceeds",         HEALTHY,                    0,      ["build", "x.sln"], 0,    True),
+    ("healthy sdk, publish proceeds",       HEALTHY,                    0,      ["publish"],        0,    True),
+    ("healthy sdk, restore proceeds",       HEALTHY,                    0,      ["restore"],        0,    True),
+    # Host queries stay unguarded even when the resolver is broken: they are what someone runs
+    # to find out why it is broken, so a guard that blocked them would remove the diagnosis.
+    ("broken resolver, --list-sdks passes", RESOLVER_FAILURE,           0,      ["--list-sdks"],    0,    True),
+    ("broken resolver, --info passes",      RESOLVER_FAILURE,           0,      ["--info"],         0,    True),
+]
+
+failures = 0
+ran_any = False
+
+for shell, label in (("sh", "scripts/build.sh"), ("ps1", "scripts/build.ps1")):
+    exe = interpreter(shell)
+    if exe is None:
+        print(f"-- {label}: interpreter not present, skipped")
+        continue
+
+    print(f"-- {label} (via {exe})")
+    for name, out, status, args, expect_code, expect_ran in cases:
+        root = Path(tempfile.mkdtemp())
+        try:
+            write_stub(root / "bin", out, status)
+            code, output = run_wrapper(shell, exe, root / "bin", args)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+        ran = RAN in output
+        ok = code == expect_code and ran == expect_ran
+        failures += 0 if ok else 1
+        ran_any = True
+        print(
+            f"   {'PASS' if ok else 'FAIL'}  {name:<38} "
+            f"exit={code} (want {expect_code})  ran={ran} (want {expect_ran})"
+        )
+        if not ok:
+            print("         " + output.strip().replace("\n", "\n         ")[:600])
+
+# A table that silently ran nothing is the exact failure mode this file is about.
+if not ran_any:
+    print("\nneither bash nor pwsh was available - no case actually ran")
+    sys.exit(1)
+
+print()
+print("all guard cases behaved" if failures == 0 else f"{failures} case(s) misbehaved")
+sys.exit(1 if failures else 0)

--- a/scripts/tests/build_wrapper_sdk_guard_tests.py
+++ b/scripts/tests/build_wrapper_sdk_guard_tests.py
@@ -158,10 +158,22 @@ cases = [
     ("healthy sdk, build proceeds",         HEALTHY,                    0,      ["build", "x.sln"], 0,    True),
     ("healthy sdk, publish proceeds",       HEALTHY,                    0,      ["publish"],        0,    True),
     ("healthy sdk, restore proceeds",       HEALTHY,                    0,      ["restore"],        0,    True),
-    # Host queries stay unguarded even when the resolver is broken: they are what someone runs
-    # to find out why it is broken, so a guard that blocked them would remove the diagnosis.
+    # Verbs the guard does not name individually. The first draft listed the verbs it covered
+    # and let every one of these through (local codex review); they are here so that a later
+    # return to an allowlist fails instead of silently reopening the hole.
+    ("broken resolver, vstest blocked",     RESOLVER_FAILURE,           0,      ["vstest", "x.dll"], 1,   False),
+    ("broken resolver, watch blocked",      RESOLVER_FAILURE,           0,      ["watch", "run"],   1,    False),
+    ("broken resolver, tool blocked",       RESOLVER_FAILURE,           0,      ["tool", "restore"], 1,   False),
+    ("broken resolver, format blocked",     RESOLVER_FAILURE,           0,      ["format"],         1,    False),
+    ("broken resolver, no args blocked",    RESOLVER_FAILURE,           0,      [],                 1,    False),
+    # The exempt forms need no SDK, so they must still work when none resolves - and the host
+    # queries among them are what someone runs to find out why none does. A guard that blocked
+    # these would take the diagnosis away along with the failure.
     ("broken resolver, --list-sdks passes", RESOLVER_FAILURE,           0,      ["--list-sdks"],    0,    True),
     ("broken resolver, --info passes",      RESOLVER_FAILURE,           0,      ["--info"],         0,    True),
+    ("broken resolver, --version passes",   RESOLVER_FAILURE,           0,      ["--version"],      0,    False),
+    ("broken resolver, exec passes",        RESOLVER_FAILURE,           0,      ["exec", "a.dll"],  0,    True),
+    ("broken resolver, a.dll passes",       RESOLVER_FAILURE,           0,      ["a.dll"],          0,    True),
 ]
 
 failures = 0

--- a/scripts/tests/build_wrapper_sdk_guard_tests.py
+++ b/scripts/tests/build_wrapper_sdk_guard_tests.py
@@ -85,6 +85,12 @@ def write_stub(directory: Path, version_output: str, version_status: int):
     would quietly stop resembling what a real host prints.
     """
     directory.mkdir(parents=True, exist_ok=True)
+    # Default newline translation, deliberately: on Windows this writes CRLF, so the healthy
+    # cases there really do feed the guard a Windows host's actual output. That is the one
+    # input that could make the anchored version match reject a good SDK and stop every build
+    # on the machine, and it holds - Git Bash's command substitution drops the CR before the
+    # match sees it. Passing newline="\n" here would look tidier and silently drop the only
+    # coverage of that path.
     (directory / "version.txt").write_text(version_output + "\n", encoding="utf-8")
 
     sh = directory / "dotnet"

--- a/scripts/tests/build_wrapper_sdk_guard_tests.py
+++ b/scripts/tests/build_wrapper_sdk_guard_tests.py
@@ -166,6 +166,10 @@ cases = [
     ("broken resolver, tool blocked",       RESOLVER_FAILURE,           0,      ["tool", "restore"], 1,   False),
     ("broken resolver, format blocked",     RESOLVER_FAILURE,           0,      ["format"],         1,    False),
     ("broken resolver, no args blocked",    RESOLVER_FAILURE,           0,      [],                 1,    False),
+    # SDK-global options come BEFORE the verb, and a predicate that judged only the leading
+    # token read these as SDK-free because they start with a dash (local codex review).
+    ("broken resolver, -d build blocked",   RESOLVER_FAILURE,           0,      ["-d", "build"],    1,    False),
+    ("broken resolver, --diagnostics build", RESOLVER_FAILURE,          0,      ["--diagnostics", "build"], 1, False),
     # The exempt forms need no SDK, so they must still work when none resolves - and the host
     # queries among them are what someone runs to find out why none does. A guard that blocked
     # these would take the diagnosis away along with the failure.
@@ -174,6 +178,8 @@ cases = [
     ("broken resolver, --version passes",   RESOLVER_FAILURE,           0,      ["--version"],      0,    False),
     ("broken resolver, exec passes",        RESOLVER_FAILURE,           0,      ["exec", "a.dll"],  0,    True),
     ("broken resolver, a.dll passes",       RESOLVER_FAILURE,           0,      ["a.dll"],          0,    True),
+    ("broken resolver, -d exec passes",     RESOLVER_FAILURE,           0,      ["-d", "exec", "a.dll"], 0, True),
+    ("broken resolver, upper A.DLL passes", RESOLVER_FAILURE,           0,      ["A.DLL"],          0,    True),
 ]
 
 failures = 0

--- a/scripts/tests/build_wrapper_sdk_guard_tests.py
+++ b/scripts/tests/build_wrapper_sdk_guard_tests.py
@@ -180,6 +180,14 @@ cases = [
     ("broken resolver, a.dll passes",       RESOLVER_FAILURE,           0,      ["a.dll"],          0,    True),
     ("broken resolver, -d exec passes",     RESOLVER_FAILURE,           0,      ["-d", "exec", "a.dll"], 0, True),
     ("broken resolver, upper A.DLL passes", RESOLVER_FAILURE,           0,      ["A.DLL"],          0,    True),
+    # Documented limit, pinned so it is a known trade rather than a surprise: a host option
+    # that takes a value puts a non-option token in front of the .dll, so the predicate
+    # guards a runtime-only run. Telling them apart needs a table of which host options
+    # consume a value - the allowlist shape that caused both defects this guard was already
+    # corrected for, and one that fails silent-green when incomplete. Erring loud is the
+    # trade. Change this case only alongside an explicit exemption, never by teaching the
+    # predicate the host's option grammar.
+    ("--roll-forward + dll guarded (known)", RESOLVER_FAILURE,         0,      ["--roll-forward", "LatestMajor", "a.dll"], 1, False),
 ]
 
 failures = 0


### PR DESCRIPTION
Fixes #347.

## The bug

`global.json` pins an SDK that is not installed. The host prints `A compatible .NET SDK was not found` and **exits 0**. Both wrappers propagated that zero, so a build which produced nothing satisfied a CI step, an `&&` chain, and anyone reading the exit code.

It bit for real: `main` used to pin a preview SDK that was later pulled from the release CDN, so a fresh worktree could not build and the wrapper said it had. The failure was only noticed because the *tests* then failed for unrelated-looking reasons.

Every instruction in `CLAUDE.md` routes contributors and agents through these scripts, so this is the exit code the project's tooling rests on.

## The fix

Probe with `dotnet --version` before dispatching, and **assert the success shape rather than the failure one**. Two things are deliberately not used:

- **Not the exit code.** The same input exits `0` on the Linux host that reported this and `155` on the Windows machine that fixed it. It is a host implementation detail that varies by version and platform, so a guard keyed to `0` would be inert exactly where the next variation appears.
- **Not the error text.** The host localizes it, so a scan for the English spelling would be a silent no-op on a translated host — the mistake #427's abort guard had to be corrected for.

A bare version line is a version line in any language. The installed-SDK list printed on failure looks similar but every entry carries a trailing ` [path]`, so anchoring both ends separates them.

Which invocations are guarded is decided by the **first non-option argument**. Exempt are the forms that need no SDK at all: options alone (answered by the shared host), and `exec` or a bare `app.dll` (which run on the runtime). `--info` and `--list-sdks` staying unguarded is the point — they are what you run to find out why nothing resolves.

## Test

`scripts/tests/build_wrapper_sdk_guard_tests.py`, in the style of the existing gate self-test, run on both OSes in the `build` job. It needs no SDK (it drives a stub `dotnet`), so it sits before the toolchain setup.

23 cases per shell, 46 total. Every case asserts **whether the command actually ran**, not just the exit code — a guard returning 1 while still letting the build proceed would satisfy an exit-code-only table, and so would one that blocked the diagnostics.

**Confirmed non-vacuous:** run against `main`'s wrappers the table reports 20 failures, ten per shell, each with `ran=True` — main really did let a build proceed on a dead toolchain.

## Review history

Local `codex review` found three real defects across four rounds, all the same shape, which is why the comments now record it:

1. The first predicate **listed the verbs to guard**, leaving `vstest`, `watch`, `tool`, `format` and anything added later able to reproduce the exact bug being guarded.
2. Inverting it fixed that but judged only the **leading token**, so `--diagnostics build` — a documented SDK-global form — read as SDK-free because it starts with a dash.
3. A third finding I **declined**: a host option that takes a value (`--roll-forward LatestMajor app.dll`) puts a non-option token in front of the `.dll`, so the predicate guards a runtime-only run. Correct, and deliberately not fixed — telling those apart needs a table of which host options consume a value, the same allowlist shape that caused (1) and (2), and one whose failure mode when incomplete is the silent green this guard exists to stop. No invocation like it exists anywhere in the repo or its docs. Documented in both wrappers and pinned as a case so it reads as a known trade rather than an oversight.

## Verification

- Both wrappers against a stub reproducing the reported exit-0: before `0`, after `1` with the resolver's own diagnosis.
- Real builds, `--version`, `--list-sdks`, and a `dotnet` missing from PATH all behave, on both shells.
- `shellcheck scripts/build.sh` clean apart from the two pre-existing SC2016 infos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)