### PR TITLE
ci(macos): make the dSYM leak assertion unable to pass vacuously (#390)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1247,7 +1247,29 @@ jobs:
           # StripSymbols leaves the dSYM beside the binary; the rm + --exclude above keep
           # it out of the bundle users download. Pin that: no dSYM entry may appear in
           # the Portable zip at all, not even an empty directory skeleton.
-          if unzip -l artifacts/velopack-dryrun/NovaTerminalApp-osx-Portable.zip | grep -q "dSYM"; then
+          #
+          # THIS CHECK COULD PASS WITHOUT INSPECTING ANYTHING (#390), in the same shape the
+          # linux lane's .dbg assertion was hardened out of in #386 - the long note there
+          # explains it in full. The short version, because it is counter-intuitive: the
+          # `set -euo pipefail` at the top of this step is NOT enough on its own. A non-zero
+          # pipeline used as an `if` CONDITION is simply "false"; set -e never sees it. So
+          # with unzip absent, or this zip renamed by a vpk change, the old
+          #   if unzip -l <zip> | grep -q "dSYM"; then
+          # went false and the step passed green having looked at nothing - while a ~94 MB
+          # dSYM shipped inside the bundle users download, with a tick next to it.
+          #
+          # Three things prevent that now: an explicit unzip preflight, an explicit test that
+          # the zip is actually there, and running unzip in a command substitution FIRST -
+          # where set -e does see it fail - then matching the captured listing.
+          command -v unzip >/dev/null             || { echo "unzip is not installed, so the dSYM leak assertion cannot run - do not let this check silently no-op." >&2; exit 1; }
+          # Named exactly, not globbed: vpk emits the version in the nupkg name but not in
+          # this one (verified against the macos-packaging-dryrun artifact), and if that ever
+          # changes this must fail loudly rather than quietly inspect nothing. The sibling
+          # glob assertion above would still pass on a renamed zip, so it cannot cover this.
+          portable_zip=artifacts/velopack-dryrun/NovaTerminalApp-osx-Portable.zip
+          test -f "$portable_zip"             || { echo "$portable_zip is missing, so the dSYM leak assertion cannot run - vpk's output naming has changed." >&2; exit 1; }
+          portable_listing="$(unzip -l "$portable_zip")"
+          if grep -q "dSYM" <<<"$portable_listing"; then
             echo "NovaTerminal.dSYM leaked into the Portable bundle" >&2
             exit 1
           fi


### PR DESCRIPTION
Fixes #390.

## The defect

```sh
if unzip -l artifacts/velopack-dryrun/NovaTerminalApp-osx-Portable.zip | grep -q "dSYM"; then
```

The step already sets `set -euo pipefail`, and **that is not enough**. A non-zero pipeline used as an `if` *condition* is simply "false" — `set -e` never sees it. So when `unzip` fails for any reason the `if` goes false and the step passes green having inspected nothing, while a ~94 MB `dSYM` ships inside the bundle users download.

Same shape the Linux lane's `.dbg` assertion was hardened out of in #386, which scoped macOS out deliberately to keep this lane provably unchanged.

## The fix

The Linux form, applied here: preflight `unzip`, run it in a command substitution where `set -e` *does* see it fail, then match the captured listing via a here-string.

Plus one thing the Linux lane doesn't need: **assert the zip exists by exact name.** A rename is a second, independent way to make the assertion inspect nothing, and the sibling glob assertion above cannot catch it — it passes on a renamed zip (demonstrated below).

I checked whether the hardcoded name was already wrong, since the design doc writes `NovaTerminalApp-<ver>-osx-Portable.zip` and the sibling nupkg assertion does carry the version. It is **not** wrong: I pulled the `macos-packaging-dryrun` artifact from run `33661364008` and vpk emits the version in the nupkg name but not in this one. The check has been inspecting a real file. The `test -f` is there so that a future vpk change fails loudly instead of quietly reverting it to a no-op.

## Demonstration

The lane is macOS-only and `workflow_dispatch`-only, so I ran the assertion text **extracted from `ci.yml` itself** against the real 31 MB Portable zip from that run:

| case | old form | new form |
|---|---|---|
| clean bundle | passes | passes |
| dSYM planted into the real zip | fails correctly | fails correctly |
| unzip absent, dSYM present | `unzip: command not found` → **`ASSERTION PASSED`, exit 0** | exit 1, names the missing tool |
| zip renamed, dSYM present | `cannot find or open` → **`ASSERTION PASSED`, exit 0** | exit 1, names the naming change |

The two bold cells are the bug: a bundle that genuinely contained a `dSYM`, reported green.

## Siblings

The issue asked me to check the `.pkg` / `.nupkg` / `releases.osx.json` assertions in the same step for the same shape. They are sound — each either captures into a command substitution (`test -n "$(ls ... || true)"`) or uses `test -f`, so a failing tool cannot hide behind another command's exit status. Left alone.

## Note

This is hardened in place with a demonstration, matching #386's precedent, rather than under an automated test. Making it testable would mean extracting the assertion into a script file for both lanes — a reasonable follow-up, but a larger change than this issue asks for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)