### PR TITLE
fix(app): refuse a degenerate pane size instead of clamping it to 1x1

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -1634,6 +1634,82 @@ namespace NovaTerminal.Shell
             }
         }
 
+        /// <summary>
+        /// The cell grid a control of <paramref name="size"/> can show, or <see langword="false"/>
+        /// when it cannot show one at all and the caller must keep the size it already had.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This used to clamp instead of refuse - <c>Math.Max(cols, 1)</c>, <c>Math.Max(rows, 1)</c>
+        /// - so a control with no size at all reported a 1x1 grid, and that is a destructive thing
+        /// to tell a terminal buffer. Resizing to a single column re-wraps the whole transcript one
+        /// character per row, which blows the scrollback budget and evicts nearly all of it, and the
+        /// eviction is permanent: growing back cannot restore what the budget already discarded.
+        /// Measured on the buffer directly, a plain resize against a 1x1 round trip:
+        /// </para>
+        /// <code>
+        /// 2000 lines: plain resize keeps 2000, a 1x1 round trip keeps 80
+        ///  200 lines: plain resize keeps  200, a 1x1 round trip keeps 72
+        /// </code>
+        /// <para>
+        /// It also reaches the shell. A 1x1 grid is sent on to the PTY, so the child reflows its
+        /// prompt for a one-column terminal and redraws for it.
+        /// </para>
+        /// <para>
+        /// <c>TerminalBuffer.Resize</c> already refuses non-positive dimensions for this reason,
+        /// keeping the last valid size until a real one arrives. The clamp here defeated that guard
+        /// by manufacturing a positive number from a zero, so the buffer never saw the degenerate
+        /// value it knows to ignore. Refusing keeps the two agreeing.
+        /// </para>
+        /// <para>
+        /// Zero size is ordinary, not exotic: a control that has not been laid out yet, one in a
+        /// collapsed or hidden container, and one detached from the visual tree all measure zero.
+        /// </para>
+        /// </remarks>
+        internal static bool TryComputeGrid(Size size, double cellWidth, double cellHeight, out int cols, out int rows)
+        {
+            cols = 0;
+            rows = 0;
+
+            if (cellWidth <= 0 || cellHeight <= 0)
+            {
+                return false;
+            }
+
+            // Non-finite extents are refused by name. Zero and negative ones need no check of their
+            // own - they divide to a non-positive cell count and fall out of the comparison below -
+            // and NaN converts to 0, so it does too. Infinity does NOT: (int)(double.Infinity / w)
+            // is int.MaxValue, which sails through a "> 0" test as a two-billion-column grid. An
+            // earlier draft of this guard asserted in a comment that both were handled by the
+            // arithmetic; only one of them is.
+            if (!double.IsFinite(size.Width) || !double.IsFinite(size.Height))
+            {
+                return false;
+            }
+
+            // Padding must match TerminalDrawOperation (PaddingLeft = 4); subtracting it here
+            // avoids clipping the last column.
+            double availableWidth = size.Width - 4;
+
+            int candidateCols = (int)(availableWidth / cellWidth);
+            int candidateRows = (int)(size.Height / cellHeight);
+
+            // A fractional cell is not a cell. Refusing rather than rounding up to one keeps a
+            // sliver of a pane from being described as a one-column terminal.
+            //
+            // Both out parameters stay zero unless BOTH dimensions are usable, so a refusal never
+            // hands back a half-computed grid that reads as a real one - a caller that ignored the
+            // return value would otherwise get a plausible column count beside a zero row count.
+            if (candidateCols <= 0 || candidateRows <= 0)
+            {
+                return false;
+            }
+
+            cols = candidateCols;
+            rows = candidateRows;
+            return true;
+        }
+
         protected override void OnSizeChanged(SizeChangedEventArgs e)
         {
             try
@@ -1657,71 +1733,65 @@ namespace NovaTerminal.Shell
 
                     if (_metrics.CellWidth <= 0 || _metrics.CellHeight <= 0) return; // Still zero? Bail.
 
-                    // Padding must match TerminalDrawOperation (PaddingLeft = 4)
-                    // We subtract padding from available width to avoid clipping last column
-                    int availableWidth = Math.Max(0, (int)e.NewSize.Width - 4);
-
-                    int cols = (int)(availableWidth / _metrics.CellWidth);
-                    int rows = (int)(e.NewSize.Height / _metrics.CellHeight);
-
-                    // Enforce minimum dimensions to prevent layout breakage on very small windows
-                    cols = Math.Max(cols, 1);
-                    rows = Math.Max(rows, 1);
-
-                    if (cols > 0 && rows > 0)
+                    if (!TryComputeGrid(e.NewSize, _metrics.CellWidth, _metrics.CellHeight, out int cols, out int rows))
                     {
-                        // DISCRETE RESIZE: Only trigger actual resize when cell dimensions change
-                        bool dimensionsChanged = (cols != _lastSentCols || rows != _lastSentRows);
+                        // Not laid out yet, or too small to hold a single cell. Keep the last
+                        // good size; a real layout pass will follow. See TryComputeGrid for why
+                        // this must not fall back to a 1x1 grid.
+                        return;
+                    }
 
-                        if (dimensionsChanged)
+                    // DISCRETE RESIZE: Only trigger actual resize when cell dimensions change
+                    bool dimensionsChanged = (cols != _lastSentCols || rows != _lastSentRows);
+
+                    if (dimensionsChanged)
+                    {
+                        // Update tracking
+                        _lastSentCols = cols;
+                        _lastSentRows = rows;
+                    }
+
+                    if (!_isReady)
+                    {
+                        _isReady = true;
+                        if (_buffer != null) _buffer.Resize(cols, rows);
+                        ResetMouseMotionTracking(); // Issue #269: grid reflowed, cell coords are stale.
+                        Ready?.Invoke(cols, rows);
+
+                        // Also trigger initial PTY resize to sync with layout
+                        OnResize?.Invoke(cols, rows);
+                    }
+
+                    if (dimensionsChanged)
+                    {
+                        // STRICT INTERVAL THROTTLE: Limit resize dispatch to 60ms
+                        _pendingCols = cols;
+                        _pendingRows = rows;
+                        var now = DateTime.UtcNow;
+                        if (_pendingResizeStartedAt == DateTime.MinValue)
                         {
-                            // Update tracking
-                            _lastSentCols = cols;
-                            _lastSentRows = rows;
+                            _pendingResizeStartedAt = now;
                         }
 
-                        if (!_isReady)
+                        if (_resizeThrottleTimer == null)
                         {
-                            _isReady = true;
-                            if (_buffer != null) _buffer.Resize(cols, rows);
-                            ResetMouseMotionTracking(); // Issue #269: grid reflowed, cell coords are stale.
-                            Ready?.Invoke(cols, rows);
-
-                            // Also trigger initial PTY resize to sync with layout
-                            OnResize?.Invoke(cols, rows);
+                            _resizeThrottleTimer = new DispatcherTimer(DispatcherPriority.Normal)
+                            {
+                                Interval = TimeSpan.FromMilliseconds(60)
+                            };
+                            _resizeThrottleTimer.Tick += OnResizeThrottleTick;
                         }
 
-                        if (dimensionsChanged)
+                        var elapsed = (now - _lastPtyResizeTime).TotalMilliseconds;
+
+                        if (elapsed >= 60 && !_resizeThrottleTimer.IsEnabled)
                         {
-                            // STRICT INTERVAL THROTTLE: Limit resize dispatch to 60ms
-                            _pendingCols = cols;
-                            _pendingRows = rows;
-                            var now = DateTime.UtcNow;
-                            if (_pendingResizeStartedAt == DateTime.MinValue)
-                            {
-                                _pendingResizeStartedAt = now;
-                            }
-
-                            if (_resizeThrottleTimer == null)
-                            {
-                                _resizeThrottleTimer = new DispatcherTimer(DispatcherPriority.Normal)
-                                {
-                                    Interval = TimeSpan.FromMilliseconds(60)
-                                };
-                                _resizeThrottleTimer.Tick += OnResizeThrottleTick;
-                            }
-
-                            var elapsed = (now - _lastPtyResizeTime).TotalMilliseconds;
-
-                            if (elapsed >= 60 && !_resizeThrottleTimer.IsEnabled)
-                            {
-                                // Enough time passed and no pending timer - send immediately
-                                SendThrottledResize();
-                            }
-                            else if (!_resizeThrottleTimer.IsEnabled)
-                            {
-                                _resizeThrottleTimer.Start();
-                            }
+                            // Enough time passed and no pending timer - send immediately
+                            SendThrottledResize();
+                        }
+                        else if (!_resizeThrottleTimer.IsEnabled)
+                        {
+                            _resizeThrottleTimer.Start();
                         }
                     }
                 }

--- a/tests/NovaTerminal.App.Tests/Core/TerminalViewGridSizingTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalViewGridSizingTests.cs
@@ -1,0 +1,89 @@
+using Avalonia;
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// <see cref="TerminalView.TryComputeGrid"/> must refuse a size it cannot express as a cell grid,
+/// rather than clamping one into existence.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The clamp it replaced - <c>Math.Max(cols, 1)</c>, <c>Math.Max(rows, 1)</c> - turned a control
+/// with no size into a 1x1 terminal, and a 1x1 resize is destructive rather than merely useless.
+/// At one column the buffer re-wraps the whole transcript to one character per row, which blows the
+/// scrollback budget; the eviction that follows is permanent, so growing back cannot undo it.
+/// Measured on <c>TerminalBuffer</c> directly, a plain resize against a 1x1 round trip: of 2000
+/// lines, 2000 survive the first and 80 the second; of 200, all 200 against 72.
+/// </para>
+/// <para>
+/// Zero size is ordinary. A control that has not been laid out, one inside a collapsed or hidden
+/// container, and one detached from the visual tree all measure zero, and every one of those used
+/// to be reported to the buffer - and forwarded to the PTY - as a one-by-one terminal.
+/// </para>
+/// <para>
+/// Tested through the seam rather than by driving layout, because what needs pinning is the
+/// decision itself: which sizes are refused, and that the accepted ones are unchanged.
+/// </para>
+/// </remarks>
+public class TerminalViewGridSizingTests
+{
+    private const double CellWidth = 8;
+    private const double CellHeight = 16;
+
+    [Theory]
+    // No size at all: the case the clamp turned into 1x1.
+    [InlineData(0, 0)]
+    [InlineData(0, 800)]
+    [InlineData(1200, 0)]
+    // Narrower than the 4px padding, so no width is left for even one column.
+    [InlineData(4, 800)]
+    [InlineData(3, 800)]
+    // Wide enough for padding but not for a whole cell, and tall enough but not for a whole row.
+    [InlineData(11, 800)]
+    [InlineData(1200, 15)]
+    // The degenerate doubles a layout pass can hand over. These are here because the guard relies
+    // on them falling out of the same comparison rather than being checked for by name, which is
+    // a claim worth pinning rather than trusting.
+    [InlineData(double.NaN, 800)]
+    [InlineData(1200, double.NaN)]
+    [InlineData(double.PositiveInfinity, 800)]
+    [InlineData(1200, double.PositiveInfinity)]
+    [InlineData(-1200, -800)]
+    public void RefusesASizeThatCannotHoldACell(double width, double height)
+    {
+        bool ok = TerminalView.TryComputeGrid(new Size(width, height), CellWidth, CellHeight, out int cols, out int rows);
+
+        Assert.False(ok, $"{width}x{height} should be refused, got {cols}x{rows}");
+        Assert.Equal(0, cols);
+        Assert.Equal(0, rows);
+    }
+
+    /// <summary>Unmeasured text metrics are refused too; they would divide by zero or worse.</summary>
+    [Theory]
+    [InlineData(0, 16)]
+    [InlineData(8, 0)]
+    [InlineData(-1, 16)]
+    public void RefusesUnmeasuredCellMetrics(double cellWidth, double cellHeight)
+    {
+        Assert.False(TerminalView.TryComputeGrid(new Size(1200, 800), cellWidth, cellHeight, out _, out _));
+    }
+
+    /// <summary>
+    /// The accepted cases still compute exactly what they did before, padding included: a real
+    /// resize must not have been narrowed by the guard.
+    /// </summary>
+    [Theory]
+    [InlineData(804, 800, 100, 50)]
+    [InlineData(1200, 800, 149, 50)]
+    [InlineData(12, 16, 1, 1)]     // the smallest size that genuinely holds one cell
+    [InlineData(1200, 807, 149, 50)] // a partial row is dropped, not rounded up
+    public void AcceptsARealSizeAndComputesTheSameGrid(double width, double height, int expectedCols, int expectedRows)
+    {
+        bool ok = TerminalView.TryComputeGrid(new Size(width, height), CellWidth, CellHeight, out int cols, out int rows);
+
+        Assert.True(ok, $"{width}x{height} should be accepted");
+        Assert.Equal(expectedCols, cols);
+        Assert.Equal(expectedRows, rows);
+    }
+}


### PR DESCRIPTION
Found while investigating #404, which is **not** resolved by this PR — see the note at the bottom.

> **Note:** an earlier revision of this line phrased that as "does not f​ix #404". GitHub's issue linker ignores the negation and parsed the keyword, so merging auto-closed #404. It has been reopened. Do not put a closing keyword next to an issue number here, even inside a denial.

## The defect

`TerminalView.OnSizeChanged` computed the cell grid and then clamped it:

```csharp
cols = Math.Max(cols, 1);
rows = Math.Max(rows, 1);
```

So a control with no size reported a **1×1 grid** rather than "no answer". That is destructive, not merely useless. At one column the buffer re-wraps the entire transcript to one character per row, which blows the scrollback budget — and the eviction that follows is **permanent**, so growing back cannot restore what was already discarded. Measured on `TerminalBuffer` directly, a plain resize against a 1×1 round trip:

```
2000 lines: plain resize keeps 2000, a 1x1 round trip keeps 80
 200 lines: plain resize keeps  200, a 1x1 round trip keeps 72
```

The same grid also goes to the PTY, so the child shell reflows its prompt for a one-column terminal.

`TerminalBuffer.Resize` already refuses non-positive dimensions and keeps the last valid size *for exactly this reason*. The clamp defeated that guard by manufacturing a positive number from a zero, so the buffer never saw the value it knows to ignore. Refusing keeps the two agreeing.

Zero size is ordinary, not exotic: a control not yet laid out, one in a collapsed or hidden container, and one detached from the visual tree all measure zero.

## The change

Extracted the decision as `TerminalView.TryComputeGrid` so it can be tested directly rather than by driving layout. Accepted sizes compute exactly what they did before, padding included; the diff is mostly the de-indent from removing the old `if (cols > 0 && rows > 0)` wrapper (`git diff -w` is small).

## Two defects the tests found in the guard itself

1. **A refusal handed back a half-computed grid** — a real column count beside a zero row count — which a caller ignoring the return value would read as valid. Both out parameters now stay zero unless the whole grid is usable.
2. **I claimed in a comment that NaN and infinity were both handled by the arithmetic. Only one is.** NaN converts to `0`; infinity converts to `int.MaxValue` and sailed straight through the `> 0` test as a 2,147,483,647-column grid. Non-finite extents are now refused by name, and both cases are pinned.

## Verification

- 19 focused cases on the seam.
- **Mutation-checked**: reintroducing the old clamp fails the guard's tests, so they would catch its return.
- Full headless lane: 3,449 passed / 0 failed / 15 skipped. PlatformBoot: 50 passed / 0 failed.

## On #404

Deliberately not claimed as a fix, and not marked `Closes`.

I could not reproduce #404. A headless test that splits a real window and measures the original pane's buffer passes on unmodified `main` — the viewport stays full — and I confirmed that test isn't vacuous by asserting the buffer size actually changes across the split. So the detach → 1×1 route is a *plausible* path into the loss above, not a demonstrated one.

The investigation also turned up a genuine design question rather than a bug: the buffer anchors a grown viewport to the top and pads blank, which is asserted deliberately by `ReflowScenariosTests.VerticalGrow_ShouldNotPullHistory_AndAddPadding` ("Standard ConPTY behavior") and `GrowHeight_ShouldRevealHistoryCorrectly`. Changing that to anchor at the end of the transcript — what xterm, iTerm2 and VTE do — makes the #404 symptom disappear in the buffer, but it contradicts two intentional tests and is a product decision, so it is parked rather than smuggled in here.

Reproducing #404 properly needs the reporter's own repro (`scripts/shots.ps1 hero-split` on `feat/shots-harness`), which is the only place it has ever been observed on demand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)