### PR TITLE
test(app): make the window-teardown tests' precondition deterministic

### DIFF
--- a/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
@@ -63,6 +63,22 @@ public sealed class TestWindowTeardownTests : IDisposable
     {
         Directory.CreateDirectory(_appDataRoot);
         Environment.SetEnvironmentVariable(AppDataRootEnvVar, _appDataRoot);
+
+        // Setting the variable is not by itself enough to make the root empty, and the gap is not
+        // hypothetical: AppPaths.EnsureInitialized migrates a legacy roaming last_session.json to
+        // whatever SessionFilePath currently resolves to, and it runs once per process behind an
+        // _initialized flag. So if this fixture is what first touches AppPaths - which it is
+        // whenever the class runs alone rather than after the rest of the assembly - the migration
+        // lands a real session inside the directory that is supposed to have none, and the failure
+        // this class exists to stop comes back on exactly the machines that still have that file.
+        // Forcing the initialization here pins it to a known point and lets the sweep below undo
+        // it; the call is a no-op once anything else in the process has already run it.
+        AppPaths.EnsureInitialized();
+
+        // settings.json goes too, not just the session: a migrated one chooses the default
+        // profile the startup tab is built from. This fixture wants defaults, from nothing.
+        try { Directory.Delete(Path.Combine(_appDataRoot, "sessions"), recursive: true); } catch { /* best effort */ }
+        try { File.Delete(Path.Combine(_appDataRoot, "settings.json")); } catch { /* best effort */ }
     }
 
     /// <remarks>

--- a/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Avalonia.Controls;
@@ -31,10 +32,67 @@ namespace NovaTerminal.Tests.Core;
 /// window that was never shown. The registry is process-wide, so each test diffs against a
 /// snapshot rather than asserting a total, the same way <c>AgentIndicatorTabRollupTests</c> does.
 /// </para>
+/// <para>
+/// Each test also points <c>NOVATERM_APPDATA_ROOT</c> at a fresh scratch directory, and that is
+/// load-bearing rather than tidy — it is the fix for #434. Without it,
+/// <c>TestMainWindowFactory.Create()</c> runs the real startup path against the machine's real
+/// profile, so what the constructor does depends on a file on disk. With no saved session it
+/// calls <c>AddTab</c> and one pane registers synchronously; with one, it takes the restore path
+/// instead — and there the only tab built eagerly is the *selected* one, every other tab being a
+/// placeholder that holds no <c>TerminalPane</c> until the Background-priority
+/// <c>DrainDeferred</c> post runs. So a saved session whose selected tab does not materialize
+/// (<c>Root: null</c>, which <c>CaptureSession</c> persists for any tab whose content is not a
+/// pane tree) restores to placeholders alone, and the window registers no pane at all before
+/// <c>Create()</c> returns. That is what reddened the gate: the two tests below that rely on the
+/// window's own startup tab failed their *precondition*, reading as a teardown regression when
+/// teardown was never reached. Tests in this assembly close real <c>MainWindow</c>s, and
+/// <c>OnClosing</c> saves the session, so the poisoning file is one the suite writes itself.
+/// </para>
 /// </remarks>
 public sealed class TestWindowTeardownTests : IDisposable
 {
-    public void Dispose() => TestMainWindowFactory.DisposeCreatedWindows();
+    private readonly string _appDataRoot =
+        Path.Combine(Path.GetTempPath(), $"novaterm_teardown_test_{Guid.NewGuid():N}");
+
+    private readonly string? _previousAppDataRoot =
+        Environment.GetEnvironmentVariable(AppDataRootEnvVar);
+
+    private const string AppDataRootEnvVar = "NOVATERM_APPDATA_ROOT";
+
+    public TestWindowTeardownTests()
+    {
+        Directory.CreateDirectory(_appDataRoot);
+        Environment.SetEnvironmentVariable(AppDataRootEnvVar, _appDataRoot);
+    }
+
+    /// <remarks>
+    /// The windows go first: disposing them is what the tests are about, and it must happen while
+    /// the override is still in force so a window that saves anything saves it into the scratch
+    /// directory rather than the developer's real profile.
+    /// </remarks>
+    public void Dispose()
+    {
+        TestMainWindowFactory.DisposeCreatedWindows();
+        Environment.SetEnvironmentVariable(AppDataRootEnvVar, _previousAppDataRoot);
+        try { Directory.Delete(_appDataRoot, recursive: true); } catch { /* best effort */ }
+    }
+
+    /// <summary>
+    /// That the isolated root really does give the deterministic startup path the two
+    /// snapshot-diffing tests below assume: exactly one pane, registered before
+    /// <see cref="TestMainWindowFactory.Create()"/> returns. Named separately so a regression in
+    /// the isolation itself fails here, saying what broke, instead of surfacing as an unexplained
+    /// precondition failure in a test about teardown.
+    /// </summary>
+    [AvaloniaFact]
+    public void AFreshWindow_RegistersItsStartupPane_BeforeCreateReturns()
+    {
+        HashSet<Guid> before = RegisteredPaneIds();
+
+        TestMainWindowFactory.Create();
+
+        Assert.Single(RegisteredPaneIds().Except(before));
+    }
 
     [AvaloniaFact]
     public void AWindowsPanes_AreGoneAfterTeardown()
@@ -43,7 +101,7 @@ public sealed class TestWindowTeardownTests : IDisposable
         TestMainWindowFactory.Create();
 
         Guid[] added = RegisteredPaneIds().Except(before).ToArray();
-        Assert.NotEmpty(added);
+        AssertStartupPaneRegistered(added);
 
         TestMainWindowFactory.DisposeCreatedWindows();
 
@@ -87,7 +145,7 @@ public sealed class TestWindowTeardownTests : IDisposable
         MainWindow window = TestMainWindowFactory.Create();
 
         Guid[] added = RegisteredPaneIds().Except(before).ToArray();
-        Assert.NotEmpty(added);
+        AssertStartupPaneRegistered(added);
 
         window.FindControl<TabControl>("Tabs")!.Items.Clear();
 
@@ -151,6 +209,20 @@ public sealed class TestWindowTeardownTests : IDisposable
 
     private static HashSet<Guid> RegisteredPaneIds()
         => AgentSessionRegistry.Instance.GetRegistrations().Select(r => r.PaneId).ToHashSet();
+
+    /// <summary>
+    /// The precondition of a teardown test: the window registered something to tear down. Says so
+    /// in the failure message, because a bare <c>Assert.NotEmpty</c> here reads as "teardown left
+    /// panes behind" when it means the opposite — see #434 and this class's remarks.
+    /// </summary>
+    private static void AssertStartupPaneRegistered(Guid[] added)
+        => Assert.True(
+            added.Length > 0,
+            "Test setup failed: creating a window registered no new panes, so there is nothing for "
+            + "the teardown assertion below to be about. The window's startup path built no "
+            + "TerminalPane synchronously - check that NOVATERM_APPDATA_ROOT is still redirected "
+            + "to an empty scratch directory, since a saved session there sends the constructor "
+            + "down the restore path instead of AddTab.");
 
     /// <summary>Adds a two-pane split tab, the shape zoom needs. Mirrors AgentObserveIndicatorTests.</summary>
     private static (TabItem Tab, TerminalPane First, TerminalPane Second) AddSplitTab(MainWindow window)


### PR DESCRIPTION
Fixes the flake tracked in #434, which had reddened `main` twice before this branch existed. Root cause reproduced locally, not inferred.

## What was failing

`TestWindowTeardownTests.AWindowsPanes_AreGoneAfterTeardown` and `ThePanesOfARemovedTab_AreGoneAfterTeardown` failed their **precondition**, not the thing they test:

```
Assert.NotEmpty() Failure: Collection was empty
  at ...TestWindowTeardownTests.cs:line 46   (and :87)
```

Line 46 is `Assert.NotEmpty(added)` — "creating a window registered no new panes". Teardown was never reached, so a CI reader was sent looking for a teardown regression that did not exist.

| when | commit | lane | verdict |
|---|---|---|---|
| 2026-09-05 19:47 | `63fd0daf` (main) | ubuntu | both failed |
| 2026-09-06 07:59 | `63fd0daf` (main) | ubuntu | both failed |
| 2026-09-07 08:19 | `dfdd645` (#433 attempt 1) | ubuntu | both failed |
| 2026-09-07 08:19 | `dfdd645` (#433 attempt 2) | ubuntu | both **passed** |
| 2026-09-07 08:19 | `462d90e` (main) | **windows** | both failed |

Both OS lanes, three commits, and two-for-two on one sha while flipping between attempts on another.

## Cause

The class did not redirect `NOVATERM_APPDATA_ROOT`, so `TestMainWindowFactory.Create()` ran the real startup path against the machine's real profile — meaning what the constructor did depended on a file on disk:

- **No saved session:** the constructor calls `AddTab(defaultProfile)` and one pane registers synchronously. That is what the assertion assumes.
- **A saved session:** it takes `TryRestoreStartupSession` instead. There only the **selected** tab is built eagerly; every other tab is a `CreateStartupPlaceholderTab` holding no `TerminalPane` until the `DispatcherPriority.Background` `DrainDeferred` post runs — which `Create()` never pumps.
- `CaptureSession` adds every `TabItem` unconditionally with `Root = BuildPaneTree(rootControl)`, and `BuildPaneTree(null)` is `null`. So a session whose **selected** tab has `Root: null` restores to placeholders alone, and the window registers nothing before `Create()` returns.

Dropping such a session into a scratch root reproduces CI exactly — same two tests, same two lines, same message, same three passing.

The poisoning file is one the suite writes itself. Four classes close a real `MainWindow` without redirecting the root, and `OnClosing` → `PerformAppTeardown` → `SessionManager.SaveSession`. `VerticalTabStripTests` closes 12 times and writes a **19-tab** session containing `Root: null` tabs. Whether `ActiveTabIndex` lands on one of them is what decides the outcome.

## The fix

Each test points `NOVATERM_APPDATA_ROOT` at a fresh scratch directory — the pattern `AgentIndicatorTabRollupTests.RunIsolated` already established and documented for the same reason. That makes the startup path `AddTab` **by construction** instead of leaving it to a file on disk.

The second commit closes a hole the local `codex review` caught in the first, and it reproduces: `AppPaths.EnsureInitialized` migrates a legacy roaming `last_session.json` to whatever `SessionFilePath` resolves to, once per process. When this fixture is the first to touch `AppPaths`, the migration lands a real session *inside* the supposedly empty root. Planting a null-selected-root session at `%APPDATA%/NovaTerminal/last_session.json` made 3 of 6 tests fail. The first attempt passed only by luck — per-test random roots mean the once-per-process migration lands in the first test's root alone, which happened to belong to a test that does not depend on the startup pane. So the constructor now forces the initialization to a known point and sweeps after it, dropping the migrated session and `settings.json` alike (a migrated `settings.json` chooses the default profile the startup tab is built from).

Also adds `AFreshWindow_RegistersItsStartupPane_BeforeCreateReturns`, so a regression in the isolation fails a test that names it rather than surfacing as an unexplained precondition failure in a test about teardown. The two preconditions now say what they mean when they do fail.

## Verification

Every step checked against the reproducing input rather than assumed:

| scenario | before | after |
|---|---|---|
| hostile session in the scratch root | 2 of 5 failed | **6 of 6 passed** |
| legacy roaming session, per-test roots | 3 of 6 failed | **6 of 6 passed** |
| legacy roaming session, stable root (every test exposed) | 3 of 6 failed | **6 of 6 passed** |
| alongside the classes that write the session | — | **91 of 91 passed** |

Both guards were confirmed to fail with the override removed, so neither is vacuous. Local `codex review --base main` is clean.

## Not addressed here

Deliberately out of scope, and worth its own issue: the four classes that write a session into the machine's real profile because they close a `MainWindow` without redirecting the root (`VerticalTabStripTests`, `MainWindowShellExitTests`, `MainWindowPaneWiringTests`, `MainWindowTabLookupTests`). That is what creates the poisoning file on CI in the first place, and it also **overwrites a developer's actual saved NovaTerminal session** when they run the suite locally. This PR makes the victim immune; it does not stop the source.

Resolves #434
