### PR TITLE
test(app): stop the suite writing a session into the real app-data profile

### DIFF
--- a/tests/NovaTerminal.App.Tests/Core/MainWindowBackupPaletteTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowBackupPaletteTests.cs
@@ -5,6 +5,8 @@ using NovaTerminal.Shell;
 using NovaTerminal.Backup;
 using NovaTerminal.Tests.Backup;
 
+using Xunit;
+
 namespace NovaTerminal.Tests.Core;
 
 /// <summary>
@@ -17,7 +19,17 @@ namespace NovaTerminal.Tests.Core;
 /// <c>SetupCommandPalette()</c>, which is lazy (runs on palette-open / settings-save) - starting it
 /// there would mean automatic snapshots only begin after the user's first palette open.
 /// </summary>
-public sealed class MainWindowBackupPaletteTests : IDisposable
+/// <remarks>
+/// The <see cref="TestAppDataRoot"/> class fixture is taken for its lifetime, not its value,
+/// which is why nothing here reads it. This class redirects the app-data root inside individual
+/// tests already, but the tests that only close a window did so against whatever root was
+/// current - so it still wrote a session into the developer's real profile and left a file behind
+/// that steers the startup path of every window built later in the process (#434). The fixture
+/// covers the whole class; the narrower per-test overrides nest inside it safely, since disposing
+/// one restores the previous value rather than clearing the variable. Scoped per class to match
+/// <c>VerticalTabStripTests</c>, whose remarks explain why per-test roots were rejected.
+/// </remarks>
+public sealed class MainWindowBackupPaletteTests : IDisposable, IClassFixture<TestAppDataRoot>
 {
     /// <summary>
     /// Disposes the panes of every window this class asked for, and with them the real shells

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowPaneWiringTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowPaneWiringTests.cs
@@ -22,7 +22,15 @@ namespace NovaTerminal.Tests.Core;
 /// throw into "[ERROR] Failed to spawn process", and the session was never created: restoring a
 /// workspace produced a window full of dead panes.
 /// </remarks>
-public sealed class MainWindowPaneWiringTests : IDisposable
+/// <remarks>
+/// The <see cref="TestAppDataRoot"/> class fixture is taken for its lifetime, not its value,
+/// which is why nothing here reads it. Tests in this class close a real <c>MainWindow</c>, and
+/// <c>OnClosing</c> saves the session - so without it the suite overwrites the developer's own
+/// saved session on a local run and leaves a file behind that steers the startup path of every
+/// window built later in the process, which is how #434 reddened main. Scoped per class to match
+/// <c>VerticalTabStripTests</c>, whose remarks explain why per-test roots were rejected.
+/// </remarks>
+public sealed class MainWindowPaneWiringTests : IDisposable, IClassFixture<TestAppDataRoot>
 {
     /// <summary>
     /// Disposes the panes of every window this class asked for, and with them the real shells

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowShellExitTests.cs
@@ -53,7 +53,15 @@ namespace NovaTerminal.Tests.Core;
 /// <c>TabClosePolicyTests</c>), and the declined branch remains uncovered for the modal-deadlock
 /// reason described above.
 /// </remarks>
-public sealed class MainWindowShellExitTests : IDisposable
+/// <remarks>
+/// The <see cref="TestAppDataRoot"/> class fixture is taken for its lifetime, not its value,
+/// which is why nothing here reads it. Tests in this class close a real <c>MainWindow</c>, and
+/// <c>OnClosing</c> saves the session - so without it the suite overwrites the developer's own
+/// saved session on a local run and leaves a file behind that steers the startup path of every
+/// window built later in the process, which is how #434 reddened main. Scoped per class to match
+/// <c>VerticalTabStripTests</c>, whose remarks explain why per-test roots were rejected.
+/// </remarks>
+public sealed class MainWindowShellExitTests : IDisposable, IClassFixture<TestAppDataRoot>
 {
     /// <summary>
     /// Disposes the panes of every window this class asked for, and with them the real shells

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -13,9 +13,21 @@ using NovaTerminal.Shell.Shortcuts;
 using NovaTerminal.Shell.TitleBar;
 using System.Reflection;
 
+using Xunit;
+
 namespace NovaTerminal.Tests.Core;
 
-public sealed class MainWindowStartupTests : IDisposable
+/// <remarks>
+/// The <see cref="TestAppDataRoot"/> class fixture is taken for its lifetime, not its value,
+/// which is why nothing here reads it. This class redirects the app-data root inside individual
+/// tests already, but the tests that only close a window did so against whatever root was
+/// current - so it still wrote a session into the developer's real profile and left a file behind
+/// that steers the startup path of every window built later in the process (#434). The fixture
+/// covers the whole class; the narrower per-test overrides nest inside it safely, since disposing
+/// one restores the previous value rather than clearing the variable. Scoped per class to match
+/// <c>VerticalTabStripTests</c>, whose remarks explain why per-test roots were rejected.
+/// </remarks>
+public sealed class MainWindowStartupTests : IDisposable, IClassFixture<TestAppDataRoot>
 {
     /// <summary>
     /// Disposes the panes of every window this class asked for, and with them the real shells

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowTabLookupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowTabLookupTests.cs
@@ -18,7 +18,15 @@ namespace NovaTerminal.Tests.Core;
 /// answering "no tab", which is why the bell indicator never appeared and why a split tab
 /// resolved the wrong pane.
 /// </summary>
-public sealed class MainWindowTabLookupTests : IDisposable
+/// <remarks>
+/// The <see cref="TestAppDataRoot"/> class fixture is taken for its lifetime, not its value,
+/// which is why nothing here reads it. Tests in this class close a real <c>MainWindow</c>, and
+/// <c>OnClosing</c> saves the session - so without it the suite overwrites the developer's own
+/// saved session on a local run and leaves a file behind that steers the startup path of every
+/// window built later in the process, which is how #434 reddened main. Scoped per class to match
+/// <c>VerticalTabStripTests</c>, whose remarks explain why per-test roots were rejected.
+/// </remarks>
+public sealed class MainWindowTabLookupTests : IDisposable, IClassFixture<TestAppDataRoot>
 {
     /// <summary>
     /// Disposes the panes of every window this class asked for, and with them the real shells

--- a/tests/NovaTerminal.App.Tests/Core/TestAppDataRoot.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TestAppDataRoot.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using NovaTerminal.Shell;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// Redirects <c>NOVATERM_APPDATA_ROOT</c> to a fresh, empty directory for as long as the scope
+/// lives, so a test that builds a real <see cref="NovaTerminal.MainWindow"/> neither reads the
+/// machine's persisted state nor writes into it.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both halves of that matter, and the write half is the one that surprised us. A
+/// <c>MainWindow</c>'s <c>OnClosing</c> runs <c>PerformAppTeardown</c>, which calls
+/// <c>SessionManager.SaveSession</c> — so every test that closes a window persists a session to
+/// whatever root is current. Against the real root that means two things: it overwrites the
+/// developer's own saved session when they run the suite locally, and it leaves a file behind that
+/// steers the *startup path* of every window built later in the process.
+/// </para>
+/// <para>
+/// That second effect is not theoretical; it is #434. <c>TestMainWindowFactory.Create()</c> calls
+/// <c>AddTab</c> and registers a pane synchronously when no session exists, but takes
+/// <c>TryRestoreStartupSession</c> when one does — and there only the selected tab is built
+/// eagerly, the rest being placeholders that hold no pane until a Background-priority post runs.
+/// <c>CaptureSession</c> persists every tab unconditionally with <c>Root = BuildPaneTree(...)</c>,
+/// and that is null for a tab whose content is not a pane tree, so a saved session can select a
+/// tab that restores to nothing. A window built from it registers no pane at all, which is what
+/// reddened the gate on main - twice from one commit, on both OS lanes.
+/// </para>
+/// <para>
+/// Setting the variable is not by itself enough to make the root empty.
+/// <see cref="AppPaths.EnsureInitialized"/> migrates a legacy roaming <c>last_session.json</c> to
+/// whatever <c>SessionFilePath</c> resolves to when it runs, once per process behind an
+/// <c>_initialized</c> flag — so a scope that happens to be what first touches
+/// <see cref="AppPaths"/> would have that session copied *into* the directory that is supposed to
+/// have none. Forcing the initialization here pins it to a known point and lets the sweep below
+/// undo it; the call is a no-op once anything else in the process has run it.
+/// </para>
+/// </remarks>
+public sealed class TestAppDataRoot : IDisposable
+{
+    private const string EnvVar = "NOVATERM_APPDATA_ROOT";
+
+    private readonly string? _previousRoot;
+
+    public TestAppDataRoot()
+    {
+        RootPath = Path.Combine(Path.GetTempPath(), $"novaterm_test_root_{Guid.NewGuid():N}");
+        _previousRoot = Environment.GetEnvironmentVariable(EnvVar);
+
+        Directory.CreateDirectory(RootPath);
+        Environment.SetEnvironmentVariable(EnvVar, RootPath);
+
+        AppPaths.EnsureInitialized();
+
+        // settings.json goes too, not just the session: a migrated one chooses the default profile
+        // a startup tab is built from. A scope means defaults, from nothing.
+        Sweep();
+    }
+
+    /// <summary>The scratch directory <see cref="AppPaths.RootDirectory"/> resolves to inside the scope.</summary>
+    public string RootPath { get; }
+
+    /// <summary>
+    /// Restores the previous value rather than clearing the variable, so scopes can nest and an
+    /// outer one survives an inner one being disposed.
+    /// </summary>
+    public void Dispose()
+    {
+        Environment.SetEnvironmentVariable(EnvVar, _previousRoot);
+        try { Directory.Delete(RootPath, recursive: true); } catch { /* best effort */ }
+    }
+
+    private void Sweep()
+    {
+        try { Directory.Delete(Path.Combine(RootPath, "sessions"), recursive: true); } catch { /* best effort */ }
+        try { File.Delete(Path.Combine(RootPath, "settings.json")); } catch { /* best effort */ }
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/TestAppDataRootTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TestAppDataRootTests.cs
@@ -1,0 +1,81 @@
+using System.IO;
+using NovaTerminal.Shell;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// That <see cref="TestAppDataRoot"/> delivers the two properties its callers depend on: paths
+/// resolve inside the scope, and the scope is actually empty of the files that steer a
+/// <c>MainWindow</c>'s startup path.
+/// </summary>
+/// <remarks>
+/// Deliberately not <c>[AvaloniaFact]</c> and deliberately builds no window. The properties worth
+/// pinning are about <see cref="AppPaths"/> and the filesystem, and <c>SaveSession</c> writes to
+/// <see cref="AppPaths.SessionFilePath"/> - so asserting where that resolves covers the write path
+/// without a UI test. This file also has to stay cheap in that specific way: adding an Avalonia
+/// test class shifts what runs next to what, and this repo has a history of that destabilising
+/// <c>VerticalTabStripTests</c> and <c>TabRunningCommandTests</c> (see the remarks in
+/// <c>TestWindowTeardownTests</c>), which are among the classes the scope is being added to.
+/// </remarks>
+public sealed class TestAppDataRootTests
+{
+    [Fact]
+    public void AScope_PointsAppPathsAtItsOwnDirectory()
+    {
+        using var scope = new TestAppDataRoot();
+
+        Assert.Equal(Path.GetFullPath(scope.RootPath), Path.GetFullPath(AppPaths.RootDirectory));
+
+        // The session file is the one that matters: it is what SaveSession writes on close and
+        // what the startup path reads, so a test closing a window must not reach outside here.
+        Assert.StartsWith(
+            Path.GetFullPath(scope.RootPath),
+            Path.GetFullPath(AppPaths.SessionFilePath),
+            System.StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The scope is empty of a saved session even though AppPaths creates the directory tree and
+    /// may migrate a legacy session into it. Without the sweep this is exactly #434 again.
+    /// </summary>
+    [Fact]
+    public void AScope_StartsWithNoSavedSessionAndNoSettings()
+    {
+        using var scope = new TestAppDataRoot();
+
+        Assert.False(File.Exists(AppPaths.SessionFilePath));
+        Assert.False(File.Exists(AppPaths.SettingsFilePath));
+    }
+
+    [Fact]
+    public void DisposingAScope_RestoresThePreviousRoot()
+    {
+        using (var outer = new TestAppDataRoot())
+        {
+            string outerRoot = Path.GetFullPath(outer.RootPath);
+
+            using (new TestAppDataRoot())
+            {
+                Assert.NotEqual(outerRoot, Path.GetFullPath(AppPaths.RootDirectory));
+            }
+
+            // Nesting has to be safe: the scopes are class fields, and a test that opens its own
+            // must not leave the class's one pointing at a deleted directory.
+            Assert.Equal(outerRoot, Path.GetFullPath(AppPaths.RootDirectory));
+        }
+    }
+
+    [Fact]
+    public void DisposingAScope_RemovesItsDirectory()
+    {
+        string root;
+        using (var scope = new TestAppDataRoot())
+        {
+            root = scope.RootPath;
+            Assert.True(Directory.Exists(root));
+        }
+
+        Assert.False(Directory.Exists(root));
+    }
+}

--- a/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TestWindowTeardownTests.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
 using System.Reflection;
 using Avalonia.Controls;
@@ -33,53 +32,17 @@ namespace NovaTerminal.Tests.Core;
 /// snapshot rather than asserting a total, the same way <c>AgentIndicatorTabRollupTests</c> does.
 /// </para>
 /// <para>
-/// Each test also points <c>NOVATERM_APPDATA_ROOT</c> at a fresh scratch directory, and that is
-/// load-bearing rather than tidy — it is the fix for #434. Without it,
-/// <c>TestMainWindowFactory.Create()</c> runs the real startup path against the machine's real
-/// profile, so what the constructor does depends on a file on disk. With no saved session it
-/// calls <c>AddTab</c> and one pane registers synchronously; with one, it takes the restore path
-/// instead — and there the only tab built eagerly is the *selected* one, every other tab being a
-/// placeholder that holds no <c>TerminalPane</c> until the Background-priority
-/// <c>DrainDeferred</c> post runs. So a saved session whose selected tab does not materialize
-/// (<c>Root: null</c>, which <c>CaptureSession</c> persists for any tab whose content is not a
-/// pane tree) restores to placeholders alone, and the window registers no pane at all before
-/// <c>Create()</c> returns. That is what reddened the gate: the two tests below that rely on the
-/// window's own startup tab failed their *precondition*, reading as a teardown regression when
-/// teardown was never reached. Tests in this assembly close real <c>MainWindow</c>s, and
-/// <c>OnClosing</c> saves the session, so the poisoning file is one the suite writes itself.
+/// Each test also takes a <see cref="TestAppDataRoot"/>, and that is load-bearing rather than
+/// tidy — it is the fix for #434. Without it <c>TestMainWindowFactory.Create()</c> runs the real
+/// startup path against the machine's real profile, so whether the constructor builds a pane
+/// synchronously depends on a file on disk; that helper's remarks carry the mechanism. What it
+/// cost here was the two tests below that rely on the window's own startup tab failing their
+/// *precondition*, reading as a teardown regression when teardown was never reached.
 /// </para>
 /// </remarks>
 public sealed class TestWindowTeardownTests : IDisposable
 {
-    private readonly string _appDataRoot =
-        Path.Combine(Path.GetTempPath(), $"novaterm_teardown_test_{Guid.NewGuid():N}");
-
-    private readonly string? _previousAppDataRoot =
-        Environment.GetEnvironmentVariable(AppDataRootEnvVar);
-
-    private const string AppDataRootEnvVar = "NOVATERM_APPDATA_ROOT";
-
-    public TestWindowTeardownTests()
-    {
-        Directory.CreateDirectory(_appDataRoot);
-        Environment.SetEnvironmentVariable(AppDataRootEnvVar, _appDataRoot);
-
-        // Setting the variable is not by itself enough to make the root empty, and the gap is not
-        // hypothetical: AppPaths.EnsureInitialized migrates a legacy roaming last_session.json to
-        // whatever SessionFilePath currently resolves to, and it runs once per process behind an
-        // _initialized flag. So if this fixture is what first touches AppPaths - which it is
-        // whenever the class runs alone rather than after the rest of the assembly - the migration
-        // lands a real session inside the directory that is supposed to have none, and the failure
-        // this class exists to stop comes back on exactly the machines that still have that file.
-        // Forcing the initialization here pins it to a known point and lets the sweep below undo
-        // it; the call is a no-op once anything else in the process has already run it.
-        AppPaths.EnsureInitialized();
-
-        // settings.json goes too, not just the session: a migrated one chooses the default
-        // profile the startup tab is built from. This fixture wants defaults, from nothing.
-        try { Directory.Delete(Path.Combine(_appDataRoot, "sessions"), recursive: true); } catch { /* best effort */ }
-        try { File.Delete(Path.Combine(_appDataRoot, "settings.json")); } catch { /* best effort */ }
-    }
+    private readonly TestAppDataRoot _appDataRoot = new();
 
     /// <remarks>
     /// The windows go first: disposing them is what the tests are about, and it must happen while
@@ -89,8 +52,7 @@ public sealed class TestWindowTeardownTests : IDisposable
     public void Dispose()
     {
         TestMainWindowFactory.DisposeCreatedWindows();
-        Environment.SetEnvironmentVariable(AppDataRootEnvVar, _previousAppDataRoot);
-        try { Directory.Delete(_appDataRoot, recursive: true); } catch { /* best effort */ }
+        _appDataRoot.Dispose();
     }
 
     /// <summary>

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -13,7 +13,19 @@ using Xunit;
 
 namespace NovaTerminal.Tests.Core;
 
-public sealed class VerticalTabStripTests : IDisposable
+/// <remarks>
+/// The <see cref="TestAppDataRoot"/> class fixture is taken for its lifetime, not its value,
+/// which is why nothing here reads it. Tests in this class close a real <c>MainWindow</c>, and
+/// <c>OnClosing</c> saves the session - so without it the suite overwrites the developer's own
+/// saved session on a local run and leaves a file behind that steers the startup path of every
+/// window built later in the process, which is how #434 reddened main. Scoped per class rather
+/// than per test on purpose: a fresh root for every test is stronger isolation but it also makes
+/// every test pay a cold root, and this class has a test that only passes against a warm one
+/// (<c>ApplyTabLayout_ModeSwitch_MarksPreviewDirty</c>, already on the flake allowlist, fails
+/// three runs out of three when run cold - on unmodified main too). A per-class root keeps the
+/// behaviour these tests already had while moving it out of the real profile.
+/// </remarks>
+public sealed class VerticalTabStripTests : IDisposable, IClassFixture<TestAppDataRoot>
 {
     /// <summary>
     /// Disposes the panes of every window this class asked for, and with them the real shells


### PR DESCRIPTION
Removes the source of the #434 flake. #435 made the victim immune; this stops the suite creating the poisoning file in the first place — and stops it overwriting your own saved session while it's at it.

## The problem

A `MainWindow`'s `OnClosing` runs `PerformAppTeardown`, which calls `SessionManager.SaveSession`. So **every test that closes a window persists a session to whatever app-data root is current**, and six classes did that against the real one. That costs two separate things:

1. **It overwrites the developer's own saved NovaTerminal session**, silently, whenever they run the suite locally.
2. **It steers the startup path of every window built later in the process.** With no saved session the constructor calls `AddTab` and registers a pane synchronously; with one it takes `TryRestoreStartupSession`, where only the *selected* tab is built eagerly and the rest are placeholders holding no pane. `CaptureSession` persists every tab unconditionally with `Root = BuildPaneTree(rootControl)`, which is `null` for a tab whose content is not a pane tree — so a saved session can select a tab that restores to nothing, and a window built from it registers no pane at all. That is what reddened main twice before #435.

## Finding the six

Empirically, not by grep — each class was run against a simulated profile and the directory checked for a session file afterwards. That mattered, because grep was wrong in both directions:

- **Over-reported:** `CommandAssistLayoutTests` closes windows six times but writes nothing.
- **Under-reported:** `MainWindowStartupTests` and `MainWindowBackupPaletteTests` *do* redirect the root — inside one test each — so they look protected. Their other tests close windows against whatever root is current and write anyway.

| class | before | after |
|---|---|---|
| `MainWindowShellExitTests` | writes | clean |
| `MainWindowPaneWiringTests` | writes | clean |
| `MainWindowTabLookupTests` | writes | clean |
| `VerticalTabStripTests` | writes | clean |
| `MainWindowStartupTests` | writes | clean |
| `MainWindowBackupPaletteTests` | writes | clean |

## The change

`TestAppDataRoot` carries the redirect. It replaces the copy #435 inlined into `TestWindowTeardownTests` and joins three hand-rolled versions that already existed — `MainWindowBackupPaletteTests`' own copy is commented as duplicated from `SettingsWindowBackupSectionTests`. It also forces `AppPaths.EnsureInitialized` to a known point and sweeps after it, since that migrates a legacy roaming `last_session.json` into whatever `SessionFilePath` resolves to and would otherwise land a real session inside the supposedly empty root (the hole codex caught on #435).

## Why per-class, not per-test

This is the one judgment call, and it's measured rather than assumed. A fresh root per test is stronger isolation, but it makes every test pay a *cold* root — and `VerticalTabStripTests` has a timing test that only passes against a warm one:

| variant | `ApplyTabLayout_ModeSwitch_MarksPreviewDirty` |
|---|---|
| pristine main | 2 of 5 runs failed |
| per-test root | **3 of 3 runs failed** |
| per-class fixture (chosen) | 2 of 5 runs failed |

That test is already on the flake allowlist, and **on unmodified main it fails three runs out of three when run cold**. So a per-test root would have converted a flake into a deterministic failure that the allowlist then absorbs silently — the opposite of what the gate is for. A per-class root keeps exactly the behaviour these tests already had while moving it out of the real profile. `TestWindowTeardownTests` keeps its per-test scope, which it needs and which is already verified.

The fixture is taken for its lifetime, not its value, so nothing reads it — each class's remarks say so explicitly, because that is exactly the shape someone deletes as dead code.

## Verification

- All six classes write no session against a simulated profile afterwards; all six wrote one before.
- Each of the six passes on its own.
- A **210-test** run across the whole MainWindow / agent-indicator / tab-strip / settings-window neighbourhood writes nothing, twice, and shows only the pre-existing allowlisted flake (once in two runs).
- `TestAppDataRootTests` pins the four properties that matter: paths resolve inside the scope, the scope starts with no session and no settings, nesting restores the outer root, and disposal removes the directory. Deliberately **not** an Avalonia test class — adding one shifts what runs next to what, and this repo has a history of that destabilising the very classes being changed here.
- Local `codex review --base main`: clean.

## Not addressed here

The three pre-existing hand-rolled root overrides (`SettingsWindowBackupSectionTests`, `PaneParserWiringTests`, `MainWindowBackupPaletteTests`' inner helper) still exist alongside `TestAppDataRoot`. They are correct and none of them contaminate, so consolidating them is tidying rather than fixing, and it would widen this diff into tests that have no problem.
