### PR TITLE
fix(session): keep an unhydrated tab's panes when capturing during startup restore

### DIFF
--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -97,20 +97,31 @@ namespace NovaTerminal.Shell
                 // recoverable. Quitting straight after launch is enough to reach it, since the
                 // close path saves the session.
                 //
-                // Only the pane-shaped fields are carried through, because they are the only ones
-                // that lose anything: GetTabId and GetOrCreateTabState both seed from this same Tag,
-                // and a placeholder's header text is the saved title, so the rest already
-                // round-trips. Deliberately keyed on "no pane tree" rather than on a startup phase
-                // - a failed hydration leaves the same blank tab long after restore is over, and
-                // keeping what was restored is right whenever the live tree cannot say otherwise.
-                // There is no competing case to protect: closing a tab's last pane closes the tab
+                // Only the fields that describe the pane tree are carried through, because they are
+                // the only ones that lose anything. Everything else already round-trips: GetTabId
+                // and GetOrCreateTabState both seed from this same Tag, a placeholder's header text
+                // is the saved title, and InitializeRestoredTabs applies the saved broadcast flag to
+                // the placeholder itself - its Content is a Border, which passes that loop's
+                // "is Control" guard - so IsBroadcastEnabledForTab above is already right and must
+                // win. Overwriting it here would silently discard a toggle the user made on a tab
+                // that never finished hydrating, which hydration would otherwise have kept (the
+                // restore path only ever adds to the broadcast set, never removes).
+                //
+                // ActivePaneId and ZoomedPaneId do need the fallback: both are resolved by finding
+                // a pane inside the tab's content, which a placeholder has none of, so the live
+                // values are null and would otherwise be persisted against a restored tree that
+                // names real panes.
+                //
+                // Deliberately keyed on "no pane tree" rather than on a startup phase - a failed
+                // hydration leaves the same blank tab long after restore is over, and keeping what
+                // was restored is right whenever the live tree cannot say otherwise. There is no
+                // competing case to protect: closing a tab's last pane closes the tab
                 // (ClosePaneAsync falls back to CloseTabAsync) instead of leaving an empty one.
                 if (tabSession.Root == null && tabItem.Tag is TabSession restored && restored.Root != null)
                 {
                     tabSession.Root = restored.Root;
                     tabSession.ActivePaneId = restored.ActivePaneId;
                     tabSession.ZoomedPaneId = restored.ZoomedPaneId;
-                    tabSession.BroadcastInputEnabled = restored.BroadcastInputEnabled;
                 }
 
                 session.Tabs.Add(tabSession);

--- a/src/NovaTerminal.App/Shell/SessionManager.cs
+++ b/src/NovaTerminal.App/Shell/SessionManager.cs
@@ -84,6 +84,35 @@ namespace NovaTerminal.Shell
                     tabSession.BroadcastInputEnabled = mainWindow.IsBroadcastEnabledForTab(tabItem);
                 }
 
+                // A tab that cannot produce a pane tree keeps the one it was restored with, rather
+                // than persisting BuildPaneTree's null over it (#327).
+                //
+                // Startup restore materializes every saved tab up front - the selected one live,
+                // the rest as placeholders whose Content is a bare Border - and hydrates the
+                // placeholders on a later Background-priority pass (MainWindow's
+                // CreateStartupPlaceholderTab / HydrateDeferredStartupTab). BuildPaneTree returns
+                // null for anything that is neither a TerminalPane nor a split Grid, so a capture
+                // inside that window wrote one real tab and N tabs saying "no panes" - and because
+                // the write replaces the previous session, the layout it erased was not
+                // recoverable. Quitting straight after launch is enough to reach it, since the
+                // close path saves the session.
+                //
+                // Only the pane-shaped fields are carried through, because they are the only ones
+                // that lose anything: GetTabId and GetOrCreateTabState both seed from this same Tag,
+                // and a placeholder's header text is the saved title, so the rest already
+                // round-trips. Deliberately keyed on "no pane tree" rather than on a startup phase
+                // - a failed hydration leaves the same blank tab long after restore is over, and
+                // keeping what was restored is right whenever the live tree cannot say otherwise.
+                // There is no competing case to protect: closing a tab's last pane closes the tab
+                // (ClosePaneAsync falls back to CloseTabAsync) instead of leaving an empty one.
+                if (tabSession.Root == null && tabItem.Tag is TabSession restored && restored.Root != null)
+                {
+                    tabSession.Root = restored.Root;
+                    tabSession.ActivePaneId = restored.ActivePaneId;
+                    tabSession.ZoomedPaneId = restored.ZoomedPaneId;
+                    tabSession.BroadcastInputEnabled = restored.BroadcastInputEnabled;
+                }
+
                 session.Tabs.Add(tabSession);
             }
 

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -135,6 +135,8 @@ public sealed class MainWindowStartupTests : IDisposable, IClassFixture<TestAppD
         TabSession capturedPlaceholder = captured.Tabs[1];
         Assert.NotNull(capturedPlaceholder.Root);
         Assert.Equal("9f2c7a41-0000-4000-8000-000000000001", capturedPlaceholder.Root!.PaneId);
+
+        DrainDeferredRestorePlan(window);
     }
 
     /// <summary>
@@ -158,6 +160,8 @@ public sealed class MainWindowStartupTests : IDisposable, IClassFixture<TestAppD
         // The live pane's own id, which restore assigned from the file - so this also pins that the
         // capture read the control rather than the Tag.
         Assert.Equal(pane.PaneId.ToString(), captured.Tabs[0].Root!.PaneId);
+
+        DrainDeferredRestorePlan(window);
     }
 
     /// <summary>
@@ -196,6 +200,46 @@ public sealed class MainWindowStartupTests : IDisposable, IClassFixture<TestAppD
         Assert.True(captured.Tabs[1].BroadcastInputEnabled);
         // ...and the panes are still carried through, so this is not passing by skipping the fallback.
         Assert.Equal("9f2c7a41-0000-4000-8000-000000000003", captured.Tabs[1].Root!.PaneId);
+
+        DrainDeferredRestorePlan(window);
+    }
+
+    /// <summary>
+    /// Consumes the deferred restore plan so the Background-priority pass MainWindow left queued
+    /// has nothing to do if it ever runs.
+    /// </summary>
+    /// <remarks>
+    /// Not tidiness, and not optional. Nothing pumps the headless dispatcher between tests, so a
+    /// plan left pending here is materialized inside whichever later test next pumps it - by which
+    /// point <c>DisposeCreatedWindows</c> has cleared the factory's list, so hydration would build
+    /// a fresh TerminalPane and a real shell in a window nothing can reap. Work outliving its test
+    /// and contaminating the dispatcher this assembly shares is the failure mode behind #81, #416
+    /// and #417 (see CONTRIBUTING's App.Tests notes); these are the first tests here to drive the
+    /// deferred-restore path at all, so they are the first that could leak this way.
+    ///
+    /// Drains the plan rather than the dispatcher, and the distinction is the whole point. The
+    /// first version of this called <c>Dispatcher.UIThread.RunJobs()</c>, which hydrated the tab
+    /// but also ran every other job the shared queue happened to be holding: ten tests across
+    /// AgentObserveIndicatorTests, VerticalTabStripTests and the
+    /// <c>AvaloniaBootLocatorHygieneTests</c> dispatcher canary went red, against 641 of 641
+    /// passing on main. Pumping that queue from a test is the contamination, not the cure.
+    /// <c>DrainDeferred</c> returns immediately once the plan is gone, so consuming it here with a
+    /// materializer that does nothing leaves the queued callback inert - and builds no pane and no
+    /// shell at all, which is strictly less to reap than hydrating would have been.
+    /// </remarks>
+    private static void DrainDeferredRestorePlan(NovaTerminal.MainWindow window)
+    {
+        var startup = (StartupOrchestrator)typeof(NovaTerminal.MainWindow)
+            .GetField("_startup", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+
+        // Also the strongest available statement that these tests really are in the state they
+        // claim: restore deferred something, so the tab asserted on above is genuinely unhydrated.
+        Assert.True(startup.HasPendingDeferredRestore);
+
+        startup.DrainDeferred(_ => { });
+
+        Assert.False(startup.HasPendingDeferredRestore);
     }
 
     /// <summary>
@@ -211,7 +255,7 @@ public sealed class MainWindowStartupTests : IDisposable, IClassFixture<TestAppD
             ActiveTabIndex = 0,
             Tabs =
             {
-                NewTab("Live", "9f2c7a41-0000-4000-8000-00000000000a", shell),
+                NewTab("Live", Guid.NewGuid().ToString(), shell),
                 NewTab("Deferred", secondTabPaneId, shell),
             },
         };

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -96,6 +96,110 @@ public sealed class MainWindowStartupTests : IDisposable, IClassFixture<TestAppD
         Assert.NotNull(window.Icon);
     }
 
+    /// <summary>
+    /// A capture taken while startup restore still has unhydrated placeholders must round-trip
+    /// their panes, not persist "no panes" over them (#327).
+    /// </summary>
+    /// <remarks>
+    /// This is a data-loss bug, which is why the assertion is on the pane id rather than merely on
+    /// "not null": restore materializes every saved tab up front but hydrates all but the selected
+    /// one on a Background-priority pass, and the capture path replaces the session file - so a
+    /// capture inside that window used to erase the layout it was about to restore, irrecoverably.
+    /// Quitting straight after launch reaches it, because the close path saves the session.
+    ///
+    /// The window is driven through the real startup path (a session file plus
+    /// TestMainWindowFactory.Create) rather than by hand-building placeholders, because the
+    /// hand-built version would assert against this test's idea of a placeholder instead of the
+    /// one MainWindow actually produces. Nothing pumps the dispatcher here, so the deferred pass
+    /// has provably not run - the precondition below states that rather than assuming it.
+    /// </remarks>
+    [AvaloniaFact]
+    public void CaptureSession_DuringDeferredRestore_KeepsTheUnhydratedTabsPanes()
+    {
+        using var appData = new TestAppDataRoot();
+        WriteSavedSession(appData.RootPath, secondTabPaneId: "9f2c7a41-0000-4000-8000-000000000001");
+
+        var window = TestMainWindowFactory.Create();
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+
+        // Preconditions: restore ran, and the second tab is still a placeholder. Without both, the
+        // capture below would be asserting on nothing.
+        Assert.Equal(2, tabs.Items.Count);
+        var placeholder = (TabItem)tabs.Items[1]!;
+        Assert.IsNotType<NovaTerminal.Controls.TerminalPane>(placeholder.Content);
+        Assert.IsNotType<Grid>(placeholder.Content);
+
+        NovaSession captured = SessionManager.CaptureSession(window, tabs);
+
+        Assert.Equal(2, captured.Tabs.Count);
+        TabSession capturedPlaceholder = captured.Tabs[1];
+        Assert.NotNull(capturedPlaceholder.Root);
+        Assert.Equal("9f2c7a41-0000-4000-8000-000000000001", capturedPlaceholder.Root!.PaneId);
+    }
+
+    /// <summary>
+    /// The other direction, so the fallback above cannot pass by simply always preferring the
+    /// restored tree: a tab that DID hydrate is captured from its live panes. The selected tab is
+    /// built eagerly by restore, so it is hydrated by the time Create() returns.
+    /// </summary>
+    [AvaloniaFact]
+    public void CaptureSession_CapturesTheLivePaneTree_ForATabThatHydrated()
+    {
+        using var appData = new TestAppDataRoot();
+        WriteSavedSession(appData.RootPath, secondTabPaneId: "9f2c7a41-0000-4000-8000-000000000002");
+
+        var window = TestMainWindowFactory.Create();
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var live = (TabItem)tabs.Items[0]!;
+        var pane = Assert.IsType<NovaTerminal.Controls.TerminalPane>(live.Content);
+
+        NovaSession captured = SessionManager.CaptureSession(window, tabs);
+
+        // The live pane's own id, which restore assigned from the file - so this also pins that the
+        // capture read the control rather than the Tag.
+        Assert.Equal(pane.PaneId.ToString(), captured.Tabs[0].Root!.PaneId);
+    }
+
+    /// <summary>
+    /// Two tabs, so restore builds the selected one live and leaves the other a placeholder. The
+    /// command has to be runnable on this platform or RestorePaneTree substitutes a default and the
+    /// pane ids stop being a useful assertion.
+    /// </summary>
+    private static void WriteSavedSession(string appDataRoot, string secondTabPaneId)
+    {
+        string shell = OperatingSystem.IsWindows() ? "cmd.exe" : "/bin/sh";
+        var session = new NovaSession
+        {
+            ActiveTabIndex = 0,
+            Tabs =
+            {
+                NewTab("Live", "9f2c7a41-0000-4000-8000-00000000000a", shell),
+                NewTab("Deferred", secondTabPaneId, shell),
+            },
+        };
+
+        string sessionsDirectory = System.IO.Path.Combine(appDataRoot, "sessions");
+        System.IO.Directory.CreateDirectory(sessionsDirectory);
+        System.IO.File.WriteAllText(
+            System.IO.Path.Combine(sessionsDirectory, "last_session.json"),
+            System.Text.Json.JsonSerializer.Serialize(
+                session, SessionSerializationContext.Default.NovaSession));
+    }
+
+    private static TabSession NewTab(string title, string paneId, string shell) => new()
+    {
+        TabId = Guid.NewGuid().ToString(),
+        Title = title,
+        Root = new PaneNode
+        {
+            Type = NodeType.Leaf,
+            PaneId = paneId,
+            Command = shell,
+            Arguments = string.Empty,
+        },
+        ActivePaneId = paneId,
+    };
+
     [AvaloniaFact]
     public void RegisterPaneOwners_TraversesDecoratorWrappedPane()
     {

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowStartupTests.cs
@@ -161,6 +161,44 @@ public sealed class MainWindowStartupTests : IDisposable, IClassFixture<TestAppD
     }
 
     /// <summary>
+    /// The fallback must not reach past the pane tree: a broadcast toggle the user made on a tab
+    /// that has not hydrated yet survives the capture.
+    /// </summary>
+    /// <remarks>
+    /// Found by review of the first cut of this fix, which carried BroadcastInputEnabled through
+    /// from Tag along with the pane fields and so reverted the toggle. It is the one runtime flag
+    /// here that a placeholder genuinely owns: InitializeRestoredTabs applies the saved value to
+    /// the placeholder itself (its Content is a Border, which passes that loop's "is Control"
+    /// guard), so the live value is already correct before hydration, and the restore path only
+    /// ever adds to the broadcast set - so a toggle would otherwise have survived hydration too.
+    /// </remarks>
+    [AvaloniaFact]
+    public void CaptureSession_DuringDeferredRestore_KeepsALiveBroadcastToggleOnAPlaceholder()
+    {
+        using var appData = new TestAppDataRoot();
+        WriteSavedSession(appData.RootPath, secondTabPaneId: "9f2c7a41-0000-4000-8000-000000000003");
+
+        var window = TestMainWindowFactory.Create();
+        var tabs = window.FindControl<TabControl>("Tabs")!;
+        var placeholder = (TabItem)tabs.Items[1]!;
+        Assert.IsNotType<NovaTerminal.Controls.TerminalPane>(placeholder.Content);
+        Assert.False(window.IsBroadcastEnabledForTab(placeholder));
+
+        // The user's toggle, through the same set ToggleBroadcastForCurrentTab drives.
+        var broadcastTabs = (System.Collections.Generic.HashSet<TabItem>)typeof(NovaTerminal.MainWindow)
+            .GetField("_broadcastEnabledTabs", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(window)!;
+        broadcastTabs.Add(placeholder);
+        Assert.True(window.IsBroadcastEnabledForTab(placeholder));
+
+        NovaSession captured = SessionManager.CaptureSession(window, tabs);
+
+        Assert.True(captured.Tabs[1].BroadcastInputEnabled);
+        // ...and the panes are still carried through, so this is not passing by skipping the fallback.
+        Assert.Equal("9f2c7a41-0000-4000-8000-000000000003", captured.Tabs[1].Root!.PaneId);
+    }
+
+    /// <summary>
     /// Two tabs, so restore builds the selected one live and leaves the other a placeholder. The
     /// command has to be runnable on this platform or RestorePaneTree substitutes a default and the
     /// pane ids stop being a useful assertion.


### PR DESCRIPTION
Fixes #327 — a data-loss bug where a session capture during startup restore erases the layout it was about to restore.

## What happens

Startup restore materializes every saved tab up front — the selected one live, the rest as placeholders whose `Content` is a bare `Border` — and hydrates the placeholders on a later `DispatcherPriority.Background` pass. `CaptureSession` did not know about that intermediate state:

```csharp
Root = BuildPaneTree(rootControl)   // null for anything that is not a TerminalPane or split Grid
```

So a capture inside that window wrote one real tab and N tabs saying "no panes" — and because the write **replaces** the previous session, the layout it erased was not recoverable. Quitting straight after launch is enough to reach it, since the close path saves the session; `Save Workspace` and an MCP-driven capture reach it too. The cost when it fires is the user's whole tab layout.

This is also the product-side root cause of the flake I containment-fixed in #435/#436: a saved session whose *selected* tab has `Root: null` restores to placeholders alone, and a window built from it registers no pane at all.

## The fix

A tab that cannot produce a pane tree keeps the one it was restored with, taken from the `TabSession` the placeholder already holds in `Tag`.

Only the fields that **describe the pane tree** are carried through — `Root`, `ActivePaneId`, `ZoomedPaneId` — because they are the only ones that lose anything. Everything else already round-trips: `GetTabId` and `GetOrCreateTabState` both seed from that same `Tag`, and a placeholder's header text is the saved title.

Two things I checked rather than assumed:

- **Keyed on "no pane tree", not on a startup phase.** A failed hydration (`CreateRestoredTabContent` returning null) leaves the same blank tab long after restore is over. This also sidesteps the trap the issue flags: `HasPendingDeferredRestore` goes false while hydration is still pending, because `DrainDeferred` clears `_pendingPlan` before scheduling the callback.
- **No competing case to protect.** Closing a tab's last pane closes the tab (`ClosePaneAsync` falls back to `CloseTabAsync`) rather than leaving an empty one behind — so "no pane tree" really does mean "not hydrated".

## Two review findings, both real

**`BroadcastInputEnabled` must not be carried through.** My first cut included it, which reverts a toggle the user made on a not-yet-hydrated tab. It is the one flag here a placeholder genuinely owns: a placeholder's `Content` is a `Border`, which *passes* `InitializeRestoredTabs`' `is Control` guard, so the saved value is already applied and the live value is correct. Nothing would have corrected it later either — the restore path only ever *adds* to the broadcast set. The asymmetry with `ActivePaneId`/`ZoomedPaneId` is the point: those are resolved by finding a pane *inside* the tab's content, which a placeholder has none of.

**The tests must not leave a deferred plan pending.** These are the first tests here to drive the deferred-restore path, and nothing pumps the headless dispatcher between tests — so the queued pass would be materialized inside whichever later test next pumps it, by which point `DisposeCreatedWindows` has cleared the factory's list and hydration builds a `TerminalPane` and a real shell in a window nothing can reap. That is the work-outliving-its-test mode behind #81/#416/#417.

The remedy is **not** the obvious one. `Dispatcher.UIThread.RunJobs()` would hydrate the tab, but it also runs every other job the shared queue happens to hold — pumping that queue from inside a test is the contamination, not the cure. `DrainDeferred` returns immediately once the plan is gone, so consuming it with a no-op materializer leaves the queued callback inert and builds no pane or shell at all.

## Verification, including what I could not measure

Non-vacuity, each checked by reverting just the relevant line:

| test | without the fix |
|---|---|
| `CaptureSession_DuringDeferredRestore_KeepsTheUnhydratedTabsPanes` | fails: `Assert.NotNull() Failure: Value is null` on the deferred tab's `Root` |
| `CaptureSession_DuringDeferredRestore_KeepsALiveBroadcastToggleOnAPlaceholder` | fails against the first cut that carried the flag through |
| `CaptureSession_CapturesTheLivePaneTree_ForATabThatHydrated` | passes either way — it is the control, so the fallback cannot pass by always preferring the restored tree |

Both new tests drive the real startup path (a session file plus `TestMainWindowFactory.Create`) instead of hand-building placeholders, so they assert against the placeholder `MainWindow` actually produces.

**What I could not measure locally, stated plainly:** on this machine the broad UI filter fails 0, 8, 4 and 12 tests across four runs of *unmodified* `origin/main` — `AgentObserveIndicatorTests` and the `AvaloniaBootLocatorHygiene` canary among them. Single runs of any variant sit inside that noise, so my local comparisons could not separate the cleanup options; the choice above rests on the mechanism. What is measurable: this class passes 22/22 three times over, and a tight session/startup filter passes 47/47 twice. CI is the authority on the rest.

Local `codex review --base main` clean on the final round.

Resolves #327
