### PR TITLE
test(app): assert the preview recompute instead of racing a live shell's output

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -552,6 +552,37 @@ namespace NovaTerminal
 
         internal void SetTabPreviewDirtyForTest(TabItem tab, bool dirty) => GetOrCreateTabState(tab).PreviewDirty = dirty;
 
+        /// <summary>
+        /// Test-only seam: backdates the preview recompute throttle so the next
+        /// <see cref="UpdateTabVisuals()"/> pass is guaranteed to recompute rather than skip.
+        /// </summary>
+        /// <remarks>
+        /// Waiting the interval out by wall clock does not work, and that is what made
+        /// <c>ApplyTabLayout_ModeSwitch_MarksPreviewDirty</c> flaky. A test window runs a real
+        /// shell, a prompt that redraws (a clock in it is enough) keeps producing output,
+        /// <c>OnPaneOutputReceived</c> marks the tab dirty for each burst, and the visual pass that
+        /// then recomputes re-arms this timestamp at a moment the test does not control - so a
+        /// sleep can end with the throttle freshly armed and the next pass skipping, leaving the
+        /// flag set. Backdating immediately before the pass removes the timing from the picture:
+        /// no dispatcher job can run between the two, because the test holds the UI thread.
+        /// </remarks>
+        internal void BackdateTabPreviewThrottleForTest(TabItem tab)
+            => GetOrCreateTabState(tab).LastPreviewUpdateUtc = DateTime.UtcNow - PreviewRefreshInterval;
+
+        /// <summary>
+        /// Test-only seam: when the preview was last actually recomputed. Advances only in the
+        /// recompute branch of <see cref="UpdateTabVisuals()"/>, so it says "a pass recomputed"
+        /// in a way the dirty flag cannot.
+        /// </summary>
+        /// <remarks>
+        /// The flag is the wrong thing for a test to assert on once a pane has a live shell behind
+        /// it: <c>OnPaneOutputReceived</c> re-marks it for every output burst, so it can be true
+        /// again a moment after a pass legitimately cleared it, and a test that reads it is racing
+        /// the shell's prompt. This timestamp is monotone through that - output never touches it.
+        /// </remarks>
+        internal DateTime GetTabPreviewRecomputedAtForTest(TabItem tab)
+            => GetOrCreateTabState(tab).LastPreviewUpdateUtc;
+
         /// <summary>Test-only seam: sets the marker inputs UpdateVerticalTabExtras resolves
         /// the chip visibilities and dot color from (same pattern as
         /// <see cref="SetTabPreviewDirtyForTest"/>), since driving real bell/agent events in

--- a/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/VerticalTabStripTests.cs
@@ -634,11 +634,17 @@ public sealed class VerticalTabStripTests : IDisposable, IClassFixture<TestAppDa
         var tab = tabs.Items.Cast<TabItem>().First();
         // Clear it so the upcoming mode switch is the only possible source of "dirty" below.
         window.SetTabPreviewDirtyForTest(tab, false);
-        // Window startup's own initial tab-visuals pass may have armed the 250ms preview
-        // throttle - wait it out so the mode switch below isn't itself throttled into
-        // leaving the dirty flag set. (Startup uses deterministic default settings via
-        // AppServiceBundle.Settings, so that pass is always horizontal now.)
-        System.Threading.Thread.Sleep(300);
+
+        // The 250ms preview throttle has to be idle, or the pass below skips its recompute and
+        // leaves the flag set. This used to sleep 300ms on the theory that only window startup's
+        // own tab-visuals pass could have armed it. That theory was wrong and it is what made this
+        // test flaky: the window runs a real shell, this repo's prompt redraws a clock, every
+        // output burst marks the tab dirty via OnPaneOutputReceived, and the pass that then
+        // recomputes re-arms the throttle whenever it happens to land - so the sleep could end with
+        // it freshly armed. Backdating leaves no window for that: the test holds the UI thread from
+        // here to RunJobs, so no dispatcher job runs in between.
+        window.BackdateTabPreviewThrottleForTest(tab);
+        DateTime recomputedBefore = window.GetTabPreviewRecomputedAtForTest(tab);
 
         settings.TabStripOrientation = "Vertical";
         window.ApplyTabLayout();
@@ -650,7 +656,17 @@ public sealed class VerticalTabStripTests : IDisposable, IClassFixture<TestAppDa
 
         var preview = NovaTerminal.MainWindow.FindTabHeaderDescendant<TextBlock>(tab.Header, "TabPreviewLine");
         Assert.NotNull(preview);
-        Assert.False(window.GetTabPreviewDirtyForTest(tab), "the first vertical pass should have recomputed and cleared dirty");
+
+        // That the pass recomputed, not that the flag ended up clear. The flag is the wrong
+        // question here and was the second half of this test's flakiness: the pane has a live
+        // shell, OnPaneOutputReceived re-marks the tab dirty for every output burst, and a burst
+        // landing after the pass cleared it makes the flag true again through no fault of the code
+        // under test. The recompute timestamp only advances in the recompute branch, so it answers
+        // "did the first vertical pass repopulate the preview" - which is what the name claims -
+        // and no amount of shell output can move it back.
+        Assert.True(
+            window.GetTabPreviewRecomputedAtForTest(tab) > recomputedBefore,
+            "the first vertical pass should have recomputed the preview");
     }
 
     // ---- Drag-to-reorder (MainWindow.WireTabHeaderReorderDrag + Shell/TabDragModel) ----

--- a/tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs
+++ b/tests/NovaTerminal.VT.Tests/VtCapabilityContractTests.cs
@@ -2,6 +2,31 @@ using NovaTerminal.VtContract;
 
 namespace NovaTerminal.VT.Tests;
 
+/// <summary>
+/// One executable contract per capability the catalog advertises as
+/// <see cref="VtSupport.Supported"/>: proof that something in the parser actually implements what
+/// the catalog claims, rather than the claim standing alone.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These assertions are <b>descriptive</b> - they record what the parser does today, not what a
+/// specification says it ought to do. So when a change alters accepted behaviour on purpose,
+/// updating the affected lines here is part of that change, not a warning sign. What must not
+/// happen is the reverse: an assertion edited to make a build pass without the behaviour change
+/// being intended and stated.
+/// </para>
+/// <para>
+/// The distinction has bitten once, which is why it is written down. 816489b added
+/// <c>AssertPosition("\x1b[?2G", ...)</c> and <c>AssertPosition("\x1b[2$G", ...)</c> by
+/// transcribing what the parser happened to do at the time - CHA had no leader guard - while the
+/// identical shapes for CNL and CPL three lines up had said <c>AssertIgnored</c> since b7a00dc.
+/// The file contradicted itself for eight days. #433 changed the G lines to match, because a
+/// leader or an intermediate makes a sequence a different sequence and neither
+/// <c>CSI ? Ps G</c> nor <c>CSI Ps $ G</c> is defined. Behaviour here is also swept
+/// systematically over every final byte in <c>AnsiParserHardeningTests</c>, so a contract line and
+/// the sweep disagreeing is a real signal worth stopping for.
+/// </para>
+/// </remarks>
 public sealed class VtCapabilityContractTests
 {
     private static readonly Dictionary<string, Action> ContractCases =

--- a/tests/app-tests-known-flaky.txt
+++ b/tests/app-tests-known-flaky.txt
@@ -14,9 +14,3 @@
 #   - Matching is by substring, so a name without theory arguments covers every case.
 #   - Removing a line is always in scope. Growing the list is a decision, not a chore.
 
-# 250ms preview-throttle window. The test sleeps 300ms to clear the throttle armed by
-# window startup, then asserts that the deferred UpdateTabVisuals pass has consumed the
-# dirty flag after one RunJobs(). On a loaded runner the deferred pass has not always been
-# queued yet, so the flag is still set. Deterministic fix is a seam that reports when the
-# pass has run, instead of a sleep plus a RunJobs() and a hope.
-NovaTerminal.Tests.Core.VerticalTabStripTests.ApplyTabLayout_ModeSwitch_MarksPreviewDirty_SoFirstPassRepopulatesIt


### PR DESCRIPTION
Fixes #438. This test was the **only** entry in `tests/app-tests-known-flaky.txt`, and it fired on `Unit Tests (ubuntu-latest)` in three consecutive PRs — #435, #436, #437 — each staying green only because the allowlist absorbed it.

## The recorded reason was wrong

> On a loaded runner the deferred pass has not always been queued yet, so the flag is still set.

The pass **is** queued and **does** run. Two different things were happening, neither about queuing.

**1. A sleep cannot clear the 250ms preview throttle.** `UpdateTabVisuals` recomputes only when `now - LastPreviewUpdateUtc >= 250ms`, else it takes its documented skip branch and leaves the tab dirty. The test slept 300ms on the theory that only window startup's pass could have armed that throttle — but a test window runs a **real shell**, and a redrawing prompt keeps producing output. Every burst marks the tab dirty via `OnPaneOutputReceived`, and the pass that then recomputes re-arms the timestamp whenever it happens to land. So the sleep could end with the throttle freshly armed.

An instrumented run on unmodified `main` shows the flag was never cleared, and shows why the output keeps coming:

```
PROBE dirtyRightAfterThePass=True  previewText=" behna   ~   ...  in cmd at 16:35:05"
```

That's this machine's live prompt — with a clock in it.

**2. The flag isn't assertable against a live shell at all.** A burst landing after the pass legitimately cleared it sets it again, through no fault of the code under test. Backdating the throttle alone still failed 1 run in 6.

## The fix — the seam the allowlist entry itself asked for

> *"Deterministic fix is a seam that reports when the pass has run, instead of a sleep plus a RunJobs() and a hope."*

- `BackdateTabPreviewThrottleForTest(tab)` replaces the sleep. No dispatcher job can run between it and the following `RunJobs()`, because the test holds the UI thread — timing leaves the picture entirely.
- `GetTabPreviewRecomputedAtForTest(tab)` reports when the preview was last actually recomputed. It advances only in the recompute branch, so it answers *"did the first vertical pass repopulate the preview"* — which is what the test's name claims — and output cannot move it back.

No product behaviour changes; the throttle is a deliberate, documented perf gate. Both additions are `internal` test seams beside the existing `SetTabPreviewDirtyForTest`.

## Evidence

This only reproduces **under load** — the same code passed 3/3 an hour earlier on an idle machine, which is exactly why it reads as a CI-only flake:

| variant | result |
|---|---|
| unmodified `main` | **failed 3/3** |
| throttle backdated, flag still asserted | failed 1/6 |
| throttle backdated + recompute asserted | **passed 10/10** |

Plus the class 30/30 three times, and 113/113 across the tab/window neighbourhood twice.

**Both guards were checked to still bite, not assumed:**

| regression introduced | result |
|---|---|
| remove `PreviewDirty = true` from `ApplyTabLayout` | first assertion fails 3/3 |
| remove `UpdateTabVisuals()` from its deferred pass | second assertion fails 3/3 |

## One thing to weigh before merging

Removing this entry leaves `tests/app-tests-known-flaky.txt` with **no test names in it** — the App.Tests gate is fully strict again. That is the right end state, and the file says "Removing a line is always in scope", but it does mean any genuine flake now reddens PRs directly. If CI disagrees with my diagnosis, re-adding the line is the remedy rather than reverting the seams.

Also worth flagging: `codex review` came back clean, but its sandbox could not restore NuGet this round, so that verdict is from reading the diff rather than running the tests — unlike its earlier reviews on #435/#437, which did execute them.

Resolves #438


---

## Also folded in: a header note on `VtCapabilityContractTests`

Unrelated to the flake, declared here rather than buried in the commit list. It is comment-only — no assertion changes, VT.Tests 438/438.

That file records **what the parser does today**; nothing said so, and the gap produced a real inconsistency. `816489b` added `AssertPosition("\x1b[?2G", ...)` and `AssertPosition("\x1b[2$G", ...)` by transcribing what the parser happened to do at the time — CHA had no leader guard — while the identical shapes for CNL and CPL three lines above had said `AssertIgnored` since `b7a00dc`. The file contradicted itself for eight days, and #433 changed the G lines to match, since a leader or an intermediate makes a sequence a different sequence and neither `CSI ? Ps G` nor `CSI Ps $ G` is defined.

The note makes the two cases distinguishable without archaeology: updating these lines alongside a deliberate behaviour change is part of that change, whereas editing one to make a build pass without the behaviour change being intended and stated is the thing to catch. It also points at the systematic sweep in `AnsiParserHardeningTests`, so a contract line disagreeing with the sweep reads as the signal it is.
