### PR TITLE
fix(app): record a resize where it is dispatched, not where it is computed

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -958,6 +958,20 @@ namespace NovaTerminal.Shell
                             _buffer.Resize(cols, rows);
                             ResetMouseMotionTracking(); // Issue #269: grid reflowed, cell coords are stale.
                             OnResize?.Invoke(cols, rows);
+
+                            // The third place a dispatch happens, and the one easiest to miss:
+                            // a font change re-grids the buffer and the PTY straight from the
+                            // new metrics, bypassing the throttle entirely. Leaving it
+                            // unrecorded would make the field describe a grid that had since
+                            // been superseded, which is the same defect this change is about.
+                            //
+                            // Note this path derives its own grid rather than using
+                            // TryComputeGrid, so it does not subtract the padding the draw
+                            // operation reserves and can land a column wider than the layout
+                            // path would. That predates this change and is left alone here;
+                            // recording what it actually dispatched is what keeps the field
+                            // honest either way.
+                            RecordDispatchedGrid(cols, rows);
                         }
                     }
                 }
@@ -1548,9 +1562,13 @@ namespace NovaTerminal.Shell
         public event Action<int, int>? OnResize;
         private bool _isReady;
 
-        // Discrete resize: track last sent dimensions to avoid redundant PTY resizes
-        private int _lastSentCols = 0;
-        private int _lastSentRows = 0;
+        // Discrete resize: the grid the buffer and the PTY were last actually told about, so a
+        // redundant dispatch can be skipped. Written where the dispatch happens and nowhere else
+        // (#432): recording a grid at the moment it was *computed* meant a dispatch cancelled
+        // before the throttle ran still counted as sent, and the buffer was then described as
+        // being on a grid it had never been given.
+        private int _lastDispatchedCols = 0;
+        private int _lastDispatchedRows = 0;
 
         // Throttle resize: limit how often we send resize to PTY (interval-based, not debounce)
         private DateTime _lastPtyResizeTime = DateTime.MinValue;
@@ -1558,6 +1576,32 @@ namespace NovaTerminal.Shell
         private int _pendingCols = 0;
         private int _pendingRows = 0;
         private DateTime _pendingResizeStartedAt = DateTime.MinValue;
+
+        /// <summary>
+        /// Overrides the throttle interval check for a test: <c>false</c> forces the next dispatch
+        /// onto the timer, null defers to the clock.
+        /// </summary>
+        /// <remarks>
+        /// A test about a deferred dispatch has to be certain the dispatch really was deferred,
+        /// and that is decided by a wall-clock comparison. A seam that only nudged the timestamp
+        /// would still be racing it - a worker that stalled for 60ms between arranging the setup
+        /// and pumping the dispatcher would take the other branch and fail on its own scheduling.
+        /// Overriding the decision rather than the clock removes the race instead of narrowing it.
+        /// Both branches remain real code; this only chooses which one runs.
+        /// </remarks>
+        private bool? _throttleElapsedForTest;
+
+        /// <summary>Forces the next dispatch onto the throttle timer rather than the inline path.</summary>
+        internal void HoldResizeThrottleForTest() => _throttleElapsedForTest = false;
+
+        /// <summary>Whether a resize has been computed and is still waiting on the throttle.</summary>
+        internal bool ResizeDispatchPendingForTest => _resizeThrottleTimer?.IsEnabled == true;
+
+        /// <summary>The grid the buffer and the PTY were last actually told about.</summary>
+        internal (int Cols, int Rows) LastDispatchedGridForTest => (_lastDispatchedCols, _lastDispatchedRows);
+
+        /// <summary>The grid a queued dispatch will send when it runs.</summary>
+        internal (int Cols, int Rows) PendingGridForTest => (_pendingCols, _pendingRows);
 
         private void StartAutoScroll(int direction)
         {
@@ -1741,15 +1785,16 @@ namespace NovaTerminal.Shell
                         return;
                     }
 
-                    // DISCRETE RESIZE: Only trigger actual resize when cell dimensions change
-                    bool dimensionsChanged = (cols != _lastSentCols || rows != _lastSentRows);
+                    // The grid the view is now drawing. Recorded unconditionally, even when no
+                    // dispatch is needed, so that a dispatch already waiting on the throttle sends
+                    // the size the view actually ended up at rather than the one that armed it -
+                    // a resize that goes 80 -> 70 -> 80 inside one 60ms window would otherwise
+                    // leave 70 queued behind a view that is back at 80.
+                    _pendingCols = cols;
+                    _pendingRows = rows;
 
-                    if (dimensionsChanged)
-                    {
-                        // Update tracking
-                        _lastSentCols = cols;
-                        _lastSentRows = rows;
-                    }
+                    // DISCRETE RESIZE: Only trigger actual resize when cell dimensions change
+                    bool dimensionsChanged = (cols != _lastDispatchedCols || rows != _lastDispatchedRows);
 
                     if (!_isReady)
                     {
@@ -1760,13 +1805,15 @@ namespace NovaTerminal.Shell
 
                         // Also trigger initial PTY resize to sync with layout
                         OnResize?.Invoke(cols, rows);
+
+                        // This path dispatches inline rather than through the throttle, so it
+                        // records the dispatch itself.
+                        RecordDispatchedGrid(cols, rows);
                     }
 
                     if (dimensionsChanged)
                     {
                         // STRICT INTERVAL THROTTLE: Limit resize dispatch to 60ms
-                        _pendingCols = cols;
-                        _pendingRows = rows;
                         var now = DateTime.UtcNow;
                         if (_pendingResizeStartedAt == DateTime.MinValue)
                         {
@@ -1782,9 +1829,10 @@ namespace NovaTerminal.Shell
                             _resizeThrottleTimer.Tick += OnResizeThrottleTick;
                         }
 
-                        var elapsed = (now - _lastPtyResizeTime).TotalMilliseconds;
+                        bool intervalElapsed =
+                            _throttleElapsedForTest ?? ((now - _lastPtyResizeTime).TotalMilliseconds >= 60);
 
-                        if (elapsed >= 60 && !_resizeThrottleTimer.IsEnabled)
+                        if (intervalElapsed && !_resizeThrottleTimer.IsEnabled)
                         {
                             // Enough time passed and no pending timer - send immediately
                             SendThrottledResize();
@@ -1803,6 +1851,22 @@ namespace NovaTerminal.Shell
         }
 
 
+        /// <summary>
+        /// Records the grid just handed to the buffer and the PTY.
+        /// </summary>
+        /// <remarks>
+        /// One method rather than two assignments at each of the three dispatch sites, because
+        /// the sites are easy to miss: the font branch of ApplySettings was overlooked in the
+        /// first draft of this change, and an unrecorded dispatch there would have left the
+        /// field describing a grid that had since been superseded. A fourth site added later
+        /// gets the whole of the bookkeeping or none of it, not half.
+        /// </remarks>
+        private void RecordDispatchedGrid(int cols, int rows)
+        {
+            _lastDispatchedCols = cols;
+            _lastDispatchedRows = rows;
+        }
+
         private void SendThrottledResize()
         {
             try
@@ -1815,6 +1879,11 @@ namespace NovaTerminal.Shell
                     // THEN notify PTY (triggers SIGWINCH, new output uses new size)
                     // This prevents race where PTY sends data for new dimensions while buffer is mid-reflow
                     _buffer.Resize(_pendingCols, _pendingRows);
+
+                    // Recorded here, where the dispatch actually happens, and not where the grid
+                    // was computed - see the field declarations and #432.
+                    RecordDispatchedGrid(_pendingCols, _pendingRows);
+
                     ResetMouseMotionTracking(); // Issue #269: grid reflowed, cell coords are stale.
                     _rowCache.MaxEntries = Math.Max(_pendingRows * 3, 50);
                     _rowCache.RequestClear();

--- a/tests/NovaTerminal.App.Tests/Core/TerminalViewResizeTrackingTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalViewResizeTrackingTests.cs
@@ -1,0 +1,149 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using NovaTerminal.Shell;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// The resize tracking must describe what the buffer and the PTY were actually told, not what a
+/// layout pass happened to compute.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>OnSizeChanged</c> computes a grid and leaves the 60ms throttle to dispatch it, so between
+/// those two moments the grid is decided but unsent. Recording it as sent in the first moment
+/// makes the field a record of intent rather than of fact, and a dispatch that never runs is then
+/// indistinguishable from one that did - which is the ground the #432 desync stands on.
+/// </para>
+/// <para>
+/// Driven through a real window rather than a seam, because these are properties of the real
+/// layout path; a test that called the pieces directly would be asserting the order it chose
+/// itself.
+/// </para>
+/// </remarks>
+public class TerminalViewResizeTrackingTests
+{
+    [AvaloniaFact]
+    [Trait("Category", "Regression")]
+    public void AResizeWaitingOnTheThrottle_IsNotYetRecordedAsDispatched()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        var window = new Window { Content = view, Width = 800, Height = 400 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(view.Bounds.Width > 0, $"the view was never arranged: {view.Bounds}");
+
+            (int cols, int rows) = view.LastDispatchedGridForTest;
+            Assert.True(cols > 0 && rows > 0, $"nothing was dispatched on show: {cols}x{rows}");
+            Assert.Equal(cols, buffer.Cols);
+
+            // Force the next change onto the throttle rather than the inline path.
+            view.HoldResizeThrottleForTest();
+
+            window.Width = 500;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(
+                view.ResizeDispatchPendingForTest,
+                "setup failed: the narrower size should still be waiting on the throttle");
+
+            // Nothing has been dispatched, so nothing may be recorded as dispatched - and the
+            // record must still agree with the grid the buffer is genuinely on.
+            Assert.Equal((cols, rows), view.LastDispatchedGridForTest);
+            Assert.Equal(cols, buffer.Cols);
+            Assert.Equal(rows, buffer.Rows);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    [AvaloniaFact]
+    [Trait("Category", "Regression")]
+    public void AFontChangeThatRegridsTheBuffer_IsRecordedAsDispatched()
+    {
+        // The third dispatch site, and the one easiest to miss: a font change re-grids the
+        // buffer and the PTY straight from the new metrics, bypassing the throttle. It has to
+        // record what it sent like the other two, or the field goes stale the moment anyone
+        // changes their font size - and every later comparison against it is then wrong.
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        var window = new Window { Content = view, Width = 800, Height = 400 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            (int cols, int rows) = view.LastDispatchedGridForTest;
+            Assert.True(cols > 0, "nothing was dispatched on show");
+
+            var settings = new TerminalSettings { FontSize = 28 };
+            view.ApplySettings(settings);
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.True(
+                buffer.Cols != cols || buffer.Rows != rows,
+                $"setup failed: the larger font did not re-grid the buffer, still {buffer.Cols}x{buffer.Rows}");
+
+            // Whatever it dispatched, the record names it - so it still describes the grid the
+            // buffer is genuinely on.
+            Assert.Equal((buffer.Cols, buffer.Rows), view.LastDispatchedGridForTest);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    [AvaloniaFact]
+    [Trait("Category", "Regression")]
+    public void AQueuedDispatchSendsTheSizeTheViewEndedAt_NotTheOneThatArmedIt()
+    {
+        // Comparing against the last *dispatched* grid means a view that leaves a size and comes
+        // back to it inside one throttle window reports no change on the way back. The queued
+        // dispatch still has to name where the view actually ended up, or the throttle would fire
+        // the intermediate size at a view that has already left it. That is why the pending grid
+        // is recorded on every pass, not only on a change.
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        var window = new Window { Content = view, Width = 800, Height = 400 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            (int cols, int rows) = view.LastDispatchedGridForTest;
+            Assert.True(cols > 0, "nothing was dispatched on show");
+
+            view.HoldResizeThrottleForTest();
+
+            window.Width = 500;                 // away from the dispatched size: arms the throttle
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(view.ResizeDispatchPendingForTest, "setup failed: nothing was queued");
+            Assert.NotEqual(cols, view.PendingGridForTest.Cols);
+
+            window.Width = 800;                 // and back, still inside the same window
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal((cols, rows), view.PendingGridForTest);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+}


### PR DESCRIPTION
**Split out of the original #441 on request.** This is part one of two for issue #432, and on its own it does **not** cure the desync that issue describes — see "What this does not do" below. Part two is #442 and carries the behavioural half.

## What this does

`TerminalView` marked a grid as sent the moment it was *computed*, but the resize is dispatched later by the 60 ms throttle. Between those two moments the grid is decided and unsent, and the field claimed otherwise — so a dispatch that never ran was indistinguishable from one that did, and the tracking could describe the buffer as being on a grid it had never been given.

The fields become `_lastDispatchedCols`/`_lastDispatchedRows` and are written at the **three** places a dispatch actually happens: `SendThrottledResize`, the inline `!_isReady` path, and the font branch of `ApplySettings`, which re-grids the buffer and the PTY straight from the new metrics and bypasses the throttle entirely.

That third site is worth naming: **I missed it in the first draft**, and local review caught it. Leaving it unrecorded would have made the field go stale the moment anyone changed their font size. All three now go through one `RecordDispatchedGrid` method, so a fourth site added later gets the whole of the bookkeeping or none of it, not half.

Nothing else read the fields — the declarations, the comparison and that single write were the only three sites before this, which answers the issue's "check whether anything else expects the current meaning".

## The trap in the same area

Comparing against the last *dispatched* grid means a view that leaves a size and returns to it inside one 60 ms window reports no change on the way back. The pending grid is therefore recorded on every pass, not only on a change — otherwise the intermediate size stays queued behind a view that has already moved on. With the stash left conditional that test fails, queueing 55 columns at a view back on 88.

## What this does not do

It makes the record honest. It does not make anything re-send a dispatch that was cancelled: `OnSizeChanged` fires on a size *change*, and a pane that is collapsed and restored comes back at the size it left at, so no further event arrives to notice the disagreement. I tested exactly this shape on its own and the pane was still stranded. Part two adds the reconciliation and carries the end-to-end coverage.

## Observation, deliberately not acted on

The font path derives its grid as `Bounds.Width / CellWidth` while `TryComputeGrid` subtracts the padding the draw operation reserves, so the two disagree by a column at some widths. That predates this change and is left alone; recording what it actually dispatched keeps the field honest either way. It matters in part two, which has to work around it.

## Verification

Each of the three tests fails against the code it covers with that code reverted: compute-time recording, the conditional pending stash, and the unrecorded font dispatch. VT 445 pass. Full App.Tests locally: 2 failures, both reproducing identically on unmodified `origin/main` here (one is an artifact of building with `SkipCliShim` because nuget.org is unreachable from this sandbox).

Tests carry `[Trait("Category", "Regression")]` per CONTRIBUTING. Noted on the previous review round: only `tests/NovaTerminal.App.Tests/Regressions/` currently uses that trait, so these are correct by the written rule and inconsistent with local practice — a repo-wide question rather than one to settle silently here.