### PR TITLE
fix(app): re-send a resize dispatch that was cancelled before it ran

### DIFF
--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -876,6 +876,9 @@ namespace NovaTerminal.Shell
             _metrics.CellHeight = cellHeight;
         }
 
+        /// <summary>The measured cell size, so a test can recompute the grid the view is drawing.</summary>
+        internal (double Width, double Height) CellSizeForTest => (_metrics.CellWidth, _metrics.CellHeight);
+
         public void ApplySettings(TerminalSettings settings)
         {
             try
@@ -1020,6 +1023,14 @@ namespace NovaTerminal.Shell
             // Ensure char metrics are available immediately upon attachment
             MeasureCharSize();
 
+            // Deliberately here and not in RefreshUiTimerState above, which is where the
+            // renderable/not decision is made. Re-attaching can land the view on a top level
+            // with a different render scale, and the cell metrics for it are not known until
+            // the MeasureCharSize on the line above - reconciling before that point would
+            // compute the grid from the old monitor and dispatch it, and if the new bounds
+            // happen to match in DIPs no later OnSizeChanged would ever correct it.
+            ReconcileDispatchedGrid();
+
             _isDirty = true;
             if (_isUiRenderable)
             {
@@ -1054,6 +1065,12 @@ namespace NovaTerminal.Shell
             if (change.Property == IsVisibleProperty || change.Property == BoundsProperty)
             {
                 RefreshUiTimerState();
+
+                // A dispatch cancelled when this view stopped being renderable is re-sent when
+                // it starts again (#432). Metrics are already current on this path - nothing
+                // here changes the top level - so unlike the attach path it can follow the
+                // renderable decision directly.
+                ReconcileDispatchedGrid();
             }
             else if (change.Property == IsKeyboardFocusWithinProperty)
             {
@@ -1589,10 +1606,22 @@ namespace NovaTerminal.Shell
         /// Overriding the decision rather than the clock removes the race instead of narrowing it.
         /// Both branches remain real code; this only chooses which one runs.
         /// </remarks>
+        // Set when StopUiTimers cancels a dispatch that was armed and waiting. Reconciliation
+        // is gated on it so that restoring a pane re-sends only a grid that was genuinely
+        // dropped, and never becomes a second, unasked-for resize path (#432).
+        private bool _resizeDispatchCancelled;
+
         private bool? _throttleElapsedForTest;
 
         /// <summary>Forces the next dispatch onto the throttle timer rather than the inline path.</summary>
         internal void HoldResizeThrottleForTest() => _throttleElapsedForTest = false;
+
+        /// <summary>Forces the next dispatch inline rather than onto the timer.</summary>
+        /// <remarks>
+        /// Needed because the headless harness never ticks a DispatcherTimer, so a test that
+        /// waited on one would sleep or hang.
+        /// </remarks>
+        internal void ReleaseResizeThrottleForTest() => _throttleElapsedForTest = true;
 
         /// <summary>Whether a resize has been computed and is still waiting on the throttle.</summary>
         internal bool ResizeDispatchPendingForTest => _resizeThrottleTimer?.IsEnabled == true;
@@ -1813,34 +1842,7 @@ namespace NovaTerminal.Shell
 
                     if (dimensionsChanged)
                     {
-                        // STRICT INTERVAL THROTTLE: Limit resize dispatch to 60ms
-                        var now = DateTime.UtcNow;
-                        if (_pendingResizeStartedAt == DateTime.MinValue)
-                        {
-                            _pendingResizeStartedAt = now;
-                        }
-
-                        if (_resizeThrottleTimer == null)
-                        {
-                            _resizeThrottleTimer = new DispatcherTimer(DispatcherPriority.Normal)
-                            {
-                                Interval = TimeSpan.FromMilliseconds(60)
-                            };
-                            _resizeThrottleTimer.Tick += OnResizeThrottleTick;
-                        }
-
-                        bool intervalElapsed =
-                            _throttleElapsedForTest ?? ((now - _lastPtyResizeTime).TotalMilliseconds >= 60);
-
-                        if (intervalElapsed && !_resizeThrottleTimer.IsEnabled)
-                        {
-                            // Enough time passed and no pending timer - send immediately
-                            SendThrottledResize();
-                        }
-                        else if (!_resizeThrottleTimer.IsEnabled)
-                        {
-                            _resizeThrottleTimer.Start();
-                        }
+                        QueueResizeDispatch();
                     }
                 }
             }
@@ -1860,11 +1862,100 @@ namespace NovaTerminal.Shell
         /// first draft of this change, and an unrecorded dispatch there would have left the
         /// field describing a grid that had since been superseded. A fourth site added later
         /// gets the whole of the bookkeeping or none of it, not half.
+        ///
+        /// Clearing the cancellation flag belongs here for the same reason. A dispatch that has
+        /// happened supersedes one that was dropped, so there is nothing left to repair - and a
+        /// stale flag is not harmless, because the next restore would then reconcile against a
+        /// grid the font path had legitimately chosen and resize away from it.
         /// </remarks>
         private void RecordDispatchedGrid(int cols, int rows)
         {
             _lastDispatchedCols = cols;
             _lastDispatchedRows = rows;
+            _resizeDispatchCancelled = false;
+        }
+
+        /// <summary>
+        /// Sends the pending grid to the buffer and the PTY, now if the throttle interval has
+        /// elapsed and on the timer otherwise.
+        /// </summary>
+        private void QueueResizeDispatch()
+        {
+            // STRICT INTERVAL THROTTLE: Limit resize dispatch to 60ms
+            var now = DateTime.UtcNow;
+            if (_pendingResizeStartedAt == DateTime.MinValue)
+            {
+                _pendingResizeStartedAt = now;
+            }
+
+            if (_resizeThrottleTimer == null)
+            {
+                _resizeThrottleTimer = new DispatcherTimer(DispatcherPriority.Normal)
+                {
+                    Interval = TimeSpan.FromMilliseconds(60)
+                };
+                _resizeThrottleTimer.Tick += OnResizeThrottleTick;
+            }
+
+            bool intervalElapsed =
+                _throttleElapsedForTest ?? ((now - _lastPtyResizeTime).TotalMilliseconds >= 60);
+
+            if (intervalElapsed && !_resizeThrottleTimer.IsEnabled)
+            {
+                // Enough time passed and no pending timer - send immediately
+                SendThrottledResize();
+            }
+            else if (!_resizeThrottleTimer.IsEnabled)
+            {
+                _resizeThrottleTimer.Start();
+            }
+        }
+
+        /// <summary>
+        /// Re-dispatches the current grid if the buffer and the PTY are not on it. Called when the
+        /// view becomes renderable again.
+        /// </summary>
+        /// <remarks>
+        /// StopUiTimers cancels a dispatch that was waiting on the throttle - collapsing a pane,
+        /// hiding it, or detaching it all reach it - and StartUiTimers deliberately does not
+        /// restart that timer. Honest bookkeeping alone does not recover from that: OnSizeChanged
+        /// fires on a size *change*, and a pane that is collapsed and restored comes back at the
+        /// size it left at, so no further event ever arrives to notice the disagreement. Measured,
+        /// not assumed - the bookkeeping half of #432 was tested on its own first and the pane was
+        /// still stranded on its old grid.
+        ///
+        /// Nothing is sent when the grids already agree, so the ordinary show/hide of a pane whose
+        /// size never changed costs a comparison.
+        /// </remarks>
+        private void ReconcileDispatchedGrid()
+        {
+            // Only ever a repair for a dispatch that was actually cancelled. Reconciling on
+            // every restore would make this a second resize path with a different opinion:
+            // the font branch of ApplySettings derives its grid as Bounds.Width / CellWidth
+            // while TryComputeGrid subtracts the padding the draw operation reserves, so the
+            // two disagree by a column at some widths - and an ungated reconcile would turn
+            // that standing disagreement into a reflow and a SIGWINCH every time someone
+            // collapsed and reopened a pane. Repairing a cancellation is this method's job;
+            // arbitrating between two grid calculations is not.
+            if (!_resizeDispatchCancelled) return;
+            if (!_isUiRenderable) return;
+            if (_buffer == null || !_isReady) return;
+            if (_metrics.CellWidth <= 0 || _metrics.CellHeight <= 0) return;
+
+            if (!TryComputeGrid(Bounds.Size, _metrics.CellWidth, _metrics.CellHeight, out int cols, out int rows))
+            {
+                // Nothing usable to reconcile against; keep the flag and let a real layout
+                // pass, or the next restore, try again.
+                return;
+            }
+
+            _resizeDispatchCancelled = false;
+
+            if (cols == _lastDispatchedCols && rows == _lastDispatchedRows) return;
+
+            _pendingCols = cols;
+            _pendingRows = rows;
+            QueueResizeDispatch();
         }
 
         private void SendThrottledResize()
@@ -1974,6 +2065,21 @@ namespace NovaTerminal.Shell
             _cursorBlinkTimer.Stop();
             _scrollAnimationTimer.Stop();
             _autoScrollTimer?.Stop();
+
+            // A resize computed but not yet dispatched dies here, and nothing restarts this
+            // timer - StartUiTimers deliberately does not. Remember that it happened so the
+            // grid can be re-sent when the view becomes renderable again.
+            if (_resizeThrottleTimer?.IsEnabled == true)
+            {
+                _resizeDispatchCancelled = true;
+
+                // The latency clock dies with the dispatch it was timing. QueueResizeDispatch
+                // only starts one when there is none, so leaving this set would bill the whole
+                // hidden interval - seconds, or minutes - to the resize that eventually runs,
+                // and RendererStatistics would report it as dispatch latency.
+                _pendingResizeStartedAt = DateTime.MinValue;
+            }
+
             _resizeThrottleTimer?.Stop();
             _uiTimersRunning = false;
             RendererStatistics.RecordTerminalViewTimersStopped();

--- a/tests/NovaTerminal.App.Tests/Core/TerminalViewResizeReconcileTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/TerminalViewResizeReconcileTests.cs
@@ -1,0 +1,280 @@
+using Avalonia.Controls;
+using Avalonia.Headless.XUnit;
+using Avalonia.Threading;
+using NovaTerminal.Shell;
+using NovaTerminal.VT;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// #432: a resize dispatch cancelled before it runs must still reach the buffer and the PTY.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>OnSizeChanged</c> computes a grid and leaves the 60ms throttle to dispatch it. Anything that
+/// stops that timer in between - collapsing the pane, hiding it, detaching it - drops the dispatch,
+/// and <c>StartUiTimers</c> deliberately does not restart it. The pane then renders one grid while
+/// the buffer and the PTY are on another: wrapping stops matching the pane, and nothing recovers it
+/// until some later size happens to differ from the one on record.
+/// </para>
+/// <para>
+/// Recording a dispatch only where it happens is a prerequisite for this and not a cure for it -
+/// <c>OnSizeChanged</c> fires on a size <i>change</i>, and a pane that is collapsed and restored
+/// comes back at the size it left at, so nothing further arrives to notice. This is the half that
+/// re-sends.
+/// </para>
+/// <para>
+/// Driven through a real window rather than a seam, because the bug is an ordering of real events -
+/// layout, visibility, timer - and a test that called the pieces directly would be asserting the
+/// order it chose itself.
+/// </para>
+/// </remarks>
+public class TerminalViewResizeReconcileTests
+{
+    [AvaloniaFact]
+    [Trait("Category", "Regression")]
+    public void AResizeCancelledBeforeItDispatches_StillReachesTheBuffer()
+    {
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        var window = new Window { Content = view, Width = 800, Height = 400 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(view.Bounds.Width > 0, $"the view was never arranged: {view.Bounds}");
+
+            (int cols, int rows) = view.LastDispatchedGridForTest;
+            Assert.True(cols > 0 && rows > 0, $"nothing was dispatched on show: {cols}x{rows}");
+            Assert.Equal(cols, buffer.Cols);
+
+            // Force the narrower size onto the throttle, so this is about a cancelled dispatch and
+            // not about how fast the machine running it is.
+            view.HoldResizeThrottleForTest();
+
+            window.Width = 500;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(
+                view.ResizeDispatchPendingForTest,
+                "setup failed: the narrower size should still be waiting on the throttle");
+
+            // The pane goes away before the timer ticks - collapsed, hidden, or detached - which
+            // stops the UI timers and takes the pending dispatch with them.
+            view.IsVisible = false;
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(
+                view.ResizeDispatchPendingForTest,
+                "setup failed: hiding the view should have stopped the throttle timer");
+
+            // ...and comes back at the same size it had, which is what a collapse/restore does, so
+            // no further size change arrives. Released so the reconciled dispatch goes inline
+            // rather than arming a timer the headless harness will never tick; which branch of the
+            // throttle runs is not what is under test.
+            view.ReleaseResizeThrottleForTest();
+            view.IsVisible = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(view.LastDispatchedGridForTest.Cols, buffer.Cols);
+            Assert.Equal(view.LastDispatchedGridForTest.Rows, buffer.Rows);
+            Assert.Equal(GridColsFor(view), buffer.Cols);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    [AvaloniaFact]
+    [Trait("Category", "Regression")]
+    public void HidingAndRestoringAPane_WithNothingCancelled_SendsNoResize()
+    {
+        // The reconcile repairs a cancellation and does nothing else, and the difference
+        // matters because the buffer can legitimately be on a grid that TryComputeGrid would
+        // not have chosen. The real instance is the font branch of ApplySettings, which
+        // derives its grid as Bounds.Width / CellWidth while TryComputeGrid subtracts the
+        // padding the draw operation reserves, so the two disagree by a column at some widths.
+        // An ungated reconcile would read that standing disagreement as work to do and reflow
+        // the buffer, sending SIGWINCH, every time a pane was collapsed and reopened.
+        //
+        // The disagreement is created here by moving the measured cell size rather than by
+        // reproducing the font path at a width where its arithmetic happens to diverge: the
+        // gate is about whether a cancellation occurred, not about which calculation is right,
+        // so any source of disagreement exercises it and one that is guaranteed to exist
+        // exercises it every run.
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        int resizes = 0;
+        var window = new Window { Content = view, Width = 800, Height = 400 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            (int cols, int rows) = view.LastDispatchedGridForTest;
+            Assert.True(cols > 0, "nothing was dispatched on show");
+            int bufferCols = buffer.Cols;
+            int bufferRows = buffer.Rows;
+
+            (double cellWidth, double cellHeight) = view.CellSizeForTest;
+            view.SetMetricsForTest((float)cellWidth * 2, (float)cellHeight * 2);
+
+            Assert.True(
+                TerminalView.TryComputeGrid(view.Bounds.Size, cellWidth * 2, cellHeight * 2, out int otherCols, out _)
+                && otherCols != cols,
+                "setup failed: the view and its last dispatch need to disagree for this to assert anything");
+
+            // Counted from here, so only the restore is under test.
+            view.OnResize += (_, _) => resizes++;
+
+            // An ordinary hide and restore: nothing was waiting on the throttle, so nothing
+            // was cancelled, so there is nothing to repair.
+            view.IsVisible = false;
+            Dispatcher.UIThread.RunJobs();
+            view.IsVisible = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0, resizes);
+            Assert.Equal((cols, rows), view.LastDispatchedGridForTest);
+            Assert.Equal(bufferCols, buffer.Cols);
+            Assert.Equal(bufferRows, buffer.Rows);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    [AvaloniaFact]
+    [Trait("Category", "Regression")]
+    public void ACancelledDispatchSupersededWhileHidden_IsNotReconciledOnRestore()
+    {
+        // A cancelled dispatch is only worth repairing while it is still the last word. Change
+        // the font while the pane is hidden and ApplySettings re-grids the buffer and the PTY
+        // directly - the dropped resize has been overtaken, and there is nothing to repair.
+        // Reconciling anyway would resize away from the grid the font path deliberately chose,
+        // which is the same unwanted reflow and SIGWINCH the gate exists to prevent.
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        int resizes = 0;
+        var window = new Window { Content = view, Width = 800, Height = 400 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            (int cols, int rows) = view.LastDispatchedGridForTest;
+            Assert.True(cols > 0, "nothing was dispatched on show");
+
+            view.HoldResizeThrottleForTest();
+            window.Width = 500;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(view.ResizeDispatchPendingForTest, "setup failed: nothing was queued");
+
+            view.IsVisible = false;
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(
+                view.ResizeDispatchPendingForTest,
+                "setup failed: hiding the view should have stopped the throttle timer");
+
+            // The dropped resize is overtaken while the pane is still hidden.
+            view.ApplySettings(new TerminalSettings { FontSize = 28 });
+            Dispatcher.UIThread.RunJobs();
+            (int fontCols, int fontRows) = view.LastDispatchedGridForTest;
+            Assert.True(
+                (fontCols, fontRows) != (cols, rows),
+                "setup failed: the font change dispatched nothing, so nothing superseded the cancelled resize");
+
+            // Force the restore to have something it *could* resize to, so this asserts the
+            // gate rather than an accidental agreement between two grid calculations.
+            (double cellWidth, double cellHeight) = view.CellSizeForTest;
+            view.SetMetricsForTest((float)cellWidth * 2, (float)cellHeight * 2);
+
+            int bufferCols = buffer.Cols;
+            int bufferRows = buffer.Rows;
+            view.OnResize += (_, _) => resizes++;
+
+            view.ReleaseResizeThrottleForTest();
+            view.IsVisible = true;
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(0, resizes);
+            Assert.Equal((fontCols, fontRows), view.LastDispatchedGridForTest);
+            Assert.Equal(bufferCols, buffer.Cols);
+            Assert.Equal(bufferRows, buffer.Rows);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    [AvaloniaFact]
+    [Trait("Category", "Regression")]
+    public void AResizeCancelledByDetaching_ReachesTheBufferOnReattach()
+    {
+        // Detaching is the third way a pending dispatch dies, alongside hiding and collapsing,
+        // and it is the one with an ordering hazard: re-attaching can land the view on a top
+        // level with a different render scale, and the cell metrics for it are not known until
+        // OnAttachedToVisualTree has re-measured. Reconciling before that would compute the
+        // grid from the old metrics, which is why it runs after MeasureCharSize rather than
+        // from the renderable decision that precedes it.
+        var buffer = new TerminalBuffer(80, 24);
+        var view = new TerminalView();
+        view.SetBuffer(buffer);
+
+        var host = new Decorator { Child = view };
+        var window = new Window { Content = host, Width = 800, Height = 400 };
+        try
+        {
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            (int cols, int rows) = view.LastDispatchedGridForTest;
+            Assert.True(cols > 0, "nothing was dispatched on show");
+            Assert.Equal(cols, buffer.Cols);
+
+            view.HoldResizeThrottleForTest();
+            window.Width = 500;
+            Dispatcher.UIThread.RunJobs();
+            Assert.True(view.ResizeDispatchPendingForTest, "setup failed: nothing was queued");
+
+            host.Child = null;                  // detach: the queued dispatch dies here
+            Dispatcher.UIThread.RunJobs();
+            Assert.False(
+                view.ResizeDispatchPendingForTest,
+                "setup failed: detaching should have stopped the throttle timer");
+
+            view.ReleaseResizeThrottleForTest();
+            host.Child = view;                  // and back
+            Dispatcher.UIThread.RunJobs();
+
+            Assert.Equal(view.LastDispatchedGridForTest.Cols, buffer.Cols);
+            Assert.Equal(view.LastDispatchedGridForTest.Rows, buffer.Rows);
+            Assert.Equal(GridColsFor(view), buffer.Cols);
+        }
+        finally
+        {
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+
+    /// <summary>The column count the view is actually drawing, independent of its bookkeeping.</summary>
+    private static int GridColsFor(TerminalView view)
+    {
+        (double cellWidth, double cellHeight) = view.CellSizeForTest;
+        Assert.True(
+            TerminalView.TryComputeGrid(view.Bounds.Size, cellWidth, cellHeight, out int cols, out _),
+            $"the view's own bounds {view.Bounds} do not describe a usable grid");
+        return cols;
+    }
+}


### PR DESCRIPTION
Part two of two for issue #432, split out on request. **Stacked on #441** — its base is that branch, so the diff here is only this half. Merge #441 first and GitHub will retarget this to `main`.

This is the half that actually cures the desync.

## Why part one is not enough

`StopUiTimers` cancels a resize waiting on the 60 ms throttle — hiding a pane, collapsing it, or detaching it all reach it — and `StartUiTimers` deliberately does not restart that timer. Part one made the tracking honest about that. It did not make anything re-send: `OnSizeChanged` fires on a size *change*, and a pane that is collapsed and restored comes back at the size it left at, so no further event arrives to notice.

Measured, not assumed: with only part one in place, a real window driven through show → resize-onto-the-throttle → hide → restore leaves the view drawing 55 columns while the buffer is still on 88.

So becoming renderable again reconciles — and only for a dispatch that is both cancelled and still the last word.

## Both halves of the gate are load-bearing

Neither is defensive tidiness; each was added because review found the case it prevents.

- **Gated on a real cancellation.** The buffer can legitimately be on a grid `TryComputeGrid` would not have chosen — the font branch of `ApplySettings` derives its own without the padding the draw operation reserves, so the two disagree by a column at some widths. An ungated reconcile reads that standing disagreement as work to do and reflows the buffer, sending SIGWINCH, **every time a pane is collapsed and reopened**.
- **Cleared by a later dispatch.** Change the font while the pane is hidden and the dropped resize has been overtaken. Repairing it then resizes away from the grid the font path deliberately chose. The clear lives inside `RecordDispatchedGrid`, so it cannot be missed at a future dispatch site.

Arbitrating between two grid calculations is a different change from repairing a cancellation. This is the one that repairs a cancellation.

## Where it is called from is also load-bearing

Not `RefreshUiTimerState`, which is where the renderable decision is made and is the obvious place. `OnAttachedToVisualTree` calls that **before** it re-measures, and re-attaching can land the view on a top level with a different render scale — so reconciling there would compute the grid from the old monitor's cell metrics and dispatch it, and if the new bounds match in DIPs no later `OnSizeChanged` would ever correct it.

The attach path therefore reconciles after `MeasureCharSize`; the visibility path, where nothing changes the top level, reconciles straight after the decision. The method checks renderability itself, since the call sites no longer imply it.

A cancelled dispatch also takes its latency clock with it — `QueueResizeDispatch` starts one only when there is none, so a retained `_pendingResizeStartedAt` would bill the whole hidden interval to the resize that eventually runs and `RendererStatistics` would report it as dispatch latency.

## Verification

Every guard was removed in turn against the test that covers it, and each removal fails:

| removed | result |
|---|---|
| the reconcile call | this issue's test fails; part one's tests still pass — which is what makes the split honest |
| the cancellation gate | an ordinary hide and restore fires one unasked-for resize |
| the flag clear | so does a hide, font change and restore |
| the attach-path call | detach and re-attach leaves the buffer on 88 while the view draws 55 |

VT 445 pass. Full App.Tests locally: 2 failures, both reproducing identically on unmodified `origin/main` here.
