### PR TITLE
test(command-assist): give the grid-truth harness the pane's dispatcher

### DIFF
--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -538,11 +538,18 @@ public sealed class CommandAssistGridTruthTests
 
     private sealed class Harness
     {
-        private Harness(CommandAssistController controller, FakeGrid grid, InMemoryHistoryStore history)
+        private readonly TestDispatcher _dispatcher;
+
+        private Harness(
+            CommandAssistController controller,
+            FakeGrid grid,
+            InMemoryHistoryStore history,
+            TestDispatcher dispatcher)
         {
             Controller = controller;
             Grid = grid;
             History = history;
+            _dispatcher = dispatcher;
         }
 
         public CommandAssistController Controller { get; }
@@ -566,6 +573,8 @@ public sealed class CommandAssistGridTruthTests
                 history.Seed(seed);
             }
 
+            var dispatcher = new TestDispatcher();
+
             var controller = new CommandAssistController(
                 history,
                 new SecretsFilter(),
@@ -576,9 +585,13 @@ public sealed class CommandAssistGridTruthTests
                 errorInsightService: null,
                 modeRouter: null,
                 resultBuilder: null,
-                queryProvider: grid == null ? null : grid.Read);
+                queryProvider: grid == null ? null : grid.Read,
 
-            return new Harness(controller, grid ?? new FakeGrid(), history);
+                // The pane's dispatcher, modelled rather than omitted - and that is what makes the
+                // reads below safe. See TestDispatcher.
+                dispatch: dispatcher.Post);
+
+            return new Harness(controller, grid ?? new FakeGrid(), history, dispatcher);
         }
 
         public Task PromptReadyAsync() => EmitAsync(ShellIntegrationEventType.CommandStarted, null, null);
@@ -589,15 +602,16 @@ public sealed class CommandAssistGridTruthTests
         public Task CommandFinishedAsync(int exitCode)
             => EmitAsync(ShellIntegrationEventType.CommandFinished, null, exitCode);
 
-        private Task EmitAsync(ShellIntegrationEventType type, string? commandText, int? exitCode)
+        private async Task EmitAsync(ShellIntegrationEventType type, string? commandText, int? exitCode)
         {
-            return Controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
+            await Controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
                 Type: type,
                 Timestamp: DateTimeOffset.UtcNow,
                 CommandText: commandText,
                 WorkingDirectory: null,
                 ExitCode: exitCode,
                 Duration: null));
+            _dispatcher.Drain();
         }
 
         /// <summary>
@@ -610,7 +624,11 @@ public sealed class CommandAssistGridTruthTests
         /// the debounce landed. Several tests here assert that nothing appeared, and those are the ones
         /// a too-short settle would pass for the wrong reason.
         /// </remarks>
-        public Task SettleAsync() => Task.Delay(250);
+        public async Task SettleAsync()
+        {
+            await Task.Delay(250);
+            _dispatcher.Drain();
+        }
 
         public Task WaitForQueryAsync(string expected)
             => WaitForConditionAsync(() => Controller.ViewModel.QueryText == expected);
@@ -618,6 +636,7 @@ public sealed class CommandAssistGridTruthTests
         public async Task WaitForConditionAsync(Func<bool> predicate, int timeoutMs = 2000)
         {
             int elapsed = 0;
+            _dispatcher.Drain();
             while (!predicate())
             {
                 if (elapsed >= timeoutMs)
@@ -629,6 +648,65 @@ public sealed class CommandAssistGridTruthTests
 
                 await Task.Delay(10);
                 elapsed += 10;
+                _dispatcher.Drain();
+            }
+        }
+
+        /// <summary>
+        /// The pane dispatcher's stand-in: queues the ranking pass's publish instead of running it
+        /// on whatever thread finished the pass, and hands it to the test thread at the next
+        /// <see cref="WaitForConditionAsync"/>, <see cref="SettleAsync"/> or event emit.
+        /// </summary>
+        /// <remarks>
+        /// Omitting <c>dispatch</c> left the controller on its <c>action => action()</c> default,
+        /// which is not what the App does: <c>TerminalPane</c> passes a dispatch that posts to the
+        /// pane thread, so in production <c>ApplyRefreshOutcome</c> and every selection read are the
+        /// same thread and cannot interleave. Inline meant the publish ran on the pass's threadpool
+        /// thread while the test thread read the results - a race the harness invented rather than
+        /// modelled.
+        ///
+        /// It bit as a rare CI failure in <c>AcceptReplacesTypedQuery_IsTrueOnlyForExplicitHistorySearch</c>,
+        /// whose <c>Suggestions.Count > 0</c> wait is satisfied by the rows already on screen from
+        /// the preceding <c>ToggleAssist</c>: the test walked on into the accept while a Search pass
+        /// was mid-publish, and <c>ApplyRefreshOutcome</c> clears the list before it refills it, so
+        /// an accept landing between the two saw no rows and refused. Under stress the same window
+        /// throws outright, from the check-then-index in <c>GetSelectedSuggestion</c>.
+        ///
+        /// Fixed here rather than by lengthening that one wait, because the race was available to
+        /// every test in this file and a sleep only makes it rarer. Keep the reads on the test
+        /// thread: anything that adds a new await point should drain here too.
+        /// </remarks>
+        private sealed class TestDispatcher
+        {
+            private readonly object _gate = new();
+            private readonly Queue<Action> _pending = new();
+
+            public void Post(Action action)
+            {
+                lock (_gate)
+                {
+                    _pending.Enqueue(action);
+                }
+            }
+
+            /// <summary>Runs everything queued so far on the calling thread.</summary>
+            public void Drain()
+            {
+                while (true)
+                {
+                    Action next;
+                    lock (_gate)
+                    {
+                        if (_pending.Count == 0)
+                        {
+                            return;
+                        }
+
+                        next = _pending.Dequeue();
+                    }
+
+                    next();
+                }
             }
         }
     }


### PR DESCRIPTION
`AcceptReplacesTypedQuery_IsTrueOnlyForExplicitHistorySearch` failed once on
windows CI, at the accept on line 386, with nothing in the diff that could reach
it. It is a race the harness invented rather than one the App has.

`CommandAssistController` takes a `dispatch`, and the App supplies one:
TerminalPane posts to the pane thread, so `ApplyRefreshOutcome` and every
selection read happen there and cannot interleave - which is what the "Applies a
ranking pass on the dispatcher thread" comment on it claims. This harness passed
no dispatch and so got the `action => action()` default, running the publish
inline on whatever threadpool thread finished the pass, concurrently with the
test thread. The ranking pass is fire-and-forget (`_ = RunPassAsync`, `Task.Run`,
`ConfigureAwait(false)`), so that concurrency is real.

What that costs: `ApplyRefreshOutcome` clears `_suggestions` before it refills
them, so a read landing between the two sees no rows. `TryAcceptSelection` then
refuses, which is exactly the observed failure. `GetSelectedSuggestion` checks
`SelectedIndex < _suggestions.Count` and then indexes, so the same window can
also throw ArgumentOutOfRangeException outright.

Reproduced and then closed, rather than argued: a probe hammering
TryGetInsertionText while passes republish underneath it threw
ArgumentOutOfRangeException from GetSelectedSuggestion after ~54ms on the old
harness; on this one it ran the full 4s, 133,246,500 iterations, zero refusals
and no throw.

Fixed in the harness, not in the one test, because the race was available to all
24 tests in the file - `TestDispatcher` queues the publish and hands it to the
test thread at the next WaitForConditionAsync, SettleAsync or event emit. A
longer wait on the one test would only have made it rarer. Anything that adds a
new await point here should drain too, and the comment says so.

Not a production bug, and deliberately no `src/` change: production serializes
these on the pane dispatcher. Unverified and left alone: the controller's comment
mentions non-App hosts (the MCP surface) also taking the no-dispatch default; if
one of those reads the selection off-thread it has the same exposure.

Still true after this change, and worth its own look: that test's
`Suggestions.Count > 0` wait is vacuous - the rows from the preceding
ToggleAssist already satisfy it, so it never waits for the Search pass and the
accept resolves against the Suggest rows. It can no longer race, but it also is
not yet asserting what its name says. The other four OpenHistorySearch tests in
the file open with an empty list, which is why this was the only one to flake.

App.Tests both lanes as CONTRIBUTING requires: main 3535 total / 0 failed,
PlatformBoot 54 / 0 failed. GridTruth file 24/24.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
