### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
   <PropertyGroup>
-    <Version>0.7.0</Version>
-    <AssemblyVersion>0.7.0.0</AssemblyVersion>
-    <FileVersion>0.7.0.0</FileVersion>
-    <InformationalVersion>0.7.0</InformationalVersion>
+    <Version>0.8.0</Version>
+    <AssemblyVersion>0.8.0.0</AssemblyVersion>
+    <FileVersion>0.8.0.0</FileVersion>
+    <InformationalVersion>0.8.0</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Promotes 0.8.0 out of prerelease. v0.8.0-rc.1 (release run 34226311285) settled
the one unknown it was cut for: the release-blocking smoke launch added in #445
has now run on a real tag. It started the published win-x64 bundle between
Publish AOT and Archive bundle, with natives taken from Download Native Artifact
rather than compiled, and matched its assertions against the bundle's own log
before any user-facing artifact existed. The RC published all 22 assets across
every platform leg, not merely green jobs.

The same log also settles the anchor question behind #445's review. Both lines
are there, one after the other:

  [RustPtySession] Spawning 'cmd.exe' args='/k chcp 65001 ' cwd='' at 113x39
  [RustPtySession] Spawned 'cmd.exe' pid=1912

The gate as first written asserted the first of those, which RustPtySession logs
BEFORE calling pty_spawn - so it would have gone green on a bundle whose PTY
never started. It now asserts the second, which carries a real child pid and sits
after the IsInvalid check. That distinction is only observable on a shipped
bundle, and this is the first tag that observed it.

The release workflow takes its version from the tag, so this property is not what
ships; it is kept in step so a local build reports the same version as the release
it corresponds to.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
