### PR TITLE
fix(assist): apply the OSC 133 lifecycle gate on the thread the bytes arrive on

### DIFF
--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -1257,9 +1257,17 @@ namespace NovaTerminal.Controls
 
                 // The lifecycle half of the same pair, and it has to come from the same place the
                 // mark does or the two can disagree - which is exactly what #448 cost. The buffer
-                // owns both and the parser applies both in one statement block, so this controller
-                // reads the window rather than keeping its own opinion of it.
-                commandInputGateProbe: () => Buffer?.IsAcceptingCommandInput ?? false,
+                // owns both and the parser publishes both in one step, so this controller reads the
+                // window rather than keeping its own opinion of it.
+                //
+                // Combined with the consumption switch, which is the third path that needs it
+                // (Codex P2 on #448). The parser writes the window for every session that emits
+                // marks, tracker or no tracker, so without this an instrumented remote host would
+                // hand grid-backed queries and Enter capture to a user who had turned shell
+                // integration off - and a remote host is exactly where they cannot uninstall the
+                // emitter instead.
+                commandInputGateProbe: () =>
+                    IsShellIntegrationConsumptionEnabled && (Buffer?.IsAcceptingCommandInput ?? false),
 
                 // The other seam the controller cannot see for itself: whether the overlay it believes
                 // is up is actually on screen. This pane hides it (no layout) and dims it (placement
@@ -2519,10 +2527,10 @@ namespace NovaTerminal.Controls
         /// settings object yet is treated as enabled, which is what the arming paths do).
         /// </summary>
         /// <remarks>
-        /// Consulted by the two consumption paths that hang off the raw parser callbacks rather than
-        /// off the tracker - the integrated-session latch and the <c>133;C</c> payload - because
-        /// those callbacks are wired unconditionally and would otherwise keep consuming remote marks
-        /// with the setting off. The callbacks themselves stay wired: they also feed the agent status
+        /// Consulted by the three consumption paths that hang off the raw parser callbacks rather
+        /// than off the tracker - the integrated-session latch, the <c>133;C</c> payload, and the
+        /// command-input window the grid read is gated on - because those callbacks are wired
+        /// unconditionally and would otherwise keep consuming remote marks with the setting off. The callbacks themselves stay wired: they also feed the agent status
         /// machine and the overlay anchor, neither of which this switch governs.
         /// </remarks>
         private bool IsShellIntegrationConsumptionEnabled =>
@@ -3204,9 +3212,11 @@ namespace NovaTerminal.Controls
                 // a resize triggers rather than waiting to be replaced; see
                 // TerminalBuffer.CommandStartMark, which is where this now lives.
                 NoteShellIntegrationMarkObserved();
-                LatestCommandStartMark = mark;
 
-
+                // The mark is not written here any more: AnsiParser publishes it into the buffer
+                // together with the command-input window, before this callback runs, so the pair can
+                // never be observed half-updated (Codex P2 on #448). LatestCommandStartMark remains
+                // as the pane's reader of it.
                 _shellLifecycleTracker?.HandleCommandStarted(new ShellMarkPosition(
                     Row: mark.Row,
                     Column: mark.Column,

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -139,15 +139,7 @@ namespace NovaTerminal.Controls
         private readonly SshDiagnosticsLevel _sshDiagnosticsLevel;
         private string? _pendingPasteFilePath;
         private string? _pendingEscapedPath;
-        // Volatile because the parse thread reads it to apply the OSC 133 lifecycle gate
-        // (OnShellIntegrationEventObserved) while it is assigned from the UI thread. That read only
-        // ever touches AssistSessionContext's own volatile flag, so the reference is all it needs to
-        // see; volatile is what makes "non-null implies fully constructed" something the memory
-        // model actually promises rather than something x64 happens to give us. It does not
-        // serialize InitializeCommandAssist - two threads finding null can still both build one -
-        // which is a pre-existing hazard this field's readers now tolerate rather than fix: see
-        // HandleShellIntegrationEventAsync for how the gate stays correct across a swap.
-        private volatile CommandAssistController? _commandAssistController;
+        private CommandAssistController? _commandAssistController;
         private CommandAssistServices? _commandAssistServices;
 
         /// <summary>
@@ -730,6 +722,7 @@ namespace NovaTerminal.Controls
             // the grid cannot serve. See NotifyTypedTextObserved and friends.
             TermView.TextInputObserved += NotifyTypedTextObserved;
             TermView.BackspaceObserved += NotifyBackspaceObserved;
+            TermView.EnterObserving += OnCommandAssistEnterObserving;
             TermView.EnterObserved += OnCommandAssistEnterObserved;
             TermView.PasteObserved += NotifyPasteObserved;
 
@@ -777,7 +770,7 @@ namespace NovaTerminal.Controls
                     SetAgentOutputPanelOpen(AgentOutputToggle.IsChecked ?? false);
                 }
             };
-            TermView.EnterObserved += OnAgentOutputEnterObserved;
+            TermView.EnterObserving += OnAgentOutputEnterObserved;
 
             // Load Settings
             ApplySettings(initialSettings ?? TerminalSettings.Load());
@@ -1261,6 +1254,12 @@ namespace NovaTerminal.Controls
                 // assist assembly's own AssistQuerySnapshot right here, at the one boundary that
                 // can see both types. Everything downstream sees plain data.
                 queryProvider: TryReadAssistQuerySnapshot,
+
+                // The lifecycle half of the same pair, and it has to come from the same place the
+                // mark does or the two can disagree - which is exactly what #448 cost. The buffer
+                // owns both and the parser applies both in one statement block, so this controller
+                // reads the window rather than keeping its own opinion of it.
+                commandInputGateProbe: () => Buffer?.IsAcceptingCommandInput ?? false,
 
                 // The other seam the controller cannot see for itself: whether the overlay it believes
                 // is up is actually on screen. This pane hides it (no layout) and dims it (placement
@@ -2243,8 +2242,9 @@ namespace NovaTerminal.Controls
         /// <summary>
         /// Enter observed with shell integration inactive: pin the output-region start from the
         /// cursor, the markless fallback. Without this, sessions without shell integration have
-        /// no region to track at all. Runs after <see cref="OnCommandAssistEnterObserved"/>,
-        /// synchronously on the UI thread, for the same narrow-window reason that method does.
+        /// no region to track at all. Runs after <see cref="OnCommandAssistEnterObserving"/> and,
+        /// like it, before the carriage return reaches the PTY: this records a grid row, and the row
+        /// only means what it says while the line the user submitted is still the one on screen.
         /// </summary>
         private void OnAgentOutputEnterObserved()
         {
@@ -2265,8 +2265,35 @@ namespace NovaTerminal.Controls
         /// widens the window in which the shell has begun repainting over it. This is as close to
         /// the keypress as the pane can get.
         /// </remarks>
-        internal void OnCommandAssistEnterObserved()
+        // What OnCommandAssistEnterObserving read out of the grid, waiting for the post-CR phase to
+        // persist it. Two fields rather than one, because null is a meaningful answer here: "the
+        // line was observed empty" and "there was nothing to observe" are different, and only the
+        // first should reach the pipeline.
+        private string? _pendingEnterSubmission;
+        private bool _hasPendingEnterSubmission;
+
+        /// <summary>
+        /// Enter's grid read, before the carriage return goes to the PTY.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is as close to the keypress as the pane can get, and closer than it used to be:
+        /// <c>TerminalView</c> sent the carriage return first, so the shell had already been handed
+        /// the chance to repaint over the line this reads. Worse, once the OSC 133 command-input
+        /// window began closing synchronously on the parse thread, a bare <c>133;C</c> could shut it
+        /// between the CR and this method - and a refused read here means the command is never
+        /// persisted at all (Codex P1 on #448).
+        /// </para>
+        /// <para>
+        /// Reads only. The persistence it feeds runs in <see cref="OnCommandAssistEnterObserved"/>,
+        /// after the CR, so a slow history store cannot sit between the keypress and the shell.
+        /// </para>
+        /// </remarks>
+        internal void OnCommandAssistEnterObserving()
         {
+            _pendingEnterSubmission = null;
+            _hasPendingEnterSubmission = false;
+
             // The reset is owed even when Command Assist is off or uninitialized: the accumulator
             // is fed from TermView events that fire regardless, and a line left in it would be
             // carried into the next one.
@@ -2286,9 +2313,27 @@ namespace NovaTerminal.Controls
                 ? grid.Text
                 : ReadEchoedMarklessSubmission();
 
-            // After the read, before the await: Enter is both the capture point and the start of
-            // the next line.
+            // After the read: Enter is both the capture point and the start of the next line.
             _marklessSubmission.Reset();
+
+            _pendingEnterSubmission = submitted;
+            _hasPendingEnterSubmission = true;
+        }
+
+        /// <summary>
+        /// Persists what <see cref="OnCommandAssistEnterObserving"/> read, after the carriage return
+        /// has already reached the shell.
+        /// </summary>
+        internal void OnCommandAssistEnterObserved()
+        {
+            if (!_hasPendingEnterSubmission)
+            {
+                return;
+            }
+
+            _hasPendingEnterSubmission = false;
+            string? submitted = _pendingEnterSubmission;
+            _pendingEnterSubmission = null;
 
             _ = HandleCommandAssistEnterObservedAsync(submitted);
         }
@@ -3104,6 +3149,7 @@ namespace NovaTerminal.Controls
             {
                 NoteShellIntegrationMarkObserved();
 
+
                 // OSC 133;C is the only moment the output region's *start* can be established: the
                 // input line is still on screen and the mark that describes it is still live, so
                 // "the row after the last row of the input" is answerable. One frame later the
@@ -3159,6 +3205,7 @@ namespace NovaTerminal.Controls
                 // TerminalBuffer.CommandStartMark, which is where this now lives.
                 NoteShellIntegrationMarkObserved();
                 LatestCommandStartMark = mark;
+
 
                 _shellLifecycleTracker?.HandleCommandStarted(new ShellMarkPosition(
                     Row: mark.Row,
@@ -4895,27 +4942,8 @@ namespace NovaTerminal.Controls
             // cross-thread Avalonia write inside Command Assist initialization could break the assist
             // overlay's content with no error anywhere (the post-3a blank-overlay regression, fixed in
             // BindCommandAssistViews). One log line is the difference between that and a mystery.
-            // The lifecycle gate moves here, synchronously, on the thread the bytes arrived on -
-            // ahead of the dispatcher hop below rather than inside it. It has to, because it is one
-            // half of a pair: the other half is the OSC 133;B mark the parser has just written into
-            // the buffer, and OnCommandAssistEnterObserved reads both at once and discards the
-            // command outright when they disagree. Applying it after the hop meant the two halves
-            // moved on different schedules, and a submission landing in that window was lost from
-            // history silently and permanently. See
-            // CommandAssistController.ApplyShellIntegrationLifecycle for the full mechanism and for
-            // why exactly one of the two paths may own each event.
-            //
-            // Snapshotted into a local rather than re-read, same as the other non-UI-thread readers
-            // of this field: the parse thread may not initialize Command Assist (that builds views),
-            // so when the controller does not exist yet the gate stays the dispatcher's job, which
-            // is where EnsureCommandAssistInitialized can run.
-            CommandAssistController? assist = _commandAssistController;
-            assist?.ApplyShellIntegrationLifecycle(shellEvent);
-
             _ = _shellIntegrationEventDispatcher
-                .EnqueueAsync(() => HandleShellIntegrationEventAsync(
-                    shellEvent,
-                    lifecycleAppliedTo: assist))
+                .EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent))
                 .ContinueWith(
                     static task => TerminalLogger.Log(
                         LogLevel.Error,
@@ -5163,37 +5191,16 @@ namespace NovaTerminal.Controls
             await _commandAssistController.HandleCommandFailureAsync(context);
         }
 
-        /// <param name="lifecycleAppliedTo">
-        /// The controller <see cref="OnShellIntegrationEventObserved"/> already applied this event's
-        /// lifecycle gate to, or <see langword="null"/> if it could not.
-        /// </param>
-        /// <remarks>
-        /// The identity comparison rather than a bool is Codex P1 on #448. Nothing serializes
-        /// <c>InitializeCommandAssist</c>, so a first mark racing a UI entry point can leave the
-        /// synchronous application on one controller and this handler holding another: a bool would
-        /// then say "already applied" about an instance whose gate had never been touched, and the
-        /// event would be skipped on the controller that actually matters - the original dropped
-        /// command, by a new route. Comparing instances answers the question that was always being
-        /// asked. A fresh controller's context has no gate history, so replaying the event onto it
-        /// is right; the same instance twice is what must not happen.
-        /// </remarks>
-        private async Task HandleShellIntegrationEventAsync(
-            ShellIntegrationEvent shellEvent,
-            CommandAssistController? lifecycleAppliedTo)
+        private async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
         {
             if (!EnsureCommandAssistInitialized())
             {
                 return;
             }
 
-            // Read once: re-reading the field could hand the two calls below different instances.
-            CommandAssistController controller = _commandAssistController!;
-
             try
             {
-                await controller.HandleShellIntegrationEventAsync(
-                    shellEvent,
-                    applyLifecycle: !ReferenceEquals(controller, lifecycleAppliedTo));
+                await _commandAssistController.HandleShellIntegrationEventAsync(shellEvent);
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -139,7 +139,15 @@ namespace NovaTerminal.Controls
         private readonly SshDiagnosticsLevel _sshDiagnosticsLevel;
         private string? _pendingPasteFilePath;
         private string? _pendingEscapedPath;
-        private CommandAssistController? _commandAssistController;
+        // Volatile because the parse thread reads it to apply the OSC 133 lifecycle gate
+        // (OnShellIntegrationEventObserved) while it is assigned from the UI thread. That read only
+        // ever touches AssistSessionContext's own volatile flag, so the reference is all it needs to
+        // see; volatile is what makes "non-null implies fully constructed" something the memory
+        // model actually promises rather than something x64 happens to give us. It does not
+        // serialize InitializeCommandAssist - two threads finding null can still both build one -
+        // which is a pre-existing hazard this field's readers now tolerate rather than fix: see
+        // HandleShellIntegrationEventAsync for how the gate stays correct across a swap.
+        private volatile CommandAssistController? _commandAssistController;
         private CommandAssistServices? _commandAssistServices;
 
         /// <summary>
@@ -4907,7 +4915,7 @@ namespace NovaTerminal.Controls
             _ = _shellIntegrationEventDispatcher
                 .EnqueueAsync(() => HandleShellIntegrationEventAsync(
                     shellEvent,
-                    applyLifecycle: assist == null))
+                    lifecycleAppliedTo: assist))
                 .ContinueWith(
                     static task => TerminalLogger.Log(
                         LogLevel.Error,
@@ -5155,20 +5163,37 @@ namespace NovaTerminal.Controls
             await _commandAssistController.HandleCommandFailureAsync(context);
         }
 
+        /// <param name="lifecycleAppliedTo">
+        /// The controller <see cref="OnShellIntegrationEventObserved"/> already applied this event's
+        /// lifecycle gate to, or <see langword="null"/> if it could not.
+        /// </param>
+        /// <remarks>
+        /// The identity comparison rather than a bool is Codex P1 on #448. Nothing serializes
+        /// <c>InitializeCommandAssist</c>, so a first mark racing a UI entry point can leave the
+        /// synchronous application on one controller and this handler holding another: a bool would
+        /// then say "already applied" about an instance whose gate had never been touched, and the
+        /// event would be skipped on the controller that actually matters - the original dropped
+        /// command, by a new route. Comparing instances answers the question that was always being
+        /// asked. A fresh controller's context has no gate history, so replaying the event onto it
+        /// is right; the same instance twice is what must not happen.
+        /// </remarks>
         private async Task HandleShellIntegrationEventAsync(
             ShellIntegrationEvent shellEvent,
-            bool applyLifecycle)
+            CommandAssistController? lifecycleAppliedTo)
         {
             if (!EnsureCommandAssistInitialized())
             {
                 return;
             }
 
+            // Read once: re-reading the field could hand the two calls below different instances.
+            CommandAssistController controller = _commandAssistController!;
+
             try
             {
-                await _commandAssistController.HandleShellIntegrationEventAsync(
+                await controller.HandleShellIntegrationEventAsync(
                     shellEvent,
-                    applyLifecycle);
+                    applyLifecycle: !ReferenceEquals(controller, lifecycleAppliedTo));
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
+++ b/src/NovaTerminal.App/Controls/TerminalPane.axaml.cs
@@ -4887,8 +4887,27 @@ namespace NovaTerminal.Controls
             // cross-thread Avalonia write inside Command Assist initialization could break the assist
             // overlay's content with no error anywhere (the post-3a blank-overlay regression, fixed in
             // BindCommandAssistViews). One log line is the difference between that and a mystery.
+            // The lifecycle gate moves here, synchronously, on the thread the bytes arrived on -
+            // ahead of the dispatcher hop below rather than inside it. It has to, because it is one
+            // half of a pair: the other half is the OSC 133;B mark the parser has just written into
+            // the buffer, and OnCommandAssistEnterObserved reads both at once and discards the
+            // command outright when they disagree. Applying it after the hop meant the two halves
+            // moved on different schedules, and a submission landing in that window was lost from
+            // history silently and permanently. See
+            // CommandAssistController.ApplyShellIntegrationLifecycle for the full mechanism and for
+            // why exactly one of the two paths may own each event.
+            //
+            // Snapshotted into a local rather than re-read, same as the other non-UI-thread readers
+            // of this field: the parse thread may not initialize Command Assist (that builds views),
+            // so when the controller does not exist yet the gate stays the dispatcher's job, which
+            // is where EnsureCommandAssistInitialized can run.
+            CommandAssistController? assist = _commandAssistController;
+            assist?.ApplyShellIntegrationLifecycle(shellEvent);
+
             _ = _shellIntegrationEventDispatcher
-                .EnqueueAsync(() => HandleShellIntegrationEventAsync(shellEvent))
+                .EnqueueAsync(() => HandleShellIntegrationEventAsync(
+                    shellEvent,
+                    applyLifecycle: assist == null))
                 .ContinueWith(
                     static task => TerminalLogger.Log(
                         LogLevel.Error,
@@ -5136,7 +5155,9 @@ namespace NovaTerminal.Controls
             await _commandAssistController.HandleCommandFailureAsync(context);
         }
 
-        private async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
+        private async Task HandleShellIntegrationEventAsync(
+            ShellIntegrationEvent shellEvent,
+            bool applyLifecycle)
         {
             if (!EnsureCommandAssistInitialized())
             {
@@ -5145,7 +5166,9 @@ namespace NovaTerminal.Controls
 
             try
             {
-                await _commandAssistController.HandleShellIntegrationEventAsync(shellEvent);
+                await _commandAssistController.HandleShellIntegrationEventAsync(
+                    shellEvent,
+                    applyLifecycle);
             }
             catch (Exception ex)
             {

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -195,8 +195,28 @@ namespace NovaTerminal.Shell
                         // TerminalPane.OnKeyDown, which owns the reconnect-on-Enter logic.
                         return false;
                     }
-                    SendUserInput("\r");
-                    EnterObserved?.Invoke();
+                    // Observers run BEFORE the carriage return, not after (Codex P1 on #448).
+                    // OnCommandAssistEnterObserved reads the command line out of the grid here, and
+                    // the read is only truthful while the line is still on screen: the moment the CR
+                    // reaches the PTY the shell may repaint over it, and - since the OSC 133
+                    // lifecycle gate is now applied synchronously on the parse thread - a fast shell
+                    // answering with a bare 133;C can close that gate before this method's next
+                    // statement runs, at which point the capture is refused and the command is lost
+                    // from history silently. Sending afterwards costs one grid read of input latency,
+                    // taken under the buffer's read lock over at most GridQueryReader.MaxSpanRows
+                    // rows, and buys an unambiguous ordering.
+                    //
+                    // finally, so a throwing observer cannot swallow the user's Enter: the keystroke
+                    // reaches the shell either way, and the exception still propagates behind it.
+                    try
+                    {
+                        EnterObserved?.Invoke();
+                    }
+                    finally
+                    {
+                        SendUserInput("\r");
+                    }
+
                     return true;
                 case Key.Back:
                     SendUserInput("\x7f");

--- a/src/NovaTerminal.App/Shell/TerminalView.cs
+++ b/src/NovaTerminal.App/Shell/TerminalView.cs
@@ -195,28 +195,34 @@ namespace NovaTerminal.Shell
                         // TerminalPane.OnKeyDown, which owns the reconnect-on-Enter logic.
                         return false;
                     }
-                    // Observers run BEFORE the carriage return, not after (Codex P1 on #448).
-                    // OnCommandAssistEnterObserved reads the command line out of the grid here, and
-                    // the read is only truthful while the line is still on screen: the moment the CR
-                    // reaches the PTY the shell may repaint over it, and - since the OSC 133
-                    // lifecycle gate is now applied synchronously on the parse thread - a fast shell
-                    // answering with a bare 133;C can close that gate before this method's next
-                    // statement runs, at which point the capture is refused and the command is lost
-                    // from history silently. Sending afterwards costs one grid read of input latency,
-                    // taken under the buffer's read lock over at most GridQueryReader.MaxSpanRows
-                    // rows, and buys an unambiguous ordering.
+                    // Two phases around the carriage return, and which side each lands on is
+                    // load-bearing (Codex P1 and P2 on #448).
+                    //
+                    // EnterObserving must precede the CR. It is where the command line is read out
+                    // of the grid, and that read is only truthful while the line is still on screen:
+                    // the moment the CR reaches the PTY the shell may repaint over it, and - since
+                    // the OSC 133 command-input window closes synchronously on the parse thread - a
+                    // fast shell answering with a bare 133;C can shut the window before this method's
+                    // next statement runs, at which point the read is refused and the command is
+                    // lost from history silently. Cost is one grid read under the buffer's read lock.
+                    //
+                    // EnterObserved must NOT. It is where history persistence starts, and
+                    // JsonlHistoryStore.AppendAsync does redaction, migration checks, directory
+                    // creation and a file open synchronously before its first incomplete await.
+                    // Slow storage has no business sitting between a keypress and the shell.
                     //
                     // finally, so a throwing observer cannot swallow the user's Enter: the keystroke
                     // reaches the shell either way, and the exception still propagates behind it.
                     try
                     {
-                        EnterObserved?.Invoke();
+                        EnterObserving?.Invoke();
                     }
                     finally
                     {
                         SendUserInput("\r");
                     }
 
+                    EnterObserved?.Invoke();
                     return true;
                 case Key.Back:
                     SendUserInput("\x7f");
@@ -538,6 +544,15 @@ namespace NovaTerminal.Shell
             !string.IsNullOrEmpty(toastMessage);
         public event Action<string>? TextInputObserved;
         public event Action? BackspaceObserved;
+        /// <summary>
+        /// Enter, before the carriage return reaches the PTY: the grid still holds the command line
+        /// exactly as the user submitted it. For reads only - see the <c>Key.Enter</c> case.
+        /// </summary>
+        public event Action? EnterObserving;
+
+        /// <summary>
+        /// Enter, after the carriage return has gone. For work that must not delay the keystroke.
+        /// </summary>
         public event Action? EnterObserved;
         public event Action<string>? PasteObserved;
 

--- a/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
+++ b/src/NovaTerminal.CommandAssist/Application/AssistSessionContext.cs
@@ -56,7 +56,7 @@ internal sealed class AssistSessionContext
     /// decide whether it is legal to touch the terminal grid at all. The others are already
     /// atomic-by-width and would only gain ordering guarantees nothing depends on.
     /// </summary>
-    private volatile bool _isAcceptingCommandInput;
+    private Func<bool> _commandInputGateProbe = static () => false;
 
     /// <summary>Shell kind reported by the host ("pwsh", "bash", ...), or null when unknown.</summary>
     public string? ShellKind { get; private set; }
@@ -208,7 +208,26 @@ internal sealed class AssistSessionContext
     /// served as a command line.
     /// </para>
     /// </remarks>
-    public bool IsAcceptingCommandInput => _isAcceptingCommandInput;
+    public bool IsAcceptingCommandInput => _commandInputGateProbe();
+
+    /// <summary>
+    /// Points <see cref="IsAcceptingCommandInput"/> at the host's terminal buffer, which owns the
+    /// gate (<c>TerminalBuffer.IsAcceptingCommandInput</c>).
+    /// </summary>
+    /// <remarks>
+    /// A probe rather than a flag this object maintains, because this object was the wrong owner
+    /// (#448). Its writes arrived after a hop onto the pane's serialized event dispatcher, while the
+    /// <c>133;B</c> mark this gate pairs with was written synchronously by the parser - so under a
+    /// busy dispatcher the two halves disagreed and a submitted command was dropped from history
+    /// outright. Owning only one half also left "which of these two objects is authoritative" a live
+    /// question, and answering it per event turned out to be unanswerable: nothing serializes
+    /// <c>TerminalPane.InitializeCommandAssist</c>, so two threads that both find the field null can
+    /// each build a controller, and the instance a queued event lands on need not be the one the
+    /// synchronous half touched - which makes "was this already applied?" the wrong question. Both
+    /// halves now live on the buffer, which belongs to the session and is written on the parse
+    /// thread, so neither question arises.
+    /// </remarks>
+    public void SetCommandInputGateProbe(Func<bool> probe) => _commandInputGateProbe = probe;
 
     /// <summary>Replaces the host-reported session facts.</summary>
     /// <remarks>
@@ -268,44 +287,7 @@ internal sealed class AssistSessionContext
     /// torn down, and that repaint re-emits <c>B</c>, so the gate reopens on evidence rather than
     /// on assumption.
     /// </remarks>
-    public void SetAltScreenActive(bool isActive)
-    {
-        IsAltScreenActive = isActive;
-        if (isActive)
-        {
-            _isAcceptingCommandInput = false;
-        }
-    }
-
-    /// <summary><c>OSC 133;B</c>: the prompt finished printing and the line editor is the user's.</summary>
-    /// <remarks>
-    /// <para>
-    /// Refused while the alt screen is up, so that the invariant "the gate is never open during an
-    /// alt screen" holds no matter which order the two facts arrive in.
-    /// <see cref="SetAltScreenActive"/> closes the gate on the way in, but a full-screen TUI is free
-    /// to emit <c>133;B</c> of its own afterwards - it is a perfectly legal thing for a program that
-    /// draws its own prompt to do - and that would reopen a window onto the TUI's grid. Consumers
-    /// already check alt-screen separately, so this is belt and braces; without it the two flags can
-    /// disagree, and a self-contradicting invariant is one refactor away from being load-bearing.
-    /// </para>
-    /// <para>
-    /// Re-emitting <c>B</c> while the gate is already open is idempotent by construction. Prompt
-    /// frameworks repaint constantly and each repaint carries the mark; the pane keeps the newest
-    /// mark and this keeps the gate open, which is exactly the intent.
-    /// </para>
-    /// </remarks>
-    public void OpenCommandInputWindow()
-    {
-        if (IsAltScreenActive)
-        {
-            return;
-        }
-
-        _isAcceptingCommandInput = true;
-    }
-
-    /// <summary><c>OSC 133;C</c> / <c>OSC 133;D</c>: the line editor is closed.</summary>
-    public void CloseCommandInputWindow() => _isAcceptingCommandInput = false;
+    public void SetAltScreenActive(bool isActive) => IsAltScreenActive = isActive;
 
     /// <summary>Records a working-directory change reported by a shell-integration event.</summary>
     public void SetWorkingDirectory(string workingDirectory) => WorkingDirectory = workingDirectory;

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -123,6 +123,7 @@ public sealed class CommandAssistController : IDisposable
         CommandAssistModeRouter? modeRouter,
         CommandAssistResultBuilder? resultBuilder,
         Func<AssistQuerySnapshot?>? queryProvider = null,
+        Func<bool>? commandInputGateProbe = null,
         Func<bool>? renderedSurfaceProbe = null,
         Action<Action>? dispatch = null,
         TimeSpan? passiveRefreshDebounce = null,
@@ -160,6 +161,15 @@ public sealed class CommandAssistController : IDisposable
             InsertionAvailableProbe = () => _isInsertionAvailable && SelectedRowCanBeInserted()
         };
         _dispatch = dispatch ?? (action => action());
+
+        // The gate the grid read is legal under. Defaults to closed for the same reason
+        // queryProvider defaults to "no truth available": a host with no terminal buffer has no
+        // lifecycle to report, and degraded is the honest answer.
+        if (commandInputGateProbe != null)
+        {
+            _context.SetCommandInputGateProbe(commandInputGateProbe);
+        }
+
         _capturePipeline = new CapturePipeline(historyStore, secretsFilter, _context);
         _suggestionOrchestrator = new SuggestionOrchestrator(
             historyStore,
@@ -1100,17 +1110,12 @@ public sealed class CommandAssistController : IDisposable
     /// dispatcher, which is not the UI thread, and the view-model is bound.
     /// </para>
     /// </remarks>
-    public async Task HandleShellIntegrationEventAsync(
-        ShellIntegrationEvent shellEvent,
-        bool applyLifecycle = true)
+    public async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
     {
-        // Only when the caller could not do it synchronously - see ApplyShellIntegrationLifecycle
-        // for why applying it in both places would be worse than applying it late.
-        if (applyLifecycle)
-        {
-            ApplyShellIntegrationLifecycle(shellEvent);
-        }
-
+        // No lifecycle gate here any more. B/C/D move TerminalBuffer.IsAcceptingCommandInput
+        // synchronously on the parse thread, beside the 133;B mark it pairs with; see
+        // AssistSessionContext.SetCommandInputGateProbe for why this object is the wrong owner.
+        // What is left is the work that genuinely belongs on the pane's serialized dispatcher.
         switch (shellEvent.Type)
         {
             case ShellIntegrationEventType.CommandStarted:
@@ -1122,59 +1127,6 @@ public sealed class CommandAssistController : IDisposable
         }
 
         await _capturePipeline.HandleShellIntegrationEventAsync(shellEvent);
-    }
-
-    /// <summary>
-    /// The command-input lifecycle gate alone, applied synchronously: <c>B</c> opens the window,
-    /// <c>C</c> and <c>D</c> close it.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Split out of <see cref="HandleShellIntegrationEventAsync"/> so the host can apply it on the
-    /// thread the bytes arrived on, ahead of the dispatcher hop. The gate is one half of a pair, and
-    /// the other half is the <c>OSC 133;B</c> mark the parser writes into the buffer synchronously.
-    /// Enter reads both at once - <c>TerminalPane.OnCommandAssistEnterObserved</c>, on the UI thread
-    /// - and refuses grid truth unless they agree, so a gate that moves on a different schedule from
-    /// the mark is a window in which a submitted command is discarded outright: no grid snapshot,
-    /// the markless accumulator empty because the shell echoed the line rather than the user typing
-    /// it, and nothing persisted. Silent and permanent, and only for the command whose prompt lost
-    /// the race.
-    /// </para>
-    /// <para>
-    /// <c>OrderedAsyncEventDispatcher</c> hides how narrow that window is. Its semaphore is
-    /// uncontended almost always, and <c>SemaphoreSlim.WaitAsync</c> then returns an already
-    /// completed task, so the handler runs inline on the parse thread and the gate does move with
-    /// the mark. It only defers when a previous event is still awaiting - a history append or an
-    /// exit-code patch - and then the whole handler lands on a thread-pool thread afterwards. That
-    /// is why this reproduced as a rare CI flake
-    /// (<c>PaneRemoteShellIntegrationTests.OnAnSshPaneEmittingABareC_EveryCommandIsStillCaptured</c>,
-    /// once in ~150 runs) rather than as a broken feature: it needs a busy dispatcher.
-    /// </para>
-    /// <para>
-    /// <b>Why the caller passes <c>applyLifecycle: false</c> rather than this being additive.</b>
-    /// Leaving the async handler to move the gate as well would let a lagging replay clobber the
-    /// fresher answer: B and C applied here in order leaves the gate closed, and the dispatcher
-    /// then catching up on B would reopen it while the command is actually running - which is the
-    /// precise failure <see cref="AssistSessionContext.IsAcceptingCommandInput"/> exists to
-    /// prevent. Exactly one of the two paths owns each event.
-    /// </para>
-    /// <para>
-    /// Safe off the UI thread: the flag is a <c>volatile bool</c> on the context, and nothing here
-    /// touches the state machine, the view-model or the pipeline.
-    /// </para>
-    /// </remarks>
-    public void ApplyShellIntegrationLifecycle(ShellIntegrationEvent shellEvent)
-    {
-        switch (shellEvent.Type)
-        {
-            case ShellIntegrationEventType.CommandStarted:
-                _context.OpenCommandInputWindow();
-                break;
-            case ShellIntegrationEventType.CommandAccepted:
-            case ShellIntegrationEventType.CommandFinished:
-                _context.CloseCommandInputWindow();
-                break;
-        }
     }
 
     public async Task<bool> TogglePinSelectionAsync()

--- a/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
+++ b/src/NovaTerminal.CommandAssist/Application/CommandAssistController.cs
@@ -1100,24 +1100,81 @@ public sealed class CommandAssistController : IDisposable
     /// dispatcher, which is not the UI thread, and the view-model is bound.
     /// </para>
     /// </remarks>
-    public async Task HandleShellIntegrationEventAsync(ShellIntegrationEvent shellEvent)
+    public async Task HandleShellIntegrationEventAsync(
+        ShellIntegrationEvent shellEvent,
+        bool applyLifecycle = true)
+    {
+        // Only when the caller could not do it synchronously - see ApplyShellIntegrationLifecycle
+        // for why applying it in both places would be worse than applying it late.
+        if (applyLifecycle)
+        {
+            ApplyShellIntegrationLifecycle(shellEvent);
+        }
+
+        switch (shellEvent.Type)
+        {
+            case ShellIntegrationEventType.CommandStarted:
+                _state.BeginCommandLine();
+                break;
+            case ShellIntegrationEventType.CommandAccepted:
+                DispatchSurfaceWrite(ResetSubmissionState);
+                break;
+        }
+
+        await _capturePipeline.HandleShellIntegrationEventAsync(shellEvent);
+    }
+
+    /// <summary>
+    /// The command-input lifecycle gate alone, applied synchronously: <c>B</c> opens the window,
+    /// <c>C</c> and <c>D</c> close it.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Split out of <see cref="HandleShellIntegrationEventAsync"/> so the host can apply it on the
+    /// thread the bytes arrived on, ahead of the dispatcher hop. The gate is one half of a pair, and
+    /// the other half is the <c>OSC 133;B</c> mark the parser writes into the buffer synchronously.
+    /// Enter reads both at once - <c>TerminalPane.OnCommandAssistEnterObserved</c>, on the UI thread
+    /// - and refuses grid truth unless they agree, so a gate that moves on a different schedule from
+    /// the mark is a window in which a submitted command is discarded outright: no grid snapshot,
+    /// the markless accumulator empty because the shell echoed the line rather than the user typing
+    /// it, and nothing persisted. Silent and permanent, and only for the command whose prompt lost
+    /// the race.
+    /// </para>
+    /// <para>
+    /// <c>OrderedAsyncEventDispatcher</c> hides how narrow that window is. Its semaphore is
+    /// uncontended almost always, and <c>SemaphoreSlim.WaitAsync</c> then returns an already
+    /// completed task, so the handler runs inline on the parse thread and the gate does move with
+    /// the mark. It only defers when a previous event is still awaiting - a history append or an
+    /// exit-code patch - and then the whole handler lands on a thread-pool thread afterwards. That
+    /// is why this reproduced as a rare CI flake
+    /// (<c>PaneRemoteShellIntegrationTests.OnAnSshPaneEmittingABareC_EveryCommandIsStillCaptured</c>,
+    /// once in ~150 runs) rather than as a broken feature: it needs a busy dispatcher.
+    /// </para>
+    /// <para>
+    /// <b>Why the caller passes <c>applyLifecycle: false</c> rather than this being additive.</b>
+    /// Leaving the async handler to move the gate as well would let a lagging replay clobber the
+    /// fresher answer: B and C applied here in order leaves the gate closed, and the dispatcher
+    /// then catching up on B would reopen it while the command is actually running - which is the
+    /// precise failure <see cref="AssistSessionContext.IsAcceptingCommandInput"/> exists to
+    /// prevent. Exactly one of the two paths owns each event.
+    /// </para>
+    /// <para>
+    /// Safe off the UI thread: the flag is a <c>volatile bool</c> on the context, and nothing here
+    /// touches the state machine, the view-model or the pipeline.
+    /// </para>
+    /// </remarks>
+    public void ApplyShellIntegrationLifecycle(ShellIntegrationEvent shellEvent)
     {
         switch (shellEvent.Type)
         {
             case ShellIntegrationEventType.CommandStarted:
                 _context.OpenCommandInputWindow();
-                _state.BeginCommandLine();
                 break;
             case ShellIntegrationEventType.CommandAccepted:
-                _context.CloseCommandInputWindow();
-                DispatchSurfaceWrite(ResetSubmissionState);
-                break;
             case ShellIntegrationEventType.CommandFinished:
                 _context.CloseCommandInputWindow();
                 break;
         }
-
-        await _capturePipeline.HandleShellIntegrationEventAsync(shellEvent);
     }
 
     public async Task<bool> TogglePinSelectionAsync()

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -2295,13 +2295,16 @@ namespace NovaTerminal.VT
                 }
                 else if (string.Equals(marker, "B", StringComparison.Ordinal))
                 {
-                    // The command-input window and the mark are one fact in two parts, so they move
-                    // together, here, before any subscriber runs. Splitting them is what #448 cost:
-                    // the mark was written by the parser while the gate was written a queue hop
-                    // later, and a consumer reading both at once got a fresh mark with a stale gate,
-                    // refused the grid read, and dropped a submitted command from history.
-                    _buffer.OpenCommandInputWindow();
-                    OnCommandStarted?.Invoke(CaptureCursorMark());
+                    // The command-input window and the mark are one fact in two parts, so they are
+                    // published together, here, under the buffer's tracked-mark lock and before any
+                    // subscriber runs. Splitting them is what #448 cost twice over: first the window
+                    // lagged the mark by a queue hop and a submitted command was dropped from
+                    // history; then, with the window moved here but the mark still written by a
+                    // subscriber, the window briefly pointed at the *previous* command's mark - which
+                    // fabricates a capture rather than losing one.
+                    ShellIntegrationMark mark = CaptureCursorMark();
+                    _buffer.BeginCommandInput(mark);
+                    OnCommandStarted?.Invoke(mark);
                 }
                 else if (string.Equals(marker, "C", StringComparison.Ordinal))
                 {

--- a/src/NovaTerminal.VT/AnsiParser.cs
+++ b/src/NovaTerminal.VT/AnsiParser.cs
@@ -2295,10 +2295,21 @@ namespace NovaTerminal.VT
                 }
                 else if (string.Equals(marker, "B", StringComparison.Ordinal))
                 {
+                    // The command-input window and the mark are one fact in two parts, so they move
+                    // together, here, before any subscriber runs. Splitting them is what #448 cost:
+                    // the mark was written by the parser while the gate was written a queue hop
+                    // later, and a consumer reading both at once got a fresh mark with a stale gate,
+                    // refused the grid read, and dropped a submitted command from history.
+                    _buffer.OpenCommandInputWindow();
                     OnCommandStarted?.Invoke(CaptureCursorMark());
                 }
                 else if (string.Equals(marker, "C", StringComparison.Ordinal))
                 {
+                    // The line has been submitted. The mark deliberately survives C - the input line
+                    // is still on screen at this instant - so closing the window is the only thing
+                    // that stops the cells below it being served as a command line once the output
+                    // starts arriving.
+                    _buffer.CloseCommandInputWindow();
                     OnCommandAccepted?.Invoke(DecodeAcceptedCommandPayload(parts));
                 }
                 else if (string.Equals(marker, "D", StringComparison.Ordinal))
@@ -2316,6 +2327,11 @@ namespace NovaTerminal.VT
                     {
                         durationMs = parsedDuration;
                     }
+
+                    // Closed at D as well as C: a shell can reach D with no intervening C, and
+                    // leaving the window open for a command's whole run is the failure it exists to
+                    // prevent.
+                    _buffer.CloseCommandInputWindow();
 
                     OnCommandFinished?.Invoke(exitCode);
                     OnCommandFinishedDetailed?.Invoke(exitCode, durationMs);

--- a/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.AccessAndSnapshot.cs
@@ -673,6 +673,16 @@ namespace NovaTerminal.VT
                 }
 
                 _isAltScreen = true;
+
+                // The prompt that emitted 133;B is not on the screen the user is looking at any
+                // more, so the command-input window closes on the way in. It does NOT reopen on the
+                // way out: the shell repaints its prompt when the alt screen is torn down and that
+                // repaint re-emits B, so the gate reopens on evidence rather than on assumption.
+                lock (_trackedMarkGate)
+                {
+                    _isAcceptingCommandInput = false;
+                }
+
                 _viewport = _altScreen;    // Switch to alt screen
 
                 // Kitty keyboard protocol: main and alternate screens own independent

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -217,24 +217,39 @@ namespace NovaTerminal.VT
             get { lock (_trackedMarkGate) { return _isAcceptingCommandInput; } }
         }
 
-        /// <summary><c>OSC 133;B</c>: the prompt finished printing and the line editor is the user's.</summary>
+        /// <summary>
+        /// <c>OSC 133;B</c>: the prompt finished printing and the line editor is the user's. Publishes
+        /// the new mark and opens the window as one step.
+        /// </summary>
         /// <remarks>
-        /// Refused while the alt screen is up, so the invariant "the gate is never open during an
-        /// alt screen" holds whichever order the two facts arrive in: a full-screen TUI drawing its
-        /// own prompt may legally emit <c>133;B</c>, and that must not open a window onto the TUI's
-        /// grid. Re-opening an already-open gate is idempotent by design - prompt frameworks repaint
+        /// <para>
+        /// One step, under one lock, because the pair has to become visible together (Codex P2 on
+        /// #448). A <c>B</c> that follows <c>C</c> with no intervening <c>D</c> arrives while the
+        /// previous command's mark is still live - deliberately, since the mark survives <c>C</c> -
+        /// so opening the window first and replacing the mark afterwards leaves an instant where a
+        /// reader sees an open window pointing at the <em>previous</em> command's mark. That does not
+        /// lose a capture, it fabricates one: the text read back is the last command's line or its
+        /// output, recorded as the command the user just submitted. Recording no command is
+        /// recoverable; recording a command the user never ran is not.
+        /// </para>
+        /// <para>
+        /// The mark is published even on the alt screen - consumers refuse it on other grounds and it
+        /// is what the reflow re-anchors - but the window is not: a full-screen TUI drawing its own
+        /// prompt may legally emit <c>133;B</c>, and that must not open a window onto the TUI's grid.
+        /// Re-opening an already-open window is idempotent by design, since prompt frameworks repaint
         /// constantly and every repaint carries the mark.
+        /// </para>
         /// </remarks>
-        public void OpenCommandInputWindow()
+        public void BeginCommandInput(ShellIntegrationMark mark)
         {
             lock (_trackedMarkGate)
             {
-                if (_isAltScreen)
-                {
-                    return;
-                }
+                _commandStartMark = mark;
 
-                _isAcceptingCommandInput = true;
+                if (!_isAltScreen)
+                {
+                    _isAcceptingCommandInput = true;
+                }
             }
         }
 

--- a/src/NovaTerminal.VT/TerminalBuffer.cs
+++ b/src/NovaTerminal.VT/TerminalBuffer.cs
@@ -156,6 +156,7 @@ namespace NovaTerminal.VT
         private readonly object _trackedMarkGate = new();
         private ShellIntegrationMark? _commandStartMark;
         private ShellIntegrationMark? _commandOutputStartMark;
+        private bool _isAcceptingCommandInput;
 
         /// <summary>
         /// The newest <c>OSC 133;B</c> mark (prompt end / start of the user's input), or
@@ -181,13 +182,85 @@ namespace NovaTerminal.VT
             set { lock (_trackedMarkGate) { _commandOutputStartMark = value; } }
         }
 
-        /// <summary>Drops both tracked marks. Used when a session is replaced.</summary>
+        /// <summary>
+        /// Whether the shell is sitting in its line editor waiting for the user: opened by
+        /// <c>OSC 133;B</c>, closed by <c>OSC 133;C</c>, <c>OSC 133;D</c>, an alt-screen switch, or
+        /// a session replacement.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the other half of <see cref="CommandStartMark"/>, and it lives here for the same
+        /// reason. Whether the cells between the mark and the cursor are a command line the user is
+        /// editing or the output of a command that already ran is a fact about the shell's
+        /// lifecycle, carried only by the OSC 133 stream - so both halves are facts about this
+        /// session's byte stream, and a consumer that reads one without the other gets an answer it
+        /// cannot trust.
+        /// </para>
+        /// <para>
+        /// It used to live on Command Assist's <c>AssistSessionContext</c>, written after a hop onto
+        /// the pane's serialized event dispatcher while the mark was written synchronously by the
+        /// parser. Under a busy dispatcher the two disagreed - a fresh mark, a stale-closed gate -
+        /// and a submitted command was dropped from history outright, silently and permanently
+        /// (#448). Here the parser applies both in the same statement block, so no queue can reorder
+        /// them and no consumer can be handed half of the answer.
+        /// </para>
+        /// <para>
+        /// Not a coordinate, so unlike the marks it needs no reflow re-anchoring: a resize that
+        /// cannot re-place the mark leaves this alone, and the consumer's "no mark" answer is what
+        /// refuses the read. Guarded by <see cref="_trackedMarkGate"/> rather than
+        /// <see cref="Lock"/> for the same reason the marks are - the UI thread reads it on every
+        /// Enter and must not queue behind a parse.
+        /// </para>
+        /// </remarks>
+        public bool IsAcceptingCommandInput
+        {
+            get { lock (_trackedMarkGate) { return _isAcceptingCommandInput; } }
+        }
+
+        /// <summary><c>OSC 133;B</c>: the prompt finished printing and the line editor is the user's.</summary>
+        /// <remarks>
+        /// Refused while the alt screen is up, so the invariant "the gate is never open during an
+        /// alt screen" holds whichever order the two facts arrive in: a full-screen TUI drawing its
+        /// own prompt may legally emit <c>133;B</c>, and that must not open a window onto the TUI's
+        /// grid. Re-opening an already-open gate is idempotent by design - prompt frameworks repaint
+        /// constantly and every repaint carries the mark.
+        /// </remarks>
+        public void OpenCommandInputWindow()
+        {
+            lock (_trackedMarkGate)
+            {
+                if (_isAltScreen)
+                {
+                    return;
+                }
+
+                _isAcceptingCommandInput = true;
+            }
+        }
+
+        /// <summary><c>OSC 133;C</c> / <c>OSC 133;D</c>: the line editor is closed.</summary>
+        /// <remarks>
+        /// <c>D</c> closes it as well as <c>C</c> because a shell can reach <c>D</c> with no
+        /// intervening <c>C</c>, and leaving the gate open for a command's whole run is exactly the
+        /// failure it exists to prevent.
+        /// </remarks>
+        public void CloseCommandInputWindow()
+        {
+            lock (_trackedMarkGate)
+            {
+                _isAcceptingCommandInput = false;
+            }
+        }
+
+        /// <summary>Drops both tracked marks and closes the command-input window. Used when a
+        /// session is replaced.</summary>
         public void ClearTrackedShellMarks()
         {
             lock (_trackedMarkGate)
             {
                 _commandStartMark = null;
                 _commandOutputStartMark = null;
+                _isAcceptingCommandInput = false;
             }
         }
 

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistControllerTests.cs
@@ -1987,6 +1987,7 @@ public sealed class CommandAssistControllerTests
             modeRouter: null,
             resultBuilder: null,
             queryProvider: grid == null ? null : grid.Read,
+            commandInputGateProbe: grid == null ? null : () => grid.IsAcceptingCommandInput,
             renderedSurfaceProbe: renderedSurfaceProbe);
 
         if (grid != null)
@@ -2016,6 +2017,7 @@ public sealed class CommandAssistControllerTests
         // worker thread, not from the thread that set the line.
         private readonly object _gate = new();
         private AssistQuerySnapshot? _snapshot;
+        private bool _acceptingCommandInput;
 
         public AssistQuerySnapshot? Read()
         {
@@ -2023,6 +2025,15 @@ public sealed class CommandAssistControllerTests
             {
                 return _snapshot;
             }
+        }
+
+        /// <summary>
+        /// The command-input gate, which the terminal owns alongside the mark since #448 - so this
+        /// stand-in owns both halves rather than leaving one to the controller.
+        /// </summary>
+        public bool IsAcceptingCommandInput
+        {
+            get { lock (_gate) { return _acceptingCommandInput; } }
         }
 
         public void SetLine(
@@ -2047,9 +2058,20 @@ public sealed class CommandAssistControllerTests
         }
 
         /// <summary><c>OSC 133;B</c> - the prompt finished printing and the line editor is live.</summary>
+        /// <remarks>
+        /// Both halves, in production's order (#448): the gate moves on the terminal first and
+        /// synchronously, beside the mark write on the parse thread, and only then does the event
+        /// reach the controller, which still owns the work that belongs on the pane's serialized
+        /// dispatcher. The controller is no longer a writer of the gate.
+        /// </remarks>
         public void OpenPrompt(CommandAssistController controller)
         {
             SetLine(string.Empty);
+            lock (_gate)
+            {
+                _acceptingCommandInput = true;
+            }
+
             controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
                 Type: ShellIntegrationEventType.CommandStarted,
                 Timestamp: DateTimeOffset.UtcNow,

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -112,50 +112,44 @@ public sealed class CommandAssistGridTruthTests
     /// command is dropped silently and permanently.
     /// </para>
     /// <para>
-    /// The pane now applies the lifecycle half on the thread the bytes arrived on, so the two halves
-    /// move together no matter how far behind the event dispatcher is.
-    /// <c>OrderedAsyncEventDispatcher</c> hid this for a long time: its semaphore is uncontended
-    /// almost always, <c>WaitAsync</c> then returns an already-completed task, and the handler runs
-    /// inline on the parse thread anyway. It only defers when a previous event is mid-await in the
-    /// history store, which is why
-    /// <c>PaneRemoteShellIntegrationTests.OnAnSshPaneEmittingABareC_EveryCommandIsStillCaptured</c>
-    /// failed roughly once in 150 CI runs and never locally until the machine was fully saturated.
+    /// Both halves now live on <c>TerminalBuffer</c> and are written by the parser on the thread the
+    /// bytes arrive on, so no amount of dispatcher backlog can put them out of step. Here that is
+    /// the terminal opening the window with no controller event emitted at all.
     /// </para>
     /// </remarks>
     [Fact]
-    public void TheLifecycleGateOpensWithoutTheAsyncHalfOfTheEventHavingRun()
+    public void TheGateOpensWithoutAnyOfTheAsyncEventPathHavingRun()
     {
         var harness = Harness.Create();
 
-        harness.Controller.ApplyShellIntegrationLifecycle(Mark(ShellIntegrationEventType.CommandStarted));
+        harness.Grid.OpenCommandInputWindow();
         harness.Grid.SetLine("hostname");
 
         Assert.Equal("hostname", harness.Controller.TryReadQuerySnapshot()?.Text);
     }
 
     /// <summary>
-    /// The cost of moving the gate off the dispatcher: a lagging replay must not undo it.
+    /// A shell-integration event arriving late cannot move the gate, in either direction.
     /// </summary>
     /// <remarks>
-    /// Exactly one of the two paths owns each event, which is what <c>applyLifecycle: false</c> is
-    /// for. Were the async handler to keep moving the gate as well, this sequence would reopen the
-    /// window while the command is actually running - the dispatcher catching up on <c>B</c> after
-    /// <c>C</c> has already been applied - and output would be served as a command line, which is
-    /// the one thing <c>AssistSessionContext.IsAcceptingCommandInput</c> exists to prevent.
+    /// The whole point of moving the gate onto the buffer. While the controller owned it, an event
+    /// replayed off the pane's serialized dispatcher could contradict the terminal's own newer
+    /// answer - reopening a window onto a running command's output, which is the one thing the gate
+    /// exists to prevent. The controller is no longer a writer, so a backlogged event is now inert
+    /// with respect to the gate and only the terminal's account of the byte stream counts.
     /// </remarks>
     [Fact]
-    public async Task ALaggingReplayOfAnOlderMark_DoesNotReopenTheGate()
+    public async Task ALateShellIntegrationEvent_CannotMoveTheGate()
     {
         var harness = Harness.Create();
 
-        harness.Controller.ApplyShellIntegrationLifecycle(Mark(ShellIntegrationEventType.CommandStarted));
-        harness.Controller.ApplyShellIntegrationLifecycle(Mark(ShellIntegrationEventType.CommandAccepted));
+        harness.Grid.OpenCommandInputWindow();
+        harness.Grid.CloseCommandInputWindow();
         harness.Grid.SetLine("on branch main");
 
-        // The dispatcher finally gets to the B whose lifecycle was applied synchronously above.
+        // The dispatcher finally gets to the B the terminal has long since superseded.
         await harness.Controller.HandleShellIntegrationEventAsync(
-            Mark(ShellIntegrationEventType.CommandStarted),
-            applyLifecycle: false);
+            Mark(ShellIntegrationEventType.CommandStarted));
 
         Assert.Null(harness.Controller.TryReadQuerySnapshot());
     }
@@ -265,7 +259,7 @@ public sealed class CommandAssistGridTruthTests
     public async Task WhileTheAltScreenIsUp_APromptMarkDoesNotOpenTheGate()
     {
         var harness = Harness.Create();
-        harness.Controller.HandleAltScreenChanged(true);
+        harness.SetAltScreen(true);
 
         await harness.PromptReadyAsync();
         harness.Grid.SetLine("git status");
@@ -273,7 +267,7 @@ public sealed class CommandAssistGridTruthTests
         Assert.Null(harness.Controller.TryReadQuerySnapshot());
 
         // Leaving the alt screen does not reopen it either: the shell's own prompt repaint does.
-        harness.Controller.HandleAltScreenChanged(false);
+        harness.SetAltScreen(false);
 
         Assert.Null(harness.Controller.TryReadQuerySnapshot());
     }
@@ -655,6 +649,7 @@ public sealed class CommandAssistGridTruthTests
                 modeRouter: null,
                 resultBuilder: null,
                 queryProvider: grid == null ? null : grid.Read,
+                commandInputGateProbe: grid == null ? null : () => grid.IsAcceptingCommandInput,
 
                 // The pane's dispatcher, modelled rather than omitted - and that is what makes the
                 // reads below safe. See TestDispatcher.
@@ -663,13 +658,41 @@ public sealed class CommandAssistGridTruthTests
             return new Harness(controller, grid ?? new FakeGrid(), history, dispatcher);
         }
 
-        public Task PromptReadyAsync() => EmitAsync(ShellIntegrationEventType.CommandStarted, null, null);
+        /// <remarks>
+        /// The gate moves first and synchronously, then the event goes to the controller - the exact
+        /// order the production path has since #448: TerminalPane's parser callback opens the window
+        /// on the buffer beside the mark write, and only then enqueues the event onto the pane's
+        /// serialized dispatcher. A harness that moved the gate via the controller would be testing
+        /// a seam that no longer exists.
+        /// </remarks>
+        public Task PromptReadyAsync()
+        {
+            Grid.OpenCommandInputWindow();
+            return EmitAsync(ShellIntegrationEventType.CommandStarted, null, null);
+        }
 
         public Task CommandAcceptedAsync(string commandText)
-            => EmitAsync(ShellIntegrationEventType.CommandAccepted, commandText, null);
+        {
+            Grid.CloseCommandInputWindow();
+            return EmitAsync(ShellIntegrationEventType.CommandAccepted, commandText, null);
+        }
 
         public Task CommandFinishedAsync(int exitCode)
-            => EmitAsync(ShellIntegrationEventType.CommandFinished, null, exitCode);
+        {
+            Grid.CloseCommandInputWindow();
+            return EmitAsync(ShellIntegrationEventType.CommandFinished, null, exitCode);
+        }
+
+        /// <summary>An alt-screen switch, moved on the terminal and reported to the controller.</summary>
+        /// <remarks>
+        /// Both, because they are two different facts now: the buffer owns the gate, while the
+        /// context keeps <c>IsAltScreenActive</c> for the consumers that check it separately.
+        /// </remarks>
+        public void SetAltScreen(bool isActive)
+        {
+            Grid.SetAltScreenActive(isActive);
+            Controller.HandleAltScreenChanged(isActive);
+        }
 
         private async Task EmitAsync(ShellIntegrationEventType type, string? commandText, int? exitCode)
         {
@@ -784,10 +807,19 @@ public sealed class CommandAssistGridTruthTests
     /// The provider seam's stand-in. Locked rather than volatile because the real provider is read
     /// from the refresh pass's worker thread, not from the thread that set the line.
     /// </summary>
+    /// <summary>
+    /// Stands in for the terminal: both halves of the OSC 133 pair, because that is where they live
+    /// now. <c>TerminalBuffer</c> owns the <c>133;B</c> mark the line is read from <em>and</em> the
+    /// command-input gate that says the read is legal (#448); a harness that owned one and let the
+    /// controller own the other would be modelling a split that no longer exists, and would keep
+    /// passing if the two came apart again.
+    /// </summary>
     private sealed class FakeGrid
     {
         private readonly object _gate = new();
         private AssistQuerySnapshot? _snapshot;
+        private bool _acceptingCommandInput;
+        private bool _altScreenActive;
 
         public AssistQuerySnapshot? Read()
         {
@@ -795,6 +827,50 @@ public sealed class CommandAssistGridTruthTests
             {
                 return _snapshot;
             }
+        }
+
+        /// <summary>The probe the controller reads, as <c>TerminalBuffer.IsAcceptingCommandInput</c>.</summary>
+        public bool IsAcceptingCommandInput
+        {
+            get { lock (_gate) { return _acceptingCommandInput; } }
+        }
+
+        /// <summary><c>OSC 133;B</c>, as the parser applies it to the buffer.</summary>
+        /// <remarks>
+        /// Refused on the alt screen, mirroring <c>TerminalBuffer.OpenCommandInputWindow</c>: a
+        /// full-screen TUI may legally draw its own prompt and emit <c>133;B</c>, and that must not
+        /// open a window onto the TUI's grid.
+        /// </remarks>
+        public void OpenCommandInputWindow()
+        {
+            lock (_gate)
+            {
+                if (_altScreenActive)
+                {
+                    return;
+                }
+
+                _acceptingCommandInput = true;
+            }
+        }
+
+        /// <summary>Entering the alt screen closes the window; leaving does not reopen it.</summary>
+        public void SetAltScreenActive(bool isActive)
+        {
+            lock (_gate)
+            {
+                _altScreenActive = isActive;
+                if (isActive)
+                {
+                    _acceptingCommandInput = false;
+                }
+            }
+        }
+
+        /// <summary><c>OSC 133;C</c> / <c>D</c>, likewise.</summary>
+        public void CloseCommandInputWindow()
+        {
+            lock (_gate) { _acceptingCommandInput = false; }
         }
 
         public void SetLine(string text, int? cursorOffset = null)

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistGridTruthTests.cs
@@ -100,6 +100,75 @@ public sealed class CommandAssistGridTruthTests
     }
 
     /// <summary>
+    /// The gate opens on the <c>B</c> itself, with none of the event's asynchronous half having run.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is what a lost history entry on CI came down to. The gate is one half of a pair - the
+    /// other is the <c>OSC 133;B</c> mark the parser writes into the buffer synchronously - and
+    /// <c>TerminalPane.OnCommandAssistEnterObserved</c> reads both at once on the UI thread. When
+    /// they disagree it refuses grid truth, falls through to the markless accumulator (empty,
+    /// because the shell echoed the line rather than the user typing it), and persists nothing. The
+    /// command is dropped silently and permanently.
+    /// </para>
+    /// <para>
+    /// The pane now applies the lifecycle half on the thread the bytes arrived on, so the two halves
+    /// move together no matter how far behind the event dispatcher is.
+    /// <c>OrderedAsyncEventDispatcher</c> hid this for a long time: its semaphore is uncontended
+    /// almost always, <c>WaitAsync</c> then returns an already-completed task, and the handler runs
+    /// inline on the parse thread anyway. It only defers when a previous event is mid-await in the
+    /// history store, which is why
+    /// <c>PaneRemoteShellIntegrationTests.OnAnSshPaneEmittingABareC_EveryCommandIsStillCaptured</c>
+    /// failed roughly once in 150 CI runs and never locally until the machine was fully saturated.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TheLifecycleGateOpensWithoutTheAsyncHalfOfTheEventHavingRun()
+    {
+        var harness = Harness.Create();
+
+        harness.Controller.ApplyShellIntegrationLifecycle(Mark(ShellIntegrationEventType.CommandStarted));
+        harness.Grid.SetLine("hostname");
+
+        Assert.Equal("hostname", harness.Controller.TryReadQuerySnapshot()?.Text);
+    }
+
+    /// <summary>
+    /// The cost of moving the gate off the dispatcher: a lagging replay must not undo it.
+    /// </summary>
+    /// <remarks>
+    /// Exactly one of the two paths owns each event, which is what <c>applyLifecycle: false</c> is
+    /// for. Were the async handler to keep moving the gate as well, this sequence would reopen the
+    /// window while the command is actually running - the dispatcher catching up on <c>B</c> after
+    /// <c>C</c> has already been applied - and output would be served as a command line, which is
+    /// the one thing <c>AssistSessionContext.IsAcceptingCommandInput</c> exists to prevent.
+    /// </remarks>
+    [Fact]
+    public async Task ALaggingReplayOfAnOlderMark_DoesNotReopenTheGate()
+    {
+        var harness = Harness.Create();
+
+        harness.Controller.ApplyShellIntegrationLifecycle(Mark(ShellIntegrationEventType.CommandStarted));
+        harness.Controller.ApplyShellIntegrationLifecycle(Mark(ShellIntegrationEventType.CommandAccepted));
+        harness.Grid.SetLine("on branch main");
+
+        // The dispatcher finally gets to the B whose lifecycle was applied synchronously above.
+        await harness.Controller.HandleShellIntegrationEventAsync(
+            Mark(ShellIntegrationEventType.CommandStarted),
+            applyLifecycle: false);
+
+        Assert.Null(harness.Controller.TryReadQuerySnapshot());
+    }
+
+    private static ShellIntegrationEvent Mark(ShellIntegrationEventType type) => new(
+        Type: type,
+        Timestamp: DateTimeOffset.UtcNow,
+        CommandText: null,
+        WorkingDirectory: null,
+        ExitCode: null,
+        Duration: null);
+
+    /// <summary>
     /// A prompt repaint re-emits <c>B</c>, so the window reopens on evidence. This is the path back
     /// from every closer: next command, alt screen teardown, resize.
     /// </summary>

--- a/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/CommandAssistPassiveBubbleTests.cs
@@ -1061,6 +1061,7 @@ public sealed class CommandAssistPassiveBubbleTests
             modeRouter: null,
             resultBuilder: null,
             queryProvider: queryProvider ?? grid.Read,
+            commandInputGateProbe: () => grid.IsAcceptingCommandInput,
             renderedSurfaceProbe: null,
             dispatch: dispatch,
             passiveRefreshDebounce: debounce ?? (delay == null ? TimeSpan.Zero : CommandAssistController_DefaultDebounce),
@@ -1158,6 +1159,7 @@ public sealed class CommandAssistPassiveBubbleTests
     {
         private readonly object _gate = new();
         private AssistQuerySnapshot? _snapshot;
+        private bool _acceptingCommandInput;
 
         public AssistQuerySnapshot? Read()
         {
@@ -1165,6 +1167,15 @@ public sealed class CommandAssistPassiveBubbleTests
             {
                 return _snapshot;
             }
+        }
+
+        /// <summary>
+        /// The command-input gate. The terminal owns it alongside the mark since #448, so this
+        /// stand-in owns both halves instead of leaving one to the controller.
+        /// </summary>
+        public bool IsAcceptingCommandInput
+        {
+            get { lock (_gate) { return _acceptingCommandInput; } }
         }
 
         /// <summary>
@@ -1190,9 +1201,22 @@ public sealed class CommandAssistPassiveBubbleTests
         }
 
         /// <summary><c>OSC 133;B</c>: the prompt is printed and the line editor is the user's.</summary>
+        /// <summary><c>OSC 133;B</c> - the prompt finished printing and the line editor is live.</summary>
+        /// <remarks>
+        /// Both halves, in production's order (#448): the gate moves on the terminal first and
+        /// synchronously - TerminalPane's parser callback opens it on the buffer beside the mark
+        /// write - and only then does the event reach the controller, which still owns what belongs
+        /// on the pane's serialized dispatcher (here, the <c>BeginCommandLine</c> that ends per-command
+        /// Escape suppression).
+        /// </remarks>
         public void OpenPrompt(CommandAssistController controller)
         {
             SetLine(string.Empty);
+            lock (_gate)
+            {
+                _acceptingCommandInput = true;
+            }
+
             controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
                 Type: ShellIntegrationEventType.CommandStarted,
                 Timestamp: DateTimeOffset.UtcNow,

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -30,24 +30,30 @@ public sealed class TerminalViewKeyHandlingTests
     }
 
     /// <summary>
-    /// Enter's observers run before the carriage return reaches the PTY.
+    /// Enter is two phases either side of the carriage return, and the sequence is the contract.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Codex P1 on #448. <c>TerminalPane.OnCommandAssistEnterObserved</c> reads the command line out
-    /// of the grid from inside <c>EnterObserved</c>, and that read is only truthful while the line is
-    /// still on screen. Sending the CR first handed the shell the chance to answer before the read -
-    /// repainting over the line, or, once the OSC 133 lifecycle gate began being applied
-    /// synchronously on the parse thread, closing the gate with a bare <c>133;C</c> and making the
-    /// capture refuse outright. Either way the command vanishes from history with nothing logged.
+    /// Codex P1 and P2 on #448. <c>EnterObserving</c> is where the pane reads the command line out
+    /// of the grid, and that read is only truthful while the line is still on screen - sending the
+    /// CR first handed the shell the chance to repaint over it, or, once the OSC 133 command-input
+    /// window began closing synchronously on the parse thread, to shut the window with a bare
+    /// <c>133;C</c> and make the read refuse outright. Either way the command vanishes from history
+    /// with nothing logged.
     /// </para>
     /// <para>
-    /// Ordering, not timing: the assertion is on the sequence the two calls actually happened in, so
-    /// there is nothing here for a loaded machine to change its mind about.
+    /// <c>EnterObserved</c> is where persistence starts, and it has to be on the far side:
+    /// <c>JsonlHistoryStore.AppendAsync</c> does redaction, migration checks, directory creation and
+    /// a file open synchronously before its first incomplete await, and slow storage has no business
+    /// sitting between a keypress and the shell.
+    /// </para>
+    /// <para>
+    /// Ordering, not timing: the assertion is on the sequence the three calls actually happened in,
+    /// so there is nothing here for a loaded machine to change its mind about.
     /// </para>
     /// </remarks>
     [AvaloniaFact]
-    public void HandleKeyDownCore_OnEnter_RaisesEnterObservedBeforeTheCarriageReturnReachesTheSession()
+    public void HandleKeyDownCore_OnEnter_ReadsTheGridBeforeTheCarriageReturnAndPersistsAfterIt()
     {
         var order = new List<string>();
         var session = new Mock<ITerminalSession>();
@@ -56,30 +62,31 @@ public sealed class TerminalViewKeyHandlingTests
 
         var view = new TerminalView();
         view.SetSession(session.Object);
-        view.EnterObserved += () => order.Add("enter-observed");
+        view.EnterObserving += () => order.Add("grid-read");
+        view.EnterObserved += () => order.Add("persist");
 
         Assert.True(view.HandleKeyDownCore(Key.Enter, KeyModifiers.None));
 
-        Assert.Equal(new[] { "enter-observed", "carriage-return" }, order);
+        Assert.Equal(new[] { "grid-read", "carriage-return", "persist" }, order);
     }
 
     /// <summary>
-    /// A throwing observer must not swallow the user's Enter.
+    /// A throwing pre-CR observer must not swallow the user's Enter.
     /// </summary>
     /// <remarks>
-    /// The cost of running observers first: an exception in one of them now sits between the keypress
-    /// and the shell. The CR goes out from a <c>finally</c>, so the keystroke lands either way and the
-    /// exception still propagates behind it rather than being quietly eaten.
+    /// The cost of reading before the CR: an exception in that phase now sits between the keypress
+    /// and the shell. The CR goes out from a <c>finally</c>, so the keystroke lands either way and
+    /// the exception still propagates behind it rather than being quietly eaten.
     /// </remarks>
     [AvaloniaFact]
-    public void HandleKeyDownCore_OnEnter_StillSendsTheCarriageReturnWhenAnObserverThrows()
+    public void HandleKeyDownCore_OnEnter_StillSendsTheCarriageReturnWhenThePreSendObserverThrows()
     {
         var session = new Mock<ITerminalSession>();
         session.SetupGet(x => x.IsProcessRunning).Returns(true);
 
         var view = new TerminalView();
         view.SetSession(session.Object);
-        view.EnterObserved += () => throw new InvalidOperationException("an observer failed");
+        view.EnterObserving += () => throw new InvalidOperationException("an observer failed");
 
         Assert.Throws<InvalidOperationException>(
             () => view.HandleKeyDownCore(Key.Enter, KeyModifiers.None));

--- a/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
+++ b/tests/NovaTerminal.App.Tests/CommandAssist/TerminalViewKeyHandlingTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System;
 using NovaTerminal.Shell;
 using Avalonia.Controls;
 using Avalonia.Headless;
@@ -25,6 +27,64 @@ public sealed class TerminalViewKeyHandlingTests
         {
             OnLostFocus(new FocusChangedEventArgs(InputElement.LostFocusEvent));
         }
+    }
+
+    /// <summary>
+    /// Enter's observers run before the carriage return reaches the PTY.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Codex P1 on #448. <c>TerminalPane.OnCommandAssistEnterObserved</c> reads the command line out
+    /// of the grid from inside <c>EnterObserved</c>, and that read is only truthful while the line is
+    /// still on screen. Sending the CR first handed the shell the chance to answer before the read -
+    /// repainting over the line, or, once the OSC 133 lifecycle gate began being applied
+    /// synchronously on the parse thread, closing the gate with a bare <c>133;C</c> and making the
+    /// capture refuse outright. Either way the command vanishes from history with nothing logged.
+    /// </para>
+    /// <para>
+    /// Ordering, not timing: the assertion is on the sequence the two calls actually happened in, so
+    /// there is nothing here for a loaded machine to change its mind about.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public void HandleKeyDownCore_OnEnter_RaisesEnterObservedBeforeTheCarriageReturnReachesTheSession()
+    {
+        var order = new List<string>();
+        var session = new Mock<ITerminalSession>();
+        session.SetupGet(x => x.IsProcessRunning).Returns(true);
+        session.Setup(x => x.SendInput("\r")).Callback(() => order.Add("carriage-return"));
+
+        var view = new TerminalView();
+        view.SetSession(session.Object);
+        view.EnterObserved += () => order.Add("enter-observed");
+
+        Assert.True(view.HandleKeyDownCore(Key.Enter, KeyModifiers.None));
+
+        Assert.Equal(new[] { "enter-observed", "carriage-return" }, order);
+    }
+
+    /// <summary>
+    /// A throwing observer must not swallow the user's Enter.
+    /// </summary>
+    /// <remarks>
+    /// The cost of running observers first: an exception in one of them now sits between the keypress
+    /// and the shell. The CR goes out from a <c>finally</c>, so the keystroke lands either way and the
+    /// exception still propagates behind it rather than being quietly eaten.
+    /// </remarks>
+    [AvaloniaFact]
+    public void HandleKeyDownCore_OnEnter_StillSendsTheCarriageReturnWhenAnObserverThrows()
+    {
+        var session = new Mock<ITerminalSession>();
+        session.SetupGet(x => x.IsProcessRunning).Returns(true);
+
+        var view = new TerminalView();
+        view.SetSession(session.Object);
+        view.EnterObserved += () => throw new InvalidOperationException("an observer failed");
+
+        Assert.Throws<InvalidOperationException>(
+            () => view.HandleKeyDownCore(Key.Enter, KeyModifiers.None));
+
+        session.Verify(x => x.SendInput("\r"), Times.Once);
     }
 
     [AvaloniaFact]

--- a/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneMarklessCaptureTests.cs
@@ -600,6 +600,9 @@ public class PaneMarklessCaptureTests
         public void PressEnter()
         {
             PressKey(Key.Enter);
+            // Both phases, in TerminalView's order: the grid read happens before the carriage
+            // return reaches the PTY, the persistence after it (#448).
+            Pane.OnCommandAssistEnterObserving();
             Pane.OnCommandAssistEnterObserved();
         }
 

--- a/tests/NovaTerminal.App.Tests/Controls/PaneRemoteShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneRemoteShellIntegrationTests.cs
@@ -35,6 +35,8 @@ public class PaneRemoteShellIntegrationTests
 {
     private const string PromptStart = "\x1b]133;A\x07";
     private const string PromptEnd = "\x1b]133;B\x07";
+    private const string BareAccept = "\x1b]133;C\x07";
+    private const string Finished = "\x1b]133;D;0;10\x07";
 
     // ---- arming ------------------------------------------------------------------------------
 
@@ -381,6 +383,59 @@ public class PaneRemoteShellIntegrationTests
         Assert.Contains(entries, e => e.CommandText == "whoami");
         Assert.Contains(entries, e => e.CommandText == "hostname");
         Assert.All(entries, e => Assert.Equal(CommandCaptureSource.Heuristic, e.Source));
+    }
+
+    /// <summary>
+    /// The whole parser-to-capture path with no <c>await</c> anywhere: a command submitted in the
+    /// same synchronous burst as the prompt that invited it is still captured.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The production shape is an agent-sent or broadcast command, or a pasted line ending in a
+    /// newline - submissions that arrive microseconds after the prompt paints, which is exactly what
+    /// <c>CommandAssistController.HandleShellIntegrationEventAsync</c> already documents <c>C</c>
+    /// arriving for. Enter reads the <c>133;B</c> mark and the command-input gate together and
+    /// discards the command outright when they disagree, so the gate has to be as current as the
+    /// mark, and the mark is applied by the parser synchronously.
+    /// </para>
+    /// <para>
+    /// <b>Honest about what this does and does not catch.</b> It passed before the gate was moved
+    /// onto the parse thread, because <c>OrderedAsyncEventDispatcher</c>'s semaphore is uncontended
+    /// here: <c>SemaphoreSlim.WaitAsync</c> returns an already-completed task and the handler runs
+    /// inline on the calling thread anyway. The gate only lands late when a previous event is
+    /// mid-<c>await</c> in the history store, and that is not reachable from this side of the seam
+    /// without a store slow enough to be its own flake. So this test pins the end-to-end path;
+    /// <c>CommandAssistGridTruthTests.TheLifecycleGateOpensWithoutTheAsyncHalfOfTheEventHavingRun</c>
+    /// is what actually bites on the defect, and
+    /// <see cref="OnAnSshPaneEmittingABareC_EveryCommandIsStillCaptured"/> is the test that was
+    /// failing on CI.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task WhenEnterIsObservedBeforeTheEventDispatcherDrains_TheCommandIsStillCaptured()
+    {
+        using var fixture = await Fixture.CreateAsync(ConnectionType.SSH);
+        fixture.Pane.ArmRemoteShellIntegrationTracker();
+        fixture.Pane.CreateAndWireParser();
+
+        // Both rounds with no await anywhere, which is what makes this deterministic. An idle
+        // serialized dispatcher runs an enqueued handler inline as far as its first await, so a
+        // lone unsettled prompt would still open the gate in time. What the flake needs is a
+        // dispatcher already busy: round one's D is mid-await inside the history store when round
+        // two's B is enqueued behind it, so the gate is still closed when Enter reads it.
+        fixture.Echo(PromptStart + "user@ubuntu:~$ " + PromptEnd + "whoami");
+        fixture.PressEnter();
+        fixture.Echo(BareAccept);
+        fixture.Echo(Finished);
+
+        fixture.Echo(PromptStart + "user@ubuntu:~$ " + PromptEnd + "hostname");
+        fixture.PressEnter();
+        fixture.Echo(BareAccept);
+        fixture.Echo(Finished);
+
+        IReadOnlyList<CommandHistoryEntry> entries = await fixture.WaitForEntriesAsync(2);
+        Assert.Contains(entries, e => e.CommandText == "whoami");
+        Assert.Contains(entries, e => e.CommandText == "hostname");
     }
 
     private sealed class Fixture : IDisposable

--- a/tests/NovaTerminal.App.Tests/Controls/PaneRemoteShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneRemoteShellIntegrationTests.cs
@@ -554,6 +554,9 @@ public class PaneRemoteShellIntegrationTests
         public void PressEnter()
         {
             Pane.TryHandleCommandAssistKey(Key.Enter, KeyModifiers.None);
+            // Both phases, in TerminalView's order: the grid read happens before the carriage
+            // return reaches the PTY, the persistence after it (#448).
+            Pane.OnCommandAssistEnterObserving();
             Pane.OnCommandAssistEnterObserved();
         }
 

--- a/tests/NovaTerminal.App.Tests/Controls/PaneRemoteShellIntegrationTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneRemoteShellIntegrationTests.cs
@@ -386,6 +386,48 @@ public class PaneRemoteShellIntegrationTests
     }
 
     /// <summary>
+    /// With shell integration turned off, an instrumented remote's <c>133;B</c> does not make the
+    /// grid readable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Codex P2 on #448. The parser writes the command-input window for every session that emits
+    /// marks - the callbacks are wired unconditionally, because they also feed the agent status
+    /// machine and the overlay anchor, neither of which this switch governs. Reading that window
+    /// straight off the buffer therefore handed grid-backed queries and Enter capture to a user who
+    /// had opted out, where previously the un-armed tracker meant the controller's gate never opened
+    /// at all.
+    /// </para>
+    /// <para>
+    /// The setting is the user's "do not participate in the OSC 133 contract" control, and a remote
+    /// host is the one place they cannot simply uninstall the emitter instead - so the App boundary
+    /// combines the window with <c>IsShellIntegrationConsumptionEnabled</c>, which is the same thing
+    /// the integrated-session latch and the <c>133;C</c> payload already do.
+    /// </para>
+    /// </remarks>
+    [AvaloniaFact]
+    public async Task WithShellIntegrationOff_AnInstrumentedRemoteDoesNotOpenTheGridToQueries()
+    {
+        using var fixture = await Fixture.CreateAsync(ConnectionType.SSH, shellIntegrationEnabled: false);
+        fixture.Pane.ArmRemoteShellIntegrationTracker();
+        fixture.Pane.CreateAndWireParser();
+
+        // The remote emits a perfectly good mark stream regardless of our setting, so the parser
+        // opens the window on the buffer either way.
+        await fixture.PromptAsync("git status");
+
+        // Enter is what makes the consequence observable, and it is also what builds Command Assist
+        // in the first place - asserting on the gated read before anything has initialized the
+        // controller would pass for the wrong reason.
+        fixture.PressEnter();
+        await fixture.BareAcceptAsync();
+        await fixture.FinishAsync(exitCode: 0, durationMs: 10);
+
+        Assert.Null(fixture.Pane.TryReadGatedAssistQuerySnapshotForTest());
+        Assert.True(await fixture.NothingWasCapturedAsync());
+    }
+
+    /// <summary>
     /// The whole parser-to-capture path with no <c>await</c> anywhere: a command submitted in the
     /// same synchronous burst as the prompt that invited it is still captured.
     /// </summary>

--- a/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
+++ b/tests/NovaTerminal.App.Tests/Controls/PaneSubscriptionLifetimeTests.cs
@@ -145,9 +145,12 @@ public class PaneSubscriptionLifetimeTests
             "BackspaceObserved=1",
             "CommandAssistAnchorHintChanged=1",
             "DropNotice=1",
-            // 2: the assist Enter accumulator plus the Agent Output markless region capture. Both
-            // construction-time pane-owned handlers; TermView dies with the pane.
-            "EnterObserved=2",
+            // Enter is two events now, either side of the carriage return (#448). Both reads sit
+            // on the pre-CR one - the assist grid read and the Agent Output markless region
+            // capture - and only the assist persistence sits after it. Both construction-time
+            // pane-owned handlers; TermView dies with the pane.
+            "EnterObserved=1",
+            "EnterObserving=2",
             "PasteObserved=1",
             "Ready=1",
             "ScrollStateChanged=1",

--- a/tests/NovaTerminal.App.Tests/Performance/CommandAssistPerformanceTests.cs
+++ b/tests/NovaTerminal.App.Tests/Performance/CommandAssistPerformanceTests.cs
@@ -154,6 +154,7 @@ public sealed class CommandAssistPerformanceTests
             modeRouter: null,
             resultBuilder: null,
             queryProvider: grid.Read,
+            commandInputGateProbe: () => grid.IsAcceptingCommandInput,
             renderedSurfaceProbe: null,
             dispatch: null,
             passiveRefreshDebounce: TimeSpan.FromMilliseconds(75),
@@ -214,6 +215,7 @@ public sealed class CommandAssistPerformanceTests
             modeRouter: null,
             resultBuilder: null,
             queryProvider: grid.Read,
+            commandInputGateProbe: () => grid.IsAcceptingCommandInput,
             renderedSurfaceProbe: null,
             dispatch: null,
             passiveRefreshDebounce: TimeSpan.Zero);
@@ -401,6 +403,7 @@ public sealed class CommandAssistPerformanceTests
     {
         private readonly object _gate = new();
         private AssistQuerySnapshot? _snapshot;
+        private bool _acceptingCommandInput;
 
         public AssistQuerySnapshot? Read()
         {
@@ -408,6 +411,15 @@ public sealed class CommandAssistPerformanceTests
             {
                 return _snapshot;
             }
+        }
+
+        /// <summary>
+        /// The command-input gate. The terminal owns it alongside the mark since #448, so this
+        /// stand-in owns both halves instead of leaving one to the controller.
+        /// </summary>
+        public bool IsAcceptingCommandInput
+        {
+            get { lock (_gate) { return _acceptingCommandInput; } }
         }
 
         public void SetLine(string text)
@@ -418,9 +430,22 @@ public sealed class CommandAssistPerformanceTests
             }
         }
 
+        /// <summary><c>OSC 133;B</c> - the prompt finished printing and the line editor is live.</summary>
+        /// <remarks>
+        /// Both halves, in production's order (#448): the gate moves on the terminal first and
+        /// synchronously - TerminalPane's parser callback opens it on the buffer beside the mark
+        /// write - and only then does the event reach the controller, which still owns what belongs
+        /// on the pane's serialized dispatcher (here, the <c>BeginCommandLine</c> that ends per-command
+        /// Escape suppression).
+        /// </remarks>
         public void OpenPrompt(CommandAssistController controller)
         {
             SetLine(string.Empty);
+            lock (_gate)
+            {
+                _acceptingCommandInput = true;
+            }
+
             controller.HandleShellIntegrationEventAsync(new ShellIntegrationEvent(
                 Type: ShellIntegrationEventType.CommandStarted,
                 Timestamp: DateTimeOffset.UtcNow,

--- a/tests/NovaTerminal.VT.Tests/Osc133CommandInputWindowTests.cs
+++ b/tests/NovaTerminal.VT.Tests/Osc133CommandInputWindowTests.cs
@@ -31,13 +31,7 @@ public class Osc133CommandInputWindowTests
     private static (AnsiParser Parser, TerminalBuffer Buffer) Make(int cols = 40, int rows = 5)
     {
         var buffer = new TerminalBuffer(cols, rows);
-        var parser = new AnsiParser(buffer);
-
-        // The window is written to the buffer by the parser; the mark is handed to a subscriber and
-        // written by the host (TerminalPane's OnCommandStarted). Wiring it the way the App does is
-        // what lets the "mark survives C, window does not" asymmetry be asserted here at all.
-        parser.OnCommandStarted = mark => buffer.CommandStartMark = mark;
-        return (parser, buffer);
+        return (new AnsiParser(buffer), buffer);
     }
 
     [Fact]
@@ -161,6 +155,51 @@ public class Osc133CommandInputWindowTests
         parser.Process("\x1b[?1049l");
 
         Assert.False(buffer.IsAcceptingCommandInput);
+    }
+
+    /// <summary>
+    /// Both halves are already published when the first subscriber runs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Codex P2 on #448, and the sharper half of the bug. The window used to be opened here while
+    /// the mark was written by a subscriber (<c>TerminalPane.OnCommandStarted</c>), so for the length
+    /// of that callback chain a reader could see an open window pointing at the mark of the
+    /// <em>previous</em> command - which survives <c>C</c> on purpose. That does not lose a capture,
+    /// it fabricates one: the text read back is the last command's line or its output, recorded as
+    /// the command the user just submitted. Recording no command is recoverable; recording a command
+    /// the user never ran is not.
+    /// </para>
+    /// <para>
+    /// Asserted from inside the subscriber, which is the earliest an outside observer can look, and
+    /// against a <c>B</c> that follows <c>C</c> with no <c>D</c> - the shape that leaves a stale mark
+    /// live to be caught with.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ByTheTimeASubscriberRuns_TheNewMarkAndTheOpenWindowAreBothVisible()
+    {
+        var (parser, buffer) = Make();
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd + "first");
+        parser.Process(CommandAccepted);
+
+        ShellIntegrationMark? staleMark = buffer.CommandStartMark;
+        Assert.NotNull(staleMark);
+
+        ShellIntegrationMark? seenMark = null;
+        bool seenWindowOpen = false;
+        parser.OnCommandStarted = _ =>
+        {
+            seenMark = buffer.CommandStartMark;
+            seenWindowOpen = buffer.IsAcceptingCommandInput;
+        };
+
+        // A second prompt on the row below, so the new mark cannot coincide with the stale one.
+        parser.Process("\r\n" + PromptStart + "user@host:~$ " + PromptEnd);
+
+        Assert.True(seenWindowOpen);
+        Assert.NotNull(seenMark);
+        Assert.NotEqual(staleMark!.Value.AbsoluteRow, seenMark!.Value.AbsoluteRow);
     }
 
     /// <summary>A replaced session must not inherit the old one's open window.</summary>

--- a/tests/NovaTerminal.VT.Tests/Osc133CommandInputWindowTests.cs
+++ b/tests/NovaTerminal.VT.Tests/Osc133CommandInputWindowTests.cs
@@ -1,0 +1,177 @@
+using NovaTerminal.VT;
+
+namespace NovaTerminal.VT.Tests;
+
+/// <summary>
+/// The command-input window: <c>TerminalBuffer.IsAcceptingCommandInput</c>, moved by the parser on
+/// <c>OSC 133;B</c> / <c>C</c> / <c>D</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This is the other half of <see cref="Osc133CommandStartMarkTests"/>'s mark, and it lives beside
+/// it deliberately. Whether the cells between the mark and the cursor are a command line being
+/// edited or the output of a command that already ran is a lifecycle fact carried only by the OSC
+/// 133 stream, so a consumer that reads the mark without the window gets an answer it cannot trust.
+/// </para>
+/// <para>
+/// It used to live on Command Assist's session context, written after a hop onto the pane's
+/// serialized event dispatcher while the mark was written here, synchronously. Under a busy
+/// dispatcher the two disagreed, the grid read was refused, and a submitted command was dropped
+/// from history outright - silently and permanently (#448). Both halves now move in the same
+/// statement block, which is what these tests pin.
+/// </para>
+/// </remarks>
+public class Osc133CommandInputWindowTests
+{
+    private const string PromptStart = "\x1b]133;A\x07";
+    private const string PromptEnd = "\x1b]133;B\x07";
+    private const string CommandAccepted = "\x1b]133;C\x07";
+    private const string CommandFinished = "\x1b]133;D;0\x07";
+
+    private static (AnsiParser Parser, TerminalBuffer Buffer) Make(int cols = 40, int rows = 5)
+    {
+        var buffer = new TerminalBuffer(cols, rows);
+        var parser = new AnsiParser(buffer);
+
+        // The window is written to the buffer by the parser; the mark is handed to a subscriber and
+        // written by the host (TerminalPane's OnCommandStarted). Wiring it the way the App does is
+        // what lets the "mark survives C, window does not" asymmetry be asserted here at all.
+        parser.OnCommandStarted = mark => buffer.CommandStartMark = mark;
+        return (parser, buffer);
+    }
+
+    [Fact]
+    public void AFreshBuffer_IsNotAcceptingCommandInput()
+    {
+        var (_, buffer) = Make();
+
+        Assert.False(buffer.IsAcceptingCommandInput);
+    }
+
+    [Fact]
+    public void PromptEnd_OpensTheWindow()
+    {
+        var (parser, buffer) = Make();
+
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd);
+
+        Assert.True(buffer.IsAcceptingCommandInput);
+    }
+
+    /// <summary>
+    /// The window closes on <c>C</c> even though the mark does not. That asymmetry is the point: at
+    /// <c>C</c> the input line is still painted and the mark still describes it, so the grid reader
+    /// would answer - and its answer is about to become this command's output.
+    /// </summary>
+    [Fact]
+    public void CommandAccepted_ClosesTheWindow_ButKeepsTheMark()
+    {
+        var (parser, buffer) = Make();
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd + "git status");
+
+        parser.Process(CommandAccepted);
+
+        Assert.False(buffer.IsAcceptingCommandInput);
+        Assert.NotNull(buffer.CommandStartMark);
+    }
+
+    /// <summary>A shell can reach <c>D</c> with no intervening <c>C</c>.</summary>
+    [Fact]
+    public void CommandFinished_ClosesTheWindow_WithNoInterveningAccept()
+    {
+        var (parser, buffer) = Make();
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd + "git status");
+
+        parser.Process(CommandFinished);
+
+        Assert.False(buffer.IsAcceptingCommandInput);
+    }
+
+    [Fact]
+    public void TheNextPromptReopensTheWindow()
+    {
+        var (parser, buffer) = Make();
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd + "git status");
+        parser.Process(CommandAccepted);
+        parser.Process(CommandFinished);
+
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd);
+
+        Assert.True(buffer.IsAcceptingCommandInput);
+    }
+
+    /// <summary>
+    /// Prompt frameworks repaint constantly and every repaint carries <c>B</c>, so re-opening an
+    /// open window has to be a no-op rather than anything stateful.
+    /// </summary>
+    [Fact]
+    public void ARepaintedPrompt_LeavesTheWindowOpen()
+    {
+        var (parser, buffer) = Make();
+
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd);
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd);
+
+        Assert.True(buffer.IsAcceptingCommandInput);
+    }
+
+    /// <summary>
+    /// Entering the alt screen closes it: the prompt that emitted <c>B</c> is not on the screen the
+    /// user is looking at any more, and a refresh would otherwise read a TUI's grid as a command
+    /// line.
+    /// </summary>
+    [Fact]
+    public void EnteringTheAltScreen_ClosesTheWindow()
+    {
+        var (parser, buffer) = Make();
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd);
+
+        parser.Process("\x1b[?1049h");
+
+        Assert.False(buffer.IsAcceptingCommandInput);
+    }
+
+    /// <summary>
+    /// A full-screen TUI drawing its own prompt may legally emit <c>133;B</c>, and that must not pry
+    /// a window open onto the TUI's own grid. Refused at the source so the invariant holds whichever
+    /// order the two facts arrive in.
+    /// </summary>
+    [Fact]
+    public void OnTheAltScreen_APromptMarkDoesNotOpenTheWindow()
+    {
+        var (parser, buffer) = Make();
+        parser.Process("\x1b[?1049h");
+
+        parser.Process(PromptStart + "tui> " + PromptEnd);
+
+        Assert.False(buffer.IsAcceptingCommandInput);
+    }
+
+    /// <summary>
+    /// Leaving the alt screen does not reopen it. The shell repaints its prompt on teardown and that
+    /// repaint re-emits <c>B</c>, so it reopens on evidence rather than on assumption.
+    /// </summary>
+    [Fact]
+    public void LeavingTheAltScreen_DoesNotReopenTheWindowOnItsOwn()
+    {
+        var (parser, buffer) = Make();
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd);
+        parser.Process("\x1b[?1049h");
+
+        parser.Process("\x1b[?1049l");
+
+        Assert.False(buffer.IsAcceptingCommandInput);
+    }
+
+    /// <summary>A replaced session must not inherit the old one's open window.</summary>
+    [Fact]
+    public void ClearTrackedShellMarks_ClosesTheWindow()
+    {
+        var (parser, buffer) = Make();
+        parser.Process(PromptStart + "user@host:~$ " + PromptEnd);
+
+        buffer.ClearTrackedShellMarks();
+
+        Assert.False(buffer.IsAcceptingCommandInput);
+    }
+}


### PR DESCRIPTION
## What

A command submitted while the pane's shell-integration dispatcher was busy could be **dropped from history outright** — silently, permanently, and only for the one command whose prompt lost the race.

## Why it happened

The command-input gate is one half of a pair:

| half | applied by | when |
|---|---|---|
| the `OSC 133;B` mark | the parser, into the buffer | synchronously, on the thread the bytes arrive on |
| `IsAcceptingCommandInput` | `CommandAssistController` | **after a hop onto `OrderedAsyncEventDispatcher`** |

`OnCommandAssistEnterObserved` reads both at once on the UI thread and refuses grid truth unless they agree. In the window between them, Enter saw a fresh mark and a stale-closed gate, refused the grid snapshot, fell through to the markless accumulator — empty, because the shell echoed the line rather than the user typing it — and `CapturePipeline` read that as "nothing to persist".

`OrderedAsyncEventDispatcher` is what hid this. Its semaphore is uncontended almost always, `SemaphoreSlim.WaitAsync` then returns an already-completed task, and the handler runs **inline on the parse thread** — so the gate does move with the mark, until a previous event is mid-`await` in the history store. Hence a rare flake rather than a broken feature.

## The fix

The gate moves in `OnShellIntegrationEventObserved`, before the enqueue, split out as `CommandAssistController.ApplyShellIntegrationLifecycle`. Safe there: a `volatile bool` on the context, touching no state machine, view-model or pipeline. The async handler keeps everything that is *not* safe off the UI thread (`BeginCommandLine`, the surface reset, the capture pipeline) and no longer moves the gate.

**Deliberately not additive.** `B` then `C` applied synchronously leave the gate closed; a dispatcher then catching up on `B` would reopen it *while the command is running* — the precise failure `IsAcceptingCommandInput` exists to prevent. Exactly one path owns each event, which is what `applyLifecycle: false` says. The parse thread only reads `_commandAssistController` and never initializes it (that builds views), so a pre-initialization event stays the dispatcher's job.

## How it was diagnosed

`PaneRemoteShellIntegrationTests.OnAnSshPaneEmittingABareC_EveryCommandIsStillCaptured` had failed about once in 150 CI runs and never locally.

- 40/40 green in isolation. Reproduced by saturating every core: **1-in-12 and 1-in-15** across two runs.
- A trace of the lost command showed `snapshotNull=True`, `submitted=''`, `persist=False`.
- The store still held **one entry 30 s later**, so lateness was never the explanation — the capture was discarded.
- **30-for-30** under the same saturation after the fix.

## Tests

Both checked against a neutered fix, so neither passes vacuously:

- `CommandAssistGridTruthTests.TheLifecycleGateOpensWithoutTheAsyncHalfOfTheEventHavingRun` — bites on the defect.
- `ALaggingReplayOfAnOlderMark_DoesNotReopenTheGate` — pins the risk the fix introduces; goes red if the async handler is made additive again.

`PaneRemoteShellIntegrationTests` gains an end-to-end companion with no `await` between the prompt bytes and Enter, which is the production shape: an agent-sent or broadcast command, or a pasted line ending in a newline. Its remarks say plainly that it passed before this change too, and why.

## Verification

- App.Tests, both lanes the way CI runs them: `Lane!=PlatformBoot` 3609 passed, `Lane=PlatformBoot` 50 passed.
- Architecture.Tests 85 passed.
- `src/NovaTerminal.App` builds with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
