### PR TITLE
fix(app): enable X11 drawn decorations so Linux gets caption buttons

### DIFF
--- a/src/NovaTerminal.App/Program.cs
+++ b/src/NovaTerminal.App/Program.cs
@@ -146,6 +146,31 @@ class Program
     public static AppBuilder BuildAvaloniaApp()
         => AppBuilder.Configure<App>()
             .UsePlatformDetect()
+            // MainWindow is a client-side-decorated window: ExtendClientAreaToDecorationsHint plus
+            // NovaWindowDecorationsTheme (App.axaml) draw our own min/max/close buttons, and the
+            // title bar overlay reserves a 140px right margin for them. On Windows and macOS that
+            // opt-in is enough. On X11 - which is what Linux gets from UsePlatformDetect, including
+            // under Wayland compositors via XWayland - Avalonia 12 gates drawn decorations behind
+            // this backend option, default false: without it IsExtendedIntoWindowDecorations stays
+            // false, the decorations theme is never instantiated, and the caption buttons simply do
+            // not exist. Under a compositor that draws no titlebar of its own (Hyprland, Sway) the
+            // window then has no close/maximize/minimize affordance at all, and the reserved 140px
+            // sits empty. Not Force*: only windows that opt in should get CSD, so SettingsWindow,
+            // AboutWindow, ConnectionManagerWindow and ReplayWindow keep their WM decorations.
+            //
+            // Expect close ALONE on a tiling compositor, and that is correct rather than a leftover
+            // of the bug: the theme hides minimize/maximize on :not(:has-minimize)/:not(:has-maximize),
+            // and X11 sets neither pseudoclass unless the window manager advertises the action. On
+            // Hyprland it does not, and measured behaviour agrees - setting WindowState to Maximized
+            // or Minimized there leaves it at Normal, so those two buttons would be inert. The same
+            // theme shows all three under a WM that does advertise them.
+            //
+            // Experimental in 12.0.4 ("used mostly for testing"), hence the suppression. Recheck on
+            // the next Avalonia bump: if the flag graduates, drop the pragma; if it is removed,
+            // this call is what has to be replaced, not the XAML.
+#pragma warning disable AVALONIA_X11_CSD
+            .With(new X11PlatformOptions { EnableDrawnDecorations = true })
+#pragma warning restore AVALONIA_X11_CSD
             .WithInterFont()
             .With(new FontManagerOptions
             {

--- a/tests/NovaTerminal.App.Tests/Core/AppBuilderX11DecorationsTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/AppBuilderX11DecorationsTests.cs
@@ -1,0 +1,91 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using Avalonia;
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// Pins the one line of <see cref="Program.BuildAvaloniaApp"/> that decides whether MainWindow has
+/// caption buttons on Linux.
+///
+/// MainWindow is client-side decorated - ExtendClientAreaToDecorationsHint plus
+/// NovaWindowDecorationsTheme draw our own minimize/maximize/close - and on Windows and macOS that
+/// opt-in is all it takes. On X11 (what Linux gets from UsePlatformDetect, including under Wayland
+/// compositors via XWayland) Avalonia 12 additionally gates drawn decorations behind
+/// X11PlatformOptions.EnableDrawnDecorations, which defaults to FALSE. Without it
+/// Window.IsExtendedIntoWindowDecorations stays false, WindowDecorationMargin stays 0,0,0,0, the
+/// decorations theme is never instantiated, and the buttons do not exist as controls at all - so on
+/// a compositor that draws no titlebar of its own (Hyprland, Sway) the window had no close, maximize
+/// or minimize affordance whatsoever, and the 140px the title bar overlay reserves for them sat
+/// empty. That shipped for the whole Avalonia 12 era because nothing failed: the XAML opt-in is
+/// still there and still correct, it was simply inert.
+///
+/// This is asserted rather than left to manual checking because the failure is silent in every
+/// direction. The headless test harness builds its own AppBuilder (see TestAppBuilder), so no other
+/// test in the suite touches this method; the compiler is happy either way; and the only symptom is
+/// on a platform CI does not run a GUI on.
+/// </summary>
+public sealed class AppBuilderX11DecorationsTests
+{
+    /// <summary>
+    /// Reads the options back out of the builder rather than through AvaloniaLocator, which is where
+    /// AppBuilder actually puts them: <c>With&lt;T&gt;</c> only appends a closure to a private
+    /// <c>_optionsInitializers</c> delegate, and nothing binds until Setup runs. Running Setup here
+    /// is not an option - it would boot a second Avalonia platform into a process whose headless one
+    /// is thread-affine (see the Lane=PlatformBoot note in CONTRIBUTING.md) - so the closure is
+    /// inspected instead, which mutates no global state at all.
+    ///
+    /// The private field name is Avalonia's, so an Avalonia bump can move it. The lookup is asserted
+    /// separately from the value for that reason: if the field is gone this fails saying so, instead
+    /// of finding no options and reporting the flag as unset.
+    /// </summary>
+    private static T? FindConfiguredOptions<T>(AppBuilder builder) where T : class
+    {
+        var field = typeof(AppBuilder).GetField("_optionsInitializers", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(field);
+
+        // Null when no .With() call was made at all, which is itself a failure of the assertions below.
+        if (field.GetValue(builder) is not Delegate initializers)
+        {
+            return null;
+        }
+
+        return initializers.GetInvocationList()
+            .Select(invocation => invocation.Target)
+            .Where(target => target is not null)
+            .SelectMany(target => target!.GetType()
+                .GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Select(f => f.GetValue(target)))
+            .OfType<T>()
+            .FirstOrDefault();
+    }
+
+    [Fact]
+    [Trait("Category", "Regression")]
+    public void BuildAvaloniaApp_EnablesX11DrawnDecorations()
+    {
+        var options = FindConfiguredOptions<X11PlatformOptions>(Program.BuildAvaloniaApp());
+
+        Assert.NotNull(options);
+
+        // Asserted on every OS, not just Linux: the registration is unconditional in
+        // BuildAvaloniaApp and inert off X11, so guarding the assertion by platform would mean the
+        // one thing this test exists to catch is only ever checked on the Linux CI leg.
+#pragma warning disable AVALONIA_X11_CSD
+        Assert.True(
+            options.EnableDrawnDecorations,
+            "X11PlatformOptions.EnableDrawnDecorations must stay true: without it MainWindow has no "
+                + "minimize/maximize/close buttons on Linux, and on a tiling compositor no way to "
+                + "close the window at all.");
+#pragma warning restore AVALONIA_X11_CSD
+
+        // ForceDrawnDecorations must stay off: it would apply CSD to every window, including
+        // SettingsWindow, AboutWindow, ConnectionManagerWindow and ReplayWindow, which do not opt in
+        // and have no decorations theme of their own to draw.
+#pragma warning disable AVALONIA_X11_FORCE_CSD
+        Assert.False(options.ForceDrawnDecorations);
+#pragma warning restore AVALONIA_X11_FORCE_CSD
+    }
+}


### PR DESCRIPTION
## What this changes

MainWindow has had **no minimize/maximize/close buttons on Linux** since the Avalonia 12 upgrade. One line in `BuildAvaloniaApp` turns them back on.

The XAML opt-in was never wrong. `MainWindow.axaml` still sets `ExtendClientAreaToDecorationsHint` and points at `NovaWindowDecorationsTheme`; `App.axaml` still draws all three buttons. It was simply inert: Avalonia 12's X11 backend gates client-side drawn decorations behind `X11PlatformOptions.EnableDrawnDecorations`, **default false**, and `BuildAvaloniaApp` called `UsePlatformDetect()` with no X11 options.

Measured against 12.0.4 with a minimal Avalonia app on Hyprland/XWayland:

| | flag off | flag on |
|---|---|---|
| `IsExtendedIntoWindowDecorations` | `False` | `True` |
| `WindowDecorationMargin` | `0,0,0,0` | `9,39,9,9` |
| `WindowDrawnDecorations` instance | never constructed | constructed, `EnabledParts=All` |

That is invisible on a desktop WM, which draws its own titlebar over the top. Under a compositor that draws none — Hyprland, Sway — the window had **no close, maximize or minimize affordance at all**, and the 140px the title bar overlay reserves for them sat empty.

`EnableDrawnDecorations`, not `ForceDrawnDecorations`: only windows that opt in should get CSD, so SettingsWindow, AboutWindow, ConnectionManagerWindow and ReplayWindow keep their WM decorations. The flag is `[Experimental]` in 12.0.4, hence a scoped `#pragma warning disable AVALONIA_X11_CSD` with a note to recheck it on the next Avalonia bump.

Fixes # — no issue was filed; reported directly.

### Expect close ALONE on a tiling compositor

That is correct rather than a leftover of the bug, and worth knowing before someone reads the screenshot as a half-fix. The theme hides the other two on `:not(:has-minimize)` / `:not(:has-maximize)`, and X11 sets neither pseudoclass unless the WM advertises the action. Hyprland does not set `_NET_WM_ALLOWED_ACTIONS` at all (verified with `xprop`), and behaviour agrees: setting `WindowState` to `Maximized` or `Minimized` there leaves it at `Normal`, so both buttons would be inert. The same theme shows all three under a WM that does advertise them.

Known cosmetic leftover, **not** addressed here: the `TitleBar` overlay's hardcoded `Margin="0,4,140,0"` reserves room for three buttons, so on a tiling compositor ~90px sits empty between `⋯` and `✕`. Correct on Windows and floating X11 WMs. Making it react to those decoration pseudoclasses is not something the content tree can currently observe, so it wants its own change.

## Invariant and ownership

- **What invariant does this change affect?** None of the VT/buffer/renderer invariants. It affects the platform-startup contract: MainWindow is client-side decorated on every OS, and the window chrome NovaTerminal draws is the only chrome it gets. Before this, that contract silently did not hold on Linux.
- **Which module owns that invariant?** `NovaTerminal.App` (`Program.BuildAvaloniaApp`, `MainWindow.axaml`, `App.axaml`).

## Tests

- **What tests cover this change?** `tests/NovaTerminal.App.Tests/Core/AppBuilderX11DecorationsTests.cs` — `BuildAvaloniaApp_EnablesX11DrawnDecorations`, tagged `Category=Regression`. It reads the options back out of the returned `AppBuilder` rather than through `AvaloniaLocator`, because `With<T>` only appends a closure to a private `_optionsInitializers` delegate and nothing binds until Setup runs — and running Setup would boot a second Avalonia platform into a process whose headless one is thread-affine (the `Lane=PlatformBoot` problem). Inspecting the closure mutates no global state. It also asserts `ForceDrawnDecorations` stays off.

  This is asserted rather than left to manual checking because every direction of the failure is silent: the headless harness builds its own `AppBuilder` (`TestAppBuilder`), so no other test in the suite reaches `BuildAvaloniaApp`; the compiler is happy either way; and the only symptom is on a platform CI runs no GUI on. **Verified to fail** (`Assert.NotNull() Failure: Value is null`) with the `.With()` call commented out, and to pass with it restored.

  The private field name is Avalonia's, so a bump can move it. The lookup is asserted separately from the value for that reason: if the field is gone the test says so instead of finding no options and reporting the flag as unset.

- **Which categories did you run locally?**

  - [x] full unfiltered run — **not** run; see the App.Tests note below
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` (non-blocking in CI — checked)
  - [ ] full local CI rehearsal (`ci/run.sh`)
  - [x] `tests/NovaTerminal.Architecture.Tests` — 85/85 pass
  - [x] `dotnet format whitespace --verify-no-changes` — clean

  **On the App.Tests lane, read this before trusting the numbers.** The full run on this branch was `Failed: 12, Passed: 3642`. The full run on `main`, same machine, same command, was `Failed: 9, Passed: 3644` — and the two failure sets barely overlap (only `ThemeSwitchPixelTests` appears in both; `main` alone fails `AvaloniaBootLocatorHygieneTests.TheAmbientMediaContextBelongsToTheSessionDispatchThread`, which is the thread-affine `MediaContext` problem CONTRIBUTING documents). Every class that failed on this branch — `AgentObserveIndicatorTests`, `VerticalTabStripTests`, `ThemeSwitchPixelTests` — passes 55/55 in isolation on **both** `main` and this branch.

  So the lane is order-dependent on this machine on `main` too, and this change is not implicated. It is not evidence that those 12 are fine, only that they are not mine. Note `tests/app-tests-known-flaky.txt` is currently empty, so `check-app-tests-baseline.py` should be failing that job for unlisted failures already — worth a separate look, and deliberately not touched here.

## Impact

- **Does this affect cross-platform behavior?** Yes, that is the point — Linux/X11 only. Windows and macOS are untouched: the option is an X11 backend bag, inert elsewhere. Verified on Arch + Hyprland (XWayland) with a locally built binary, screenshotted: the ✕ renders where nothing did before. **Not verified on a floating X11 WM** (GNOME/KDE/Xfce), where the expectation is all three buttons; that is the same code path Avalonia's own default theme takes, but a second pair of eyes on a desktop WM would be welcome. Also unverified by an actual click — I had no pointer-automation tool on this machine, so hit-testing over the extended client area is Avalonia's default template behaviour taken on trust.
- **Does this change renderer metrics?** No. Nothing in the draw path, caches or invalidation.
- **Does this change VT coverage?** No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
