### PR TITLE
fix(app): measure the caption-button reserve instead of hardcoding 140px

### DIFF
--- a/src/NovaTerminal.App/MainWindow.axaml
+++ b/src/NovaTerminal.App/MainWindow.axaml
@@ -218,7 +218,16 @@
 
         <!-- Overlay layer for custom buttons (right aligned, leaving space for the system caption
              buttons). Contents are built by MainWindow.RebuildTitleBar from TitleBarCatalog +
-             the user's saved placement, so nothing but the + button is declared here. -->
+             the user's saved placement, so nothing but the + button is declared here.
+
+             The 140 in the right margin is a STARTING VALUE, not the reserve. It is what three
+             45px caption buttons plus spacing and the border margin come to, and it holds only
+             until MainWindow.UpdateCaptionButtonReserve has measured the strip that is actually
+             there - which is a different width wherever the window manager does not advertise
+             minimize and maximize, since the theme hides those buttons and ~92px of this would
+             otherwise sit empty. Kept as the pre-measurement value because it is the widest case,
+             so the first paint can only be too generous, never overlap the buttons. macOS keeps
+             its own collapsed value (caption on the left) - see UpdateCaptionButtonReserve. -->
         <Grid VerticalAlignment="Top" Height="32" HorizontalAlignment="Right" ZIndex="100" x:Name="TitleBar" Margin="0,4,140,0" Background="Transparent">
             <Grid.ContextMenu>
                 <ContextMenu>

--- a/src/NovaTerminal.App/MainWindow.axaml.cs
+++ b/src/NovaTerminal.App/MainWindow.axaml.cs
@@ -130,6 +130,24 @@ namespace NovaTerminal
         internal const double MinimumTabHeaderRightReserve = 440;
         internal const double MacOsTrafficLightReserve = 92;
         internal const double TabHeaderViewportPadding = 16;
+
+        /// <summary>
+        /// Breathing room between our last title bar button and the first caption button, and the
+        /// whole right reserve when there are no drawn caption buttons to clear. Matches the value
+        /// the macOS branch in the constructor has always used.
+        /// </summary>
+        internal const double CaptionReserveGutter = 8;
+
+        /// <summary>
+        /// x:Name of the caption-button strip in NovaWindowDecorationsTheme (App.axaml). Ours, not
+        /// Avalonia's - though the default theme uses the same name, which is where ours was copied
+        /// from.
+        /// </summary>
+        private const string CaptionButtonStripName = "PART_OverlayPanel";
+
+        /// <summary>The caption strip <see cref="WatchCaptionButtonStrip"/> is hooked to, so it hooks once.</summary>
+        private Control? _watchedCaptionButtonStrip;
+
         // Hoisted out of UpdateVerticalTabExtras: that method runs per tab per visual-refresh
         // pass, and allocating a new SolidColorBrush per tab per pass adds up.
         private static readonly IBrush TabAttentionBrush = new ImmutableSolidColorBrush(Color.Parse("#FFD25A"));
@@ -1529,6 +1547,225 @@ namespace NovaTerminal
                 .FirstOrDefault(s => s.Name == "PART_TabHeaderScrollViewer");
         }
 
+        /// <summary>
+        /// How much of the title bar's right edge our own buttons have to keep clear so they do not
+        /// sit under the drawn caption buttons.
+        ///
+        /// This used to be the literal 140 in MainWindow.axaml's <c>Margin="0,4,140,0"</c>: three
+        /// 45px buttons plus their 2px spacing plus the 1px border margin. That number is only right
+        /// when all three are actually there, and how many are there is not ours to decide - the
+        /// theme hides minimize and maximize on <c>:not(:has-minimize)</c> / <c>:not(:has-maximize)</c>,
+        /// and X11 sets neither pseudoclass unless the window manager advertises the action. On a
+        /// tiling compositor (Hyprland, Sway) only close survives, so ~92px of the reserve was dead
+        /// space between our last button and the ✕.
+        ///
+        /// So measure the strip instead of predicting it. <paramref name="captionStripLeft"/> and
+        /// <paramref name="windowWidth"/> are in the same coordinate space, and the gap between them
+        /// is the whole reserve: the strip itself plus whatever frame inset sits to its right.
+        /// </summary>
+        /// <param name="windowWidth">Width of the window, in the coordinate space the caption strip was translated into.</param>
+        /// <param name="captionStripLeft">Left edge of the caption strip, in that same space.</param>
+        /// <param name="captionStripWidth">
+        /// Width of the caption strip. Zero or negative means there is nothing to clear - no drawn
+        /// decorations on this platform, or the strip is collapsed (the theme hides it in fullscreen)
+        /// - and the reserve collapses to the gutter. <paramref name="captionStripLeft"/> is not
+        /// meaningful in that case, so it is not read.
+        /// </param>
+        internal static double ComputeCaptionButtonReserve(
+            double windowWidth,
+            double captionStripLeft,
+            double captionStripWidth,
+            double gutter = CaptionReserveGutter)
+        {
+            if (captionStripWidth <= 0 || double.IsNaN(captionStripWidth))
+            {
+                return gutter;
+            }
+
+            if (double.IsNaN(windowWidth) || double.IsNaN(captionStripLeft))
+            {
+                return gutter;
+            }
+
+            double reserve = Math.Ceiling(windowWidth - captionStripLeft + gutter);
+
+            // Clamped rather than trusted. A reserve wider than half the window would push our own
+            // buttons somewhere absurd, and the inputs come from a live layout pass that can be
+            // read mid-transition (a window state change resizes the frame and the strip on
+            // different passes). The floor matters for the same reason: a strip briefly measured as
+            // hanging past the right edge would otherwise yield a negative margin, which Avalonia
+            // honours by letting our buttons overhang the window.
+            double ceiling = Math.Max(gutter, windowWidth / 2);
+            return Math.Clamp(reserve, gutter, ceiling);
+        }
+        /// <summary>
+        /// Finds the drawn caption-button strip, or null when this window has none.
+        ///
+        /// It is deliberately NOT a visual descendant of this window: TopLevelHost owns the
+        /// decorations and the Window is its child, so the strip is a SIBLING of our whole content
+        /// tree and <c>this.GetVisualDescendants()</c> never sees it (verified against 12.0.4 -
+        /// the window's own tree ends at PART_ContentPresenter). Hence the hop up to the visual
+        /// parent first.
+        ///
+        /// Returns null in three different situations that all want the same answer - a bare gutter:
+        /// a platform drawing native chrome instead (macOS traffic lights), decorations disabled
+        /// altogether, and the strip not built yet. The third is why callers must not treat null as
+        /// settled while <see cref="Window.IsExtendedIntoWindowDecorations"/> is true.
+        /// </summary>
+        private Control? FindCaptionButtonStrip()
+        {
+            return this.GetVisualParent()?
+                .GetVisualDescendants()
+                .OfType<Control>()
+                .FirstOrDefault(c => c.Name == CaptionButtonStripName);
+        }
+
+        /// <summary>
+        /// Re-measures the drawn caption buttons and reserves exactly their width on the right of
+        /// our own title bar strip, replacing the hardcoded 140px the XAML used to carry. See
+        /// <see cref="ComputeCaptionButtonReserve"/> for why a constant cannot be right.
+        ///
+        /// macOS is left alone on purpose. Its caption lives on the LEFT, the constructor already
+        /// collapses the right reserve to <see cref="CaptionReserveGutter"/> for it, and that
+        /// behaviour is known-good on a platform this change could not be tested on. If macOS turns
+        /// out to build a drawn strip too, this measurement would produce the same answer and the
+        /// special case can go - but that is a claim to verify there, not to assume here.
+        /// </summary>
+        private void UpdateCaptionButtonReserve()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return;
+            }
+
+            var titleBar = this.FindControl<Grid>("TitleBar");
+            if (titleBar == null)
+            {
+                return;
+            }
+
+            var strip = FindCaptionButtonStrip();
+            if (strip == null)
+            {
+                // Extended into the decorations means a strip is coming, so this is "too early",
+                // not "there is none". Collapsing the reserve now would park our buttons under the
+                // caption buttons for as long as it took some unrelated event to recompute; the
+                // triggers wired in WireCaptionButtonReserve run this again once the strip exists.
+                if (IsExtendedIntoWindowDecorations)
+                {
+                    return;
+                }
+
+                ApplyCaptionButtonReserve(titleBar, CaptionReserveGutter);
+                return;
+            }
+
+            WatchCaptionButtonStrip(strip);
+
+            // Translated rather than compared raw: the strip is in TopLevelHost's space and our
+            // title bar is in the window's, and with drawn decorations those origins differ by the
+            // shadow and frame inset. Null when the two are not connected in the visual tree, which
+            // is transient - leave the current reserve and wait for the next trigger.
+            var left = strip.TranslatePoint(default, this)?.X;
+            if (left == null)
+            {
+                return;
+            }
+
+            ApplyCaptionButtonReserve(
+                titleBar,
+                ComputeCaptionButtonReserve(Bounds.Width, left.Value, strip.Bounds.Width));
+        }
+
+        /// <summary>
+        /// Writes the reserve into the title bar's right margin, and only then tells the tab header
+        /// to re-measure - <see cref="GetTabHeaderViewportMargin"/> reads that margin, so the order
+        /// matters. No-ops on an unchanged value so the SizeChanged and Bounds triggers cannot ping
+        /// -pong: setting Margin relayouts the bar, which fires SizeChanged, which lands back here.
+        /// </summary>
+        private void ApplyCaptionButtonReserve(Grid titleBar, double reserve)
+        {
+            var current = titleBar.Margin;
+            if (Math.Abs(current.Right - reserve) < 0.5)
+            {
+                return;
+            }
+
+            titleBar.Margin = new Thickness(current.Left, current.Top, reserve, current.Bottom);
+
+            // Logged because this is the number a "my buttons overlap the caption buttons" report on
+            // some untested window manager turns on, and it is otherwise invisible. Only fires when
+            // the value actually changes, so it is a handful of lines per session, not per layout.
+            AppLogger.Log($"[TitleBar] caption reserve {current.Right:0.#} -> {reserve:0.#}");
+            Dispatcher.UIThread.Post(UpdateTabHeaderViewport, DispatcherPriority.Background);
+        }
+
+        /// <summary>
+        /// Keeps the reserve correct after the first measurement. The strip's width is not fixed for
+        /// the life of the window: the theme collapses the whole panel in fullscreen and the caption
+        /// set can change with window state, so its Bounds is the authoritative signal. Subscribed
+        /// once and only once - this runs from a recompute that is itself triggered by layout, so an
+        /// unguarded subscribe would add a handler per pass.
+        /// </summary>
+        private void WatchCaptionButtonStrip(Control strip)
+        {
+            if (ReferenceEquals(_watchedCaptionButtonStrip, strip))
+            {
+                return;
+            }
+
+            if (_watchedCaptionButtonStrip != null)
+            {
+                _watchedCaptionButtonStrip.PropertyChanged -= OnCaptionButtonStripPropertyChanged;
+            }
+
+            _watchedCaptionButtonStrip = strip;
+            strip.PropertyChanged += OnCaptionButtonStripPropertyChanged;
+        }
+
+        /// <summary>
+        /// The strip's own Bounds is the authoritative width signal, so only that property is acted
+        /// on - the panel raises plenty of others. Posted rather than handled inline because this
+        /// fires from inside a layout pass, and <see cref="UpdateCaptionButtonReserve"/> reads
+        /// Bounds and writes a Margin.
+        /// </summary>
+        private void OnCaptionButtonStripPropertyChanged(object? sender, AvaloniaPropertyChangedEventArgs e)
+        {
+            if (e.Property == BoundsProperty)
+            {
+                Dispatcher.UIThread.Post(UpdateCaptionButtonReserve, DispatcherPriority.Background);
+            }
+        }
+
+        /// <summary>
+        /// Triggers for <see cref="UpdateCaptionButtonReserve"/>. Called from the constructor.
+        ///
+        /// Opened is the earliest point the platform window - and therefore the decorations - exists
+        /// at all, and even then the strip is built during a layout pass, so the recompute is posted
+        /// at Background priority for the same reason RebuildTitleBar posts: Background (-2) drains
+        /// after every layout/render priority Avalonia schedules its own passes at. SizeChanged
+        /// covers the case where Opened still ran too early, since the first real arrange resizes us.
+        /// </summary>
+        private void WireCaptionButtonReserve()
+        {
+            void Recompute() =>
+                Dispatcher.UIThread.Post(UpdateCaptionButtonReserve, DispatcherPriority.Background);
+
+            Opened += (_, _) => Recompute();
+            this.SizeChanged += (_, _) => Recompute();
+
+            // WindowState changes the caption set on platforms that offer maximize/restore, and
+            // fullscreen collapses the strip entirely. IsExtendedIntoWindowDecorations flips once,
+            // late, when a platform builds drawn decorations - the transition that takes
+            // FindCaptionButtonStrip from "nothing yet" to a real strip.
+            this.PropertyChanged += (_, e) =>
+            {
+                if (e.Property == WindowStateProperty || e.Property == IsExtendedIntoWindowDecorationsProperty)
+                {
+                    Recompute();
+                }
+            };
+        }
         internal static Thickness GetTabHeaderViewportMargin(
             bool isMacOs,
             double titleBarWidth,
@@ -3546,15 +3783,20 @@ namespace NovaTerminal
                 };
                 titleBar.SizeChanged += (_, __) => Dispatcher.UIThread.Post(UpdateTabHeaderViewport, DispatcherPriority.Background);
 
-                // XAML sets Margin="0,4,140,0" to reserve space for Windows-style caption buttons on the right.
-                // On macOS the system traffic lights are on the left, so collapse the right reservation
-                // so the custom buttons (+, tab list, record, …, settings) sit flush against the edge.
+                // XAML sets Margin="0,4,140,0" as a pre-measurement floor for drawn caption buttons
+                // on the right. On macOS the system traffic lights are on the left, so collapse the
+                // right reservation so the custom buttons (+, tab list, record, …, settings) sit
+                // flush against the edge. Everywhere else UpdateCaptionButtonReserve measures it.
                 if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
                     var m = titleBar.Margin;
-                    titleBar.Margin = new Thickness(m.Left, m.Top, 8, m.Bottom);
+                    titleBar.Margin = new Thickness(m.Left, m.Top, CaptionReserveGutter, m.Bottom);
                 }
             }
+
+            // Everywhere else the right reserve is measured off the real caption buttons rather than
+            // guessed, which is what makes the XAML default a floor and not the answer.
+            WireCaptionButtonReserve();
 
 
             if (tabs != null)

--- a/tests/NovaTerminal.App.Tests/Core/MainWindowCaptionReserveTests.cs
+++ b/tests/NovaTerminal.App.Tests/Core/MainWindowCaptionReserveTests.cs
@@ -1,0 +1,136 @@
+using Xunit;
+
+namespace NovaTerminal.Tests.Core;
+
+/// <summary>
+/// Covers <see cref="NovaTerminal.MainWindow.ComputeCaptionButtonReserve"/>, which replaced the
+/// literal 140 in MainWindow.axaml's title bar margin.
+///
+/// 140 is three 45px caption buttons plus 2px spacing plus the 1px border margin, and it is only
+/// right when all three buttons are there. How many are there is not the app's decision: the theme
+/// hides minimize and maximize on <c>:not(:has-minimize)</c> / <c>:not(:has-maximize)</c>, and X11
+/// sets neither pseudoclass unless the window manager advertises the action. Under a tiling
+/// compositor only close survives, so ~94px of the reserve was dead space.
+///
+/// The lookup that feeds this - hopping to TopLevelHost and translating the strip's origin - needs a
+/// real platform window and is not covered here. What is covered is the arithmetic and, more
+/// usefully, its behaviour at the edges: every input comes from a live layout pass that can be read
+/// mid-transition, and a bad answer here moves the user's buttons off the window.
+/// </summary>
+public class MainWindowCaptionReserveTests
+{
+    private const double Gutter = NovaTerminal.MainWindow.CaptionReserveGutter;
+
+    // Measured off a real X11 window on Hyprland (only the close button survives there): the window
+    // spanned 1227 DIPs, the strip sat at x=1173 and was 45 wide. Pinned as the concrete case so a
+    // change to the formula has to explain itself against a real observation rather than an invented
+    // one.
+    private const double RealWindowWidth = 1227;
+    private const double RealStripLeft = 1173;
+    private const double RealStripWidth = 45;
+
+    [Fact]
+    public void CloseOnlyStrip_ReservesTheStripPlusItsInsetPlusTheGutter()
+    {
+        var reserve = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            RealWindowWidth, RealStripLeft, RealStripWidth);
+
+        // 1227 - 1173 = 54 (the 45px button plus the 9px frame inset to its right), + 8 gutter.
+        Assert.Equal(62, reserve);
+    }
+
+    [Fact]
+    public void CloseOnlyStrip_ReservesFarLessThanTheOldHardcoded140()
+    {
+        var reserve = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            RealWindowWidth, RealStripLeft, RealStripWidth);
+
+        Assert.True(reserve < 140, $"expected the measured reserve to beat the old constant, got {reserve}");
+    }
+
+    /// <summary>
+    /// The regression in one assertion: a window whose WM advertises all three actions and one whose
+    /// WM advertises none differ by exactly the width of the two hidden buttons, and nothing else.
+    /// The old constant charged the wider figure to both.
+    /// </summary>
+    [Fact]
+    public void ThreeButtonAndOneButtonStrips_DifferByExactlyTheHiddenButtonWidth()
+    {
+        const double windowWidth = 1227;
+        const double inset = 9;
+
+        // 3 x 45 plus 2 x 2px spacing; then the same strip with minimize and maximize hidden.
+        const double threeWide = 139;
+        const double oneWide = 45;
+
+        var three = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            windowWidth, windowWidth - inset - threeWide, threeWide);
+        var one = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            windowWidth, windowWidth - inset - oneWide, oneWide);
+
+        Assert.Equal(threeWide - oneWide, three - one);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(double.NaN)]
+    public void NoStripToClear_CollapsesToTheGutter(double stripWidth)
+    {
+        // Zero width is a real state, not just a guard: the theme collapses the whole overlay panel
+        // in fullscreen. A platform drawing native chrome instead reaches the same answer via a null
+        // strip in UpdateCaptionButtonReserve.
+        var reserve = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            RealWindowWidth, RealStripLeft, stripWidth);
+
+        Assert.Equal(Gutter, reserve);
+    }
+
+    [Theory]
+    [InlineData(double.NaN, RealStripLeft)]
+    [InlineData(RealWindowWidth, double.NaN)]
+    public void UnmeasuredGeometry_CollapsesToTheGutter(double windowWidth, double stripLeft)
+    {
+        // Both are NaN before the first arrange. Without the guard the subtraction would propagate
+        // NaN into a Thickness, and Avalonia lays out a NaN margin as zero - silently putting our
+        // buttons underneath the caption buttons rather than failing.
+        var reserve = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            windowWidth, stripLeft, RealStripWidth);
+
+        Assert.Equal(Gutter, reserve);
+    }
+
+    [Fact]
+    public void AStripMeasuredPastTheRightEdge_NeverYieldsANegativeReserve()
+    {
+        // left > windowWidth is reachable mid-transition, when the frame has resized on one layout
+        // pass and the strip has not caught up. A negative margin is legal in Avalonia and would let
+        // our buttons overhang the window, so the floor matters.
+        var reserve = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            windowWidth: 800, captionStripLeft: 900, captionStripWidth: 45);
+
+        Assert.Equal(Gutter, reserve);
+    }
+
+    [Fact]
+    public void AnAbsurdlyWideStrip_IsClampedToHalfTheWindow()
+    {
+        // Same mid-transition origin: a strip still holding a previous, much larger window's
+        // coordinates would otherwise reserve most of the title bar and push our buttons out of view.
+        var reserve = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            windowWidth: 800, captionStripLeft: 10, captionStripWidth: 700);
+
+        Assert.Equal(400, reserve);
+    }
+
+    [Fact]
+    public void ANarrowWindow_StillHonoursTheGutterFloorOverTheHalfWidthCeiling()
+    {
+        // The ceiling is max(gutter, width/2) rather than width/2 so the two bounds cannot cross on a
+        // window narrower than twice the gutter, which Math.Clamp would throw on.
+        var reserve = NovaTerminal.MainWindow.ComputeCaptionButtonReserve(
+            windowWidth: 10, captionStripLeft: 0, captionStripWidth: 45);
+
+        Assert.Equal(Gutter, reserve);
+    }
+}


### PR DESCRIPTION
## What this changes

**Stacked on #451** — based on `fix/linux-caption-buttons-x11-csd`, so this diff is one commit. GitHub retargets it to `main` when #451 merges. #451 is the reason this is now visible at all: it made the caption buttons render on Linux, and the reserve behind them turned out to be a constant that cannot be right.

`MainWindow.axaml` reserved a literal **140px** on the right of the title bar strip so our own buttons would clear the drawn caption buttons. 140 is three 45px buttons plus 2px spacing plus the 1px border margin — right only when all three buttons are there.

How many are there is not the app's decision. The theme hides minimize and maximize on `:not(:has-minimize)` / `:not(:has-maximize)`, and X11 sets neither pseudoclass unless the WM advertises the action. Under a tiling compositor only close survives, so **~94px of the reserve was dead space** between our last button and the ✕.

So measure the strip rather than predict it. `UpdateCaptionButtonReserve` finds the caption strip, translates its origin into window space, and reserves the distance from there to the right edge plus a gutter. On the reported window that is **62px instead of 140px**, logged once per change:

```
[TitleBar] caption reserve 140 -> 62
```

Same window, same build, only `WireCaptionButtonReserve()` toggled — before (140) above, after (62) below:

_(before/after screenshot shared with the reporter; the numbers above are the same evidence.)_

The sliver that remains is the gutter plus the ✕ button's own centring padding (an 11px glyph in a 45px button), not dead reserve.

### Two things that are easy to get wrong here

**The strip is not a visual descendant of the window.** `TopLevelHost` owns the decorations and the `Window` is its child, so the strip is a *sibling* of the whole content tree and `this.GetVisualDescendants()` never sees it — verified against 12.0.4, where the window's own tree ends at `PART_ContentPresenter`. Hence the hop to the visual parent, and hence `TranslatePoint` rather than comparing raw bounds: with drawn decorations the two origins differ by the shadow and frame inset (measuring raw would have been 8px off).

**A null strip means three different things.** Native chrome instead (macOS), decorations disabled, and *not built yet* — the first two want a bare gutter, the third must not be mistaken for them. While `IsExtendedIntoWindowDecorations` is true a null strip is treated as "too early" and the reserve is left alone until a trigger fires again. Consequence worth stating: **if Windows uses native caption buttons rather than a drawn strip, it keeps the 140px it has today** — unchanged, by design, rather than silently collapsed.

macOS is untouched on purpose. Its caption is on the LEFT, the constructor already collapses the right reserve to `CaptionReserveGutter` there, and that is known-good on a platform this could not be tested on. If macOS does build a drawn strip, the measurement would produce the same answer and the special case can go — but that is a claim to verify there, not to assume here.

The XAML keeps 140 as the pre-measurement value because it is the widest case: the first paint can only be too generous, never overlap.

## Invariant and ownership

- **What invariant does this change affect?** The title bar layout contract: our own buttons never sit under the window's caption buttons, and never leave a gap wider than the gutter. Previously that held only for a three-button caption set.
- **Which module owns that invariant?** `NovaTerminal.App` — `MainWindow` (`UpdateCaptionButtonReserve`, `ComputeCaptionButtonReserve`, feeding the existing `GetTabHeaderViewportMargin`).

## Tests

- **What tests cover this change?** `tests/NovaTerminal.App.Tests/Core/MainWindowCaptionReserveTests.cs` — 11 cases over `MainWindow.ComputeCaptionButtonReserve`:
  - the real measured Hyprland geometry (window 1227, strip at 1173, 45 wide → 62), pinned as a concrete observation rather than an invented one;
  - the regression stated as arithmetic: a three-button strip and a one-button strip differ by *exactly* the width of the two hidden buttons and nothing else — the old constant charged the wider figure to both;
  - collapsed/absent strip (zero, negative, NaN width) → gutter, which is a real state and not just a guard: the theme collapses the whole panel in fullscreen;
  - NaN window width or strip origin (both true before the first arrange) → gutter, because a NaN margin lays out as **zero**, i.e. buttons silently under the caption buttons rather than a visible failure;
  - a strip measured past the right edge → floored at the gutter, since Avalonia honours a negative margin as an overhang;
  - an absurdly wide strip → clamped to half the window;
  - a window narrower than twice the gutter → the `max(gutter, width/2)` ceiling, which exists so `Math.Clamp` cannot be handed `min > max` and throw.

  Not covered: the lookup itself (visual-parent hop + `TranslatePoint`), which needs a real platform window. That half was verified by hand — see Impact.

- **Which categories did you run locally?**

  - [ ] full unfiltered run
  - [ ] `Category=Replay`
  - [ ] `Category=RenderMetrics`
  - [ ] `Category=PtySmoke`
  - [x] `tests/NovaTerminal.App.Tests` — targeted, see below
  - [ ] full local CI rehearsal (`ci/run.sh`)
  - [x] `tests/NovaTerminal.Architecture.Tests` — 85/85
  - [x] `dotnet format whitespace --verify-no-changes` — clean

  Targeted App.Tests: the new file 11/11, and **144/144** across everything that reads this margin or the title bar strip — `MainWindowTitleBarTests`, `TabBehaviorTests`, `MainWindowCustomizeTitleBarSettingsTargetTests`, `TitleBarViewFactoryTests`, `SettingsWindowTitleBar*`, `VerticalTabStripTests`, `AgentObserveIndicatorTests`. The full unfiltered App.Tests run was skipped deliberately: as documented on #451 it is order-dependent on this machine on `main` too (12 failures on one ref, a near-disjoint 9 on the other), so it would produce noise rather than a signal. Every class that touches this margin was run instead.

## Impact

- **Does this affect cross-platform behavior?** Linux/X11 is where the behaviour changes. Verified by hand on Arch + Hyprland (XWayland) with a locally built binary: reserve `140 -> 62`, one log line and no churn across three window resizes and a fullscreen round-trip (the no-op-on-unchanged guard is what stops `SizeChanged` → set `Margin` → `SizeChanged` ping-ponging). macOS is explicitly unchanged. Windows keeps 140 if it draws no strip, and gets a measured value if it does — **neither path tested there**, and that is the main thing worth a second pair of eyes.
- **Does this change renderer metrics?** No. A margin write on decoration changes only; nothing in the draw path, caches or invalidation.
- **Does this change VT coverage?** No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
